### PR TITLE
Fix stale Greasy Fork reruns and preserve newest changelogs

### DIFF
--- a/.github/scripts/extract_greasyfork_changelog.py
+++ b/.github/scripts/extract_greasyfork_changelog.py
@@ -41,6 +41,8 @@ BOILERPLATE_LINES = {
     "these are all versions of this script.",
 }
 
+DISCORD_FIELD_LIMIT = 1000
+
 
 class HistoryParser(HTMLParser):
     """Extract top-level version entries from Greasy Fork's History page."""
@@ -180,7 +182,7 @@ def clean_reader_fragment(value):
 
 
 def parse_reader_entries(text):
-    """Parse Jina Reader/Markdown/plain-text output as a fallback."""
+    """Parse reader/Markdown/plain-text output as a fallback."""
     text = re.sub(r"!\[[^\]]*\]\([^)]+\)", "", text)
     text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
     lines = text.splitlines()
@@ -237,6 +239,43 @@ def extract_entries(document):
     return parse_reader_entries(document), "reader text"
 
 
+def format_changelogs(newest_first):
+    """Fit changelog sections into Discord while always preserving newest notes."""
+    chronological = list(reversed(newest_first))
+    sections = [f"**v{version}**\n{changelog}" for version, changelog in chronological]
+    combined = "\n\n".join(sections)
+
+    if len(combined) <= DISCORD_FIELD_LIMIT:
+        return combined
+
+    # Drop the oldest sections first. The previous implementation cut the end of
+    # the string, which removed the newest release notes and repeated old entries.
+    for omitted in range(1, len(sections)):
+        label = "entry" if omitted == 1 else "entries"
+        note = (
+            f"_Omitted {omitted} earlier unannounced changelog {label}; "
+            "see version history._"
+        )
+        candidate = note + "\n\n" + "\n\n".join(sections[omitted:])
+        if len(candidate) <= DISCORD_FIELD_LIMIT:
+            return candidate
+
+    # The newest single changelog is itself too long. Keep its beginning and state
+    # clearly that it was shortened, rather than losing the newest release entirely.
+    latest = sections[-1]
+    if len(sections) > 1:
+        note = (
+            f"_Omitted {len(sections) - 1} earlier unannounced changelog "
+            f"{'entry' if len(sections) == 2 else 'entries'}; "
+            "the latest entry was shortened. See version history._\n\n"
+        )
+    else:
+        note = "_The latest changelog was shortened; see version history._\n\n"
+
+    available = max(0, DISCORD_FIELD_LIMIT - len(note) - 3)
+    return note + latest[:available].rstrip() + "..."
+
+
 def main():
     if len(sys.argv) != 5:
         raise SystemExit(
@@ -281,12 +320,7 @@ def main():
         )
         return 1
 
-    new_changelogs.reverse()
-    sections = [f"**v{version}**\n{changelog}" for version, changelog in new_changelogs]
-    combined = "\n\n".join(sections)
-
-    if len(combined) > 1000:
-        combined = combined[:997].rstrip() + "..."
+    combined = format_changelogs(new_changelogs)
 
     output_path.write_text(combined, encoding="utf-8")
     print(

--- a/.github/scripts/test_extract_greasyfork_changelog.py
+++ b/.github/scripts/test_extract_greasyfork_changelog.py
@@ -84,7 +84,7 @@ def main() -> int:
     assert "Major interface update" in output
     assert "Already announced" not in output
 
-    # Multiple new changelogs are combined in chronological order.
+    # Multiple short changelogs remain chronological.
     result, output = run_case(
         "4.0.0",
         "3.7.1",
@@ -98,6 +98,40 @@ def main() -> int:
     assert output is not None
     assert output.index("**v3.9.0**") < output.index("**v4.0.0**")
     assert "Do not repeat" not in output
+
+    # When the Discord limit is exceeded, older sections are omitted first and
+    # the newest release notes are always retained.
+    result, output = run_case(
+        "5.0.0",
+        "4.7.0",
+        history(
+            entry("5.0.0", "<p>LATEST UNIQUE RELEASE NOTES</p>")
+            + entry("4.9.0", "<p>" + ("Middle changes " * 55) + "</p>")
+            + entry("4.8.0", "<p>" + ("Old changes " * 65) + "</p>")
+            + entry("4.7.0", "<p>Already announced</p>")
+        ),
+    )
+    assert result.returncode == 0, result.stderr
+    assert output is not None
+    assert len(output) <= 1000
+    assert "LATEST UNIQUE RELEASE NOTES" in output
+    assert "Omitted" in output
+    assert "Already announced" not in output
+
+    # A single oversized latest changelog is shortened rather than discarded.
+    result, output = run_case(
+        "5.1.0",
+        "5.0.0",
+        history(
+            entry("5.1.0", "<p>LATEST START " + ("detail " * 300) + "</p>")
+            + entry("5.0.0", "<p>Already announced</p>")
+        ),
+    )
+    assert result.returncode == 0, result.stderr
+    assert output is not None
+    assert len(output) <= 1000
+    assert "LATEST START" in output
+    assert "shortened" in output
 
     # New versions without any changelog produce an empty result, not an old one.
     result, output = run_case(
@@ -131,7 +165,7 @@ def main() -> int:
     assert result.returncode != 0
     assert output is None
 
-    # Jina Reader-style Markdown works when Greasy Fork blocks GitHub Actions.
+    # Reader-style Markdown works when Greasy Fork blocks GitHub Actions.
     reader_markdown = """
 Title: Version history for MissionChief Map Command Toolkit
 URL Source: https://greasyfork.org/en/scripts/586018/versions

--- a/.github/workflows/greasyfork-discord-update.yml
+++ b/.github/workflows/greasyfork-discord-update.yml
@@ -27,10 +27,20 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - name: Check out repository
+      - name: Check out latest main
         uses: actions/checkout@v7
         with:
+          ref: main
           fetch-depth: 0
+
+      - name: Synchronize repository state
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin main --prune
+          git checkout -B main origin/main
+          echo "Using repository commit: $(git rev-parse HEAD)"
+          echo "Tracked Greasy Fork version: $(tr -d '\r\n ' < .github/greasyfork-version.txt 2>/dev/null || echo none)"
 
       - name: Test changelog extractor
         shell: bash
@@ -122,8 +132,40 @@ jobs:
             echo "::warning::The new Greasy Fork version is live, but its History entry could not yet be read. No Discord post was sent; the next scheduled run will retry."
           fi
 
-      - name: Post update to Discord
+      - name: Confirm update is still unannounced
+        id: pending
         if: steps.version.outputs.changed == 'true' && steps.changelog.outputs.ready == 'true'
+        env:
+          CURRENT_VERSION: ${{ steps.version.outputs.current }}
+          PREVIOUS_VERSION: ${{ steps.version.outputs.previous }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "pending=false" >> "$GITHUB_OUTPUT"
+
+          git fetch origin main --prune
+          REMOTE_STATE="$(
+            git show origin/main:.github/greasyfork-version.txt 2>/dev/null |
+              tr -d '\r\n ' || true
+          )"
+
+          echo "State used for this run: ${PREVIOUS_VERSION:-none}"
+          echo "Current state on main: ${REMOTE_STATE:-none}"
+
+          if [[ "$REMOTE_STATE" == "$CURRENT_VERSION" ]]; then
+            echo "Version $CURRENT_VERSION has already been announced. Skipping duplicate Discord post."
+            exit 0
+          fi
+
+          if [[ "$REMOTE_STATE" != "$PREVIOUS_VERSION" ]]; then
+            echo "::warning::The announcement state changed while this run was active. Skipping to prevent repeated changelogs."
+            exit 0
+          fi
+
+          echo "pending=true" >> "$GITHUB_OUTPUT"
+
+      - name: Post update to Discord
+        if: steps.pending.outputs.pending == 'true'
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_UPDATE_WEBHOOK }}
           CURRENT_VERSION: ${{ steps.version.outputs.current }}
@@ -202,24 +244,48 @@ jobs:
           echo "Discord update notification sent."
 
       - name: Save latest announced version
-        if: steps.version.outputs.changed == 'true' && steps.changelog.outputs.ready == 'true'
+        if: steps.pending.outputs.pending == 'true'
         env:
           CURRENT_VERSION: ${{ steps.version.outputs.current }}
+          PREVIOUS_VERSION: ${{ steps.version.outputs.previous }}
         shell: bash
         run: |
           set -euo pipefail
 
           STATE_FILE=".github/greasyfork-version.txt"
-          printf '%s\n' "$CURRENT_VERSION" > "$STATE_FILE"
-
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add "$STATE_FILE"
 
-          if git diff --cached --quiet; then
-            echo "No version-state change to commit."
-            exit 0
-          fi
+          for attempt in 1 2 3; do
+            echo "Saving announcement state (attempt $attempt of 3)..."
+            git fetch origin main --prune
+            git reset --hard origin/main
 
-          git commit -m "Track Greasy Fork version ${CURRENT_VERSION}"
-          git push
+            REMOTE_STATE="$(tr -d '\r\n ' < "$STATE_FILE" 2>/dev/null || true)"
+
+            if [[ "$REMOTE_STATE" == "$CURRENT_VERSION" ]]; then
+              echo "Version $CURRENT_VERSION is already recorded."
+              exit 0
+            fi
+
+            if [[ "$REMOTE_STATE" != "$PREVIOUS_VERSION" ]]; then
+              echo "::warning::Main now records ${REMOTE_STATE:-none}, not ${PREVIOUS_VERSION:-none}. Refusing to overwrite newer announcement state."
+              exit 0
+            fi
+
+            printf '%s\n' "$CURRENT_VERSION" > "$STATE_FILE"
+            git add "$STATE_FILE"
+            git commit -m "Track Greasy Fork version ${CURRENT_VERSION}"
+
+            if git push origin HEAD:main; then
+              echo "Recorded Greasy Fork version $CURRENT_VERSION."
+              exit 0
+            fi
+
+            if [[ "$attempt" -lt 3 ]]; then
+              sleep 5
+            fi
+          done
+
+          echo "::error::Discord was notified, but the announcement state could not be saved after three attempts."
+          exit 1


### PR DESCRIPTION
Fixes two linked failure modes in the Discord update workflow:

- rerun attempts now check out and synchronize with the latest `main` state instead of the original stale workflow commit;
- a pre-post state guard prevents duplicate Discord announcements when another run has already advanced the tracker;
- state commits now retry safely against the latest remote branch;
- oversized changelog ranges discard the oldest entries first, ensuring the newest release notes are always included;
- regression tests cover Discord truncation and newest-note preservation.

This should correct the repeated 3.13.3 changelog issue and the non-fast-forward failure after Discord had already posted.