### PR TITLE
Establish Release Pipeline v2 foundation

### DIFF
--- a/.github/workflows/discord-commit-notifications.yml
+++ b/.github/workflows/discord-commit-notifications.yml
@@ -1,0 +1,104 @@
+name: Discord Development Updates
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: discord-development-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  notify:
+    name: Post development update
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+
+    steps:
+      - name: Build and post Discord message
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_COMMITS_WEBHOOK }}
+          REPOSITORY: ${{ github.repository }}
+          REPOSITORY_URL: ${{ github.server_url }}/${{ github.repository }}
+          COMPARE_URL: ${{ github.event.compare }}
+          BRANCH: ${{ github.ref_name }}
+          PUSHER: ${{ github.actor }}
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
+          COMMITS_JSON: ${{ toJson(github.event.commits) }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${DISCORD_WEBHOOK_URL:-}" ]]; then
+            echo "::error::DISCORD_COMMITS_WEBHOOK is not configured."
+            exit 1
+          fi
+
+          COMMIT_COUNT="$(jq 'length' <<< "$COMMITS_JSON")"
+          SHORT_SHA="${AFTER_SHA:0:7}"
+
+          COMMIT_LINES="$(
+            jq -r '
+              .[:10]
+              | map("[`" + (.id[0:7]) + "`](${{ github.server_url }}/${{ github.repository }}/commit/" + .id + ") " + ((.message | split("\n")[0])[:120]))
+              | join("\n")
+            ' <<< "$COMMITS_JSON"
+          )"
+
+          if [[ "$COMMIT_COUNT" -gt 10 ]]; then
+            COMMIT_LINES+=$'\n'"…and $((COMMIT_COUNT - 10)) more commit(s)."
+          fi
+
+          if [[ -z "$COMMIT_LINES" ]]; then
+            COMMIT_LINES="No commit summary was supplied by GitHub."
+          fi
+
+          jq -n \
+            --arg repository "$REPOSITORY" \
+            --arg repository_url "$REPOSITORY_URL" \
+            --arg compare_url "$COMPARE_URL" \
+            --arg branch "$BRANCH" \
+            --arg pusher "$PUSHER" \
+            --arg short_sha "$SHORT_SHA" \
+            --arg commit_count "$COMMIT_COUNT" \
+            --arg commit_lines "$COMMIT_LINES" \
+            '{
+              username: "MissionChief Toolkit Development",
+              allowed_mentions: { parse: [] },
+              embeds: [
+                {
+                  title: ("Development update · " + $short_sha),
+                  url: $compare_url,
+                  description: $commit_lines,
+                  color: 5793266,
+                  fields: [
+                    { name: "Repository", value: ("[" + $repository + "](" + $repository_url + ")"), inline: true },
+                    { name: "Branch", value: ("`" + $branch + "`"), inline: true },
+                    { name: "Pushed by", value: ("`" + $pusher + "`"), inline: true },
+                    { name: "Commits", value: $commit_count, inline: true }
+                  ],
+                  footer: { text: "MissionChief Map Command Toolkit · Development" }
+                }
+              ]
+            }' > discord-development-payload.json
+
+          curl \
+            --fail \
+            --silent \
+            --show-error \
+            --max-time 30 \
+            --retry 2 \
+            --retry-delay 3 \
+            --request POST \
+            --header "Content-Type: application/json" \
+            --data @discord-development-payload.json \
+            "${DISCORD_WEBHOOK_URL}?wait=true"
+
+          echo
+          echo "Development notification posted to Discord."

--- a/README.md
+++ b/README.md
@@ -1,2 +1,108 @@
-# missionchief-toolkit-assets
-Assets for the MissionChief Map Command Toolkit
+# MissionChief Map Command Toolkit
+
+[![Greasy Fork](https://img.shields.io/badge/Greasy%20Fork-Install-670000?logo=tampermonkey&logoColor=white)](https://greasyfork.org/en/scripts/586018-missionchief-map-command-toolkit)
+[![Release Pipeline](https://img.shields.io/badge/Release%20Pipeline-v2%20Foundation-2563eb)](status/release-dashboard.json)
+[![Platform](https://img.shields.io/badge/MissionChief-UK-0f766e)](https://www.missionchief.co.uk/)
+[![Licence](https://img.shields.io/badge/Licence-MIT-16a34a)](#licence)
+
+A feature-rich MissionChief userscript providing an expanded map command interface, operational overlays, mission monitoring, payout presentation, responsive desktop/tablet/mobile layouts, themed interfaces and supporting media assets.
+
+> **Migration status:** GitHub is being established as the canonical source of truth. Greasy Fork remains the public installation and update platform. Existing public asset paths are being preserved to avoid breaking installed versions.
+
+## Release dashboard
+
+| Component | Current state |
+|---|---|
+| Canonical source | GitHub migration in progress |
+| Public distribution | Greasy Fork |
+| Development notifications | `Mission-Chief-Dev` |
+| Release notifications | `Mission-Chief` |
+| Existing Greasy Fork monitor | Active during migration |
+| Validation pipeline | Foundation stage |
+| Automated GitHub releases | Planned |
+| Automated backups | Planned |
+
+Machine-readable status: [`status/release-dashboard.json`](status/release-dashboard.json)
+
+## Toolkit highlights
+
+- Mission and alliance visibility controls
+- Mission Age Watch and critical mission workflows
+- Alliance payout overlays and completion history
+- Vehicle code status and transport monitoring
+- Coverage heat maps, bookmarks and map jumps
+- Desktop, tablet and iOS mobile modes
+- Multiple complete interface themes
+- Configurable payout presentations and hosted audio
+- Import/export settings and persistent UI state
+- MissionChief-specific performance and usability improvements
+
+## Distribution
+
+The supported public release remains available through Greasy Fork:
+
+- [View the script](https://greasyfork.org/en/scripts/586018-missionchief-map-command-toolkit)
+- [Install or update](https://update.greasyfork.org/scripts/586018/MissionChief%20Map%20Command%20Toolkit.user.js)
+- [Version history](https://greasyfork.org/en/scripts/586018-missionchief-map-command-toolkit/versions)
+
+## Repository role
+
+This repository currently serves several connected purposes:
+
+1. Hosting stable images, theme packages and audio used by existing Toolkit installations.
+2. Running the current Greasy Fork monitoring and Discord notification automation.
+3. Becoming the canonical source, validation and release system for future Toolkit versions.
+4. Providing release-state, documentation and backup records.
+
+### Asset stability policy
+
+Existing public files will not be renamed, moved or deleted until every reference has been audited. New organisation will be introduced alongside current paths first. Compatibility takes priority over cosmetic restructuring.
+
+## Release Pipeline v2
+
+The planned controlled release path is:
+
+```text
+Canonical userscript in GitHub
+        ↓
+Automated validation
+        ↓
+Version and changelog verification
+        ↓
+GitHub tag, release and immutable backup
+        ↓
+Greasy Fork synchronisation
+        ↓
+Greasy Fork version verification
+        ↓
+Discord release announcement
+```
+
+Routine development pushes are routed to the development channel. Verified public releases are routed separately to the release channel.
+
+## Project structure
+
+The repository is being migrated incrementally. Planned additions include:
+
+```text
+src/          Canonical userscript source
+dist/         Validated public release files
+status/       Release dashboard state
+docs/         Project and user documentation
+backups/      Release manifests and migration records
+.github/      Validation, release and notification automation
+```
+
+Current media and theme paths remain unchanged during this process.
+
+## Development
+
+The project is maintained by **Conroy1988** for the MissionChief UK community. Release automation is designed to prevent mismatched versions, repeated changelogs, incomplete backups and premature Discord announcements.
+
+## Licence
+
+The Toolkit code is intended to remain available under the MIT licence. Individual third-party references, game trademarks and externally hosted materials remain the property of their respective owners.
+
+---
+
+**MissionChief Map Command Toolkit** · GitHub-controlled releases · Greasy Fork distribution

--- a/status/release-dashboard.json
+++ b/status/release-dashboard.json
@@ -1,0 +1,23 @@
+{
+  "project": "MissionChief Map Command Toolkit",
+  "pipelineVersion": 2,
+  "currentVersion": "4.3.0",
+  "sourceOfTruth": "GitHub",
+  "distribution": "Greasy Fork",
+  "status": {
+    "validation": "foundation",
+    "githubRelease": "not-configured",
+    "greasyForkSync": "legacy-monitor",
+    "backup": "not-configured",
+    "discordDevelopment": "configured",
+    "discordRelease": "secret-configured"
+  },
+  "channels": {
+    "development": "Mission-Chief-Dev",
+    "releases": "Mission-Chief"
+  },
+  "assets": {
+    "policy": "Existing public paths remain stable during migration"
+  },
+  "lastUpdated": "2026-07-14"
+}


### PR DESCRIPTION
Introduces the first non-destructive foundation for the new release system:

- adds dedicated development push notifications using `DISCORD_COMMITS_WEBHOOK`;
- excludes GitHub Actions bot commits to prevent tracker and automation spam;
- adds a machine-readable release dashboard status file;
- replaces the placeholder README with a professional project landing page;
- documents the asset-stability policy so existing image, theme and audio URLs remain untouched during migration.

This does not move, rename or delete any existing public assets and does not yet replace the legacy Greasy Fork monitoring workflow.