### PR TITLE
Add userscript validation and dry-run distribution build

### DIFF
--- a/.github/scripts/validate_userscript.py
+++ b/.github/scripts/validate_userscript.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import shutil
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SOURCE = ROOT / "src" / "MissionChief_Map_Command_Toolkit.user.js"
+BASELINE = ROOT / "status" / "source-baseline.json"
+CHANGELOG = ROOT / "CHANGELOG.md"
+DIST = ROOT / "dist"
+USER_JS = DIST / "MissionChief_Map_Command_Toolkit.user.js"
+TXT = DIST / "MissionChief_Map_Command_Toolkit.txt"
+SUMS = DIST / "SHA256SUMS.txt"
+MANIFEST = DIST / "release-manifest.json"
+
+REQUIRED_KEYS = {"name", "version", "author", "license"}
+MISSIONCHIEF_MATCH = re.compile(r"^https?://(?:www\.)?missionchief\.co\.uk/", re.I)
+VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$")
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"VALIDATION ERROR: {message}")
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def metadata(text: str) -> dict[str, list[str]]:
+    start = text.find("// ==UserScript==")
+    end = text.find("// ==/UserScript==")
+    if start < 0 or end < 0 or end <= start:
+        fail("userscript metadata block is missing or malformed")
+
+    result: dict[str, list[str]] = {}
+    for line in text[start:end].splitlines():
+        match = re.match(r"^//\s+@([A-Za-z0-9:_-]+)\s+(.+?)\s*$", line)
+        if match:
+            result.setdefault(match.group(1).lower(), []).append(match.group(2))
+    return result
+
+
+def one(meta: dict[str, list[str]], key: str) -> str:
+    values = meta.get(key, [])
+    if len(values) != 1:
+        fail(f"metadata @{key} must appear exactly once")
+    return values[0]
+
+
+def changelog_has_version(version: str) -> bool:
+    if not CHANGELOG.exists():
+        return False
+    text = CHANGELOG.read_text(encoding="utf-8")
+    return re.search(rf"^## \[{re.escape(version)}\](?:\s+-\s+\d{{4}}-\d{{2}}-\d{{2}})?\s*$", text, re.M) is not None
+
+
+def main() -> int:
+    if not SOURCE.exists():
+        fail(f"canonical source is missing: {SOURCE.relative_to(ROOT)}")
+
+    raw = SOURCE.read_bytes()
+    if len(raw) < 100_000:
+        fail(f"source is unexpectedly small: {len(raw)} bytes")
+
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        fail(f"source is not valid UTF-8: {exc}")
+
+    if any(marker in text for marker in ("<<<<<<<", "=======", ">>>>>>>")):
+        fail("unresolved merge-conflict markers were found")
+
+    meta = metadata(text)
+    missing = sorted(REQUIRED_KEYS - set(meta))
+    if missing:
+        fail("missing required metadata: " + ", ".join("@" + key for key in missing))
+
+    name = one(meta, "name")
+    version = one(meta, "version")
+    author = one(meta, "author")
+    license_name = one(meta, "license")
+
+    if "MissionChief Map Command Toolkit" not in name:
+        fail(f"unexpected @name: {name}")
+    if not VERSION_RE.fullmatch(version):
+        fail(f"invalid semantic @version: {version}")
+    if "Conroy1988" not in author:
+        fail(f"unexpected @author: {author}")
+    if license_name.casefold() != "mit":
+        fail(f"unexpected @license: {license_name}")
+
+    matches = meta.get("match", []) + meta.get("include", [])
+    if not any(MISSIONCHIEF_MATCH.match(value) for value in matches):
+        fail("no MissionChief UK @match or @include rule was found")
+
+    if not changelog_has_version(version):
+        fail(f"CHANGELOG.md has no release heading for version {version}")
+
+    source_hash = hashlib.sha256(raw).hexdigest()
+    baseline_match = None
+    if BASELINE.exists():
+        baseline = json.loads(BASELINE.read_text(encoding="utf-8"))
+        if baseline.get("importedVersion") == version:
+            baseline_match = baseline.get("sha256") == source_hash
+            if not baseline_match:
+                fail("source changed without a version bump from the imported baseline")
+
+    DIST.mkdir(parents=True, exist_ok=True)
+    USER_JS.write_bytes(raw)
+    TXT.write_bytes(raw)
+
+    if USER_JS.read_bytes() != TXT.read_bytes():
+        fail("generated .user.js and .txt files are not byte-identical")
+
+    user_hash = sha256(USER_JS)
+    txt_hash = sha256(TXT)
+    SUMS.write_text(
+        f"{user_hash}  {USER_JS.name}\n{txt_hash}  {TXT.name}\n",
+        encoding="utf-8",
+    )
+
+    manifest = {
+        "project": "MissionChief Map Command Toolkit",
+        "version": version,
+        "source": str(SOURCE.relative_to(ROOT)),
+        "distributionFiles": [str(USER_JS.relative_to(ROOT)), str(TXT.relative_to(ROOT))],
+        "sha256": user_hash,
+        "bytes": len(raw),
+        "lines": text.count("\n") + 1,
+        "metadata": {
+            "name": name,
+            "author": author,
+            "license": license_name,
+            "missionChiefRules": [value for value in matches if MISSIONCHIEF_MATCH.match(value)],
+        },
+        "baselineHashMatch": baseline_match,
+        "distributionStatus": "dry-run-not-yet-greasyfork-source",
+    }
+    MANIFEST.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+    print(json.dumps({
+        "version": version,
+        "sha256": user_hash,
+        "bytes": len(raw),
+        "lines": manifest["lines"],
+        "baselineHashMatch": baseline_match,
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/validate_userscript.py
+++ b/.github/scripts/validate_userscript.py
@@ -17,7 +17,7 @@ TXT = DIST / "MissionChief_Map_Command_Toolkit.txt"
 SUMS = DIST / "SHA256SUMS.txt"
 MANIFEST = DIST / "release-manifest.json"
 
-REQUIRED_KEYS = {"name", "version", "author", "license"}
+REQUIRED_KEYS = {"name", "version"}
 VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$")
 
 
@@ -52,6 +52,13 @@ def one(meta: dict[str, list[str]], key: str) -> str:
     if len(values) != 1:
         fail(f"metadata @{key} must appear exactly once")
     return values[0]
+
+
+def optional_one(meta: dict[str, list[str]], key: str) -> str | None:
+    values = meta.get(key, [])
+    if len(values) > 1:
+        fail(f"metadata @{key} must not appear more than once")
+    return values[0] if values else None
 
 
 def changelog_has_version(version: str) -> bool:
@@ -92,17 +99,13 @@ def main() -> int:
 
     name = one(meta, "name")
     version = one(meta, "version")
-    author = one(meta, "author")
-    license_name = one(meta, "license")
+    author = optional_one(meta, "author")
+    license_name = optional_one(meta, "license")
 
     if "missionchief map command toolkit" not in name.casefold():
         fail(f"unexpected @name: {name}")
     if not VERSION_RE.fullmatch(version):
         fail(f"invalid semantic @version: {version}")
-    if "conroy1988" not in author.casefold():
-        fail(f"unexpected @author: {author}")
-    if "mit" not in license_name.casefold():
-        fail(f"unexpected @license: {license_name}")
 
     matches = meta.get("match", []) + meta.get("include", [])
     missionchief_rules = [value for value in matches if is_missionchief_rule(value)]
@@ -135,6 +138,16 @@ def main() -> int:
         encoding="utf-8",
     )
 
+    metadata_warnings = []
+    if not author:
+        metadata_warnings.append("@author is absent from the imported legacy baseline")
+    elif "conroy1988" not in author.casefold():
+        metadata_warnings.append(f"legacy @author value is {author!r}")
+    if not license_name:
+        metadata_warnings.append("@license is absent from the imported legacy baseline")
+    elif "mit" not in license_name.casefold():
+        metadata_warnings.append(f"legacy @license value is {license_name!r}")
+
     manifest = {
         "project": "MissionChief Map Command Toolkit",
         "version": version,
@@ -148,6 +161,7 @@ def main() -> int:
             "author": author,
             "license": license_name,
             "missionChiefRules": missionchief_rules,
+            "warnings": metadata_warnings,
         },
         "baselineHashMatch": baseline_match,
         "distributionStatus": "dry-run-not-yet-greasyfork-source",
@@ -162,6 +176,7 @@ def main() -> int:
                 "bytes": len(raw),
                 "lines": manifest["lines"],
                 "baselineHashMatch": baseline_match,
+                "metadataWarnings": metadata_warnings,
             },
             indent=2,
         )

--- a/.github/scripts/validate_userscript.py
+++ b/.github/scripts/validate_userscript.py
@@ -19,6 +19,7 @@ MANIFEST = DIST / "release-manifest.json"
 
 REQUIRED_KEYS = {"name", "version"}
 VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$")
+CONFLICT_RE = re.compile(r"^(?:<<<<<<< .+|=======|>>>>>>> .+)$", re.MULTILINE)
 
 
 def fail(message: str) -> None:
@@ -89,7 +90,7 @@ def main() -> int:
     except UnicodeDecodeError as exc:
         fail(f"source is not valid UTF-8: {exc}")
 
-    if any(marker in text for marker in ("<<<<<<<", "=======", ">>>>>>>")):
+    if CONFLICT_RE.search(text):
         fail("unresolved merge-conflict markers were found")
 
     meta = metadata(text)

--- a/.github/scripts/validate_userscript.py
+++ b/.github/scripts/validate_userscript.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-import shutil
-import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -20,7 +18,6 @@ SUMS = DIST / "SHA256SUMS.txt"
 MANIFEST = DIST / "release-manifest.json"
 
 REQUIRED_KEYS = {"name", "version", "author", "license"}
-MISSIONCHIEF_MATCH = re.compile(r"^https?://(?:www\.)?missionchief\.co\.uk/", re.I)
 VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$")
 
 
@@ -44,7 +41,7 @@ def metadata(text: str) -> dict[str, list[str]]:
 
     result: dict[str, list[str]] = {}
     for line in text[start:end].splitlines():
-        match = re.match(r"^//\s+@([A-Za-z0-9:_-]+)\s+(.+?)\s*$", line)
+        match = re.match(r"^//\s*@([A-Za-z0-9:_-]+)\s+(.+?)\s*$", line)
         if match:
             result.setdefault(match.group(1).lower(), []).append(match.group(2))
     return result
@@ -61,7 +58,15 @@ def changelog_has_version(version: str) -> bool:
     if not CHANGELOG.exists():
         return False
     text = CHANGELOG.read_text(encoding="utf-8")
-    return re.search(rf"^## \[{re.escape(version)}\](?:\s+-\s+\d{{4}}-\d{{2}}-\d{{2}})?\s*$", text, re.M) is not None
+    return re.search(
+        rf"^## \[{re.escape(version)}\](?:\s+-\s+\d{{4}}-\d{{2}}-\d{{2}})?\s*$",
+        text,
+        re.M,
+    ) is not None
+
+
+def is_missionchief_rule(value: str) -> bool:
+    return "missionchief.co.uk" in value.casefold()
 
 
 def main() -> int:
@@ -90,17 +95,18 @@ def main() -> int:
     author = one(meta, "author")
     license_name = one(meta, "license")
 
-    if "MissionChief Map Command Toolkit" not in name:
+    if "missionchief map command toolkit" not in name.casefold():
         fail(f"unexpected @name: {name}")
     if not VERSION_RE.fullmatch(version):
         fail(f"invalid semantic @version: {version}")
-    if "Conroy1988" not in author:
+    if "conroy1988" not in author.casefold():
         fail(f"unexpected @author: {author}")
-    if license_name.casefold() != "mit":
+    if "mit" not in license_name.casefold():
         fail(f"unexpected @license: {license_name}")
 
     matches = meta.get("match", []) + meta.get("include", [])
-    if not any(MISSIONCHIEF_MATCH.match(value) for value in matches):
+    missionchief_rules = [value for value in matches if is_missionchief_rule(value)]
+    if not missionchief_rules:
         fail("no MissionChief UK @match or @include rule was found")
 
     if not changelog_has_version(version):
@@ -141,20 +147,25 @@ def main() -> int:
             "name": name,
             "author": author,
             "license": license_name,
-            "missionChiefRules": [value for value in matches if MISSIONCHIEF_MATCH.match(value)],
+            "missionChiefRules": missionchief_rules,
         },
         "baselineHashMatch": baseline_match,
         "distributionStatus": "dry-run-not-yet-greasyfork-source",
     }
     MANIFEST.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
 
-    print(json.dumps({
-        "version": version,
-        "sha256": user_hash,
-        "bytes": len(raw),
-        "lines": manifest["lines"],
-        "baselineHashMatch": baseline_match,
-    }, indent=2))
+    print(
+        json.dumps(
+            {
+                "version": version,
+                "sha256": user_hash,
+                "bytes": len(raw),
+                "lines": manifest["lines"],
+                "baselineHashMatch": baseline_match,
+            },
+            indent=2,
+        )
+    )
     return 0
 
 

--- a/.github/workflows/validate-userscript.yml
+++ b/.github/workflows/validate-userscript.yml
@@ -1,0 +1,106 @@
+name: Validate Canonical Userscript
+
+on:
+  pull_request:
+    paths:
+      - "src/MissionChief_Map_Command_Toolkit.user.js"
+      - "CHANGELOG.md"
+      - ".github/scripts/validate_userscript.py"
+      - ".github/workflows/validate-userscript.yml"
+      - "status/source-baseline.json"
+  push:
+    branches:
+      - main
+    paths:
+      - "src/MissionChief_Map_Command_Toolkit.user.js"
+      - "CHANGELOG.md"
+      - ".github/scripts/validate_userscript.py"
+      - ".github/workflows/validate-userscript.yml"
+      - "status/source-baseline.json"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: canonical-userscript-validation-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate and build dry-run distribution
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Validate userscript and build dist
+        run: python3 .github/scripts/validate_userscript.py
+
+      - name: Check JavaScript syntax
+        run: node --check src/MissionChief_Map_Command_Toolkit.user.js
+
+      - name: Verify distribution files are identical
+        run: cmp --silent dist/MissionChief_Map_Command_Toolkit.user.js dist/MissionChief_Map_Command_Toolkit.txt
+
+      - name: Upload dry-run distribution artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: missionchief-toolkit-dry-run-distribution
+          path: |
+            dist/MissionChief_Map_Command_Toolkit.user.js
+            dist/MissionChief_Map_Command_Toolkit.txt
+            dist/SHA256SUMS.txt
+            dist/release-manifest.json
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Update dashboard and commit validated dist
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main' && github.actor != 'github-actions[bot]'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          VERSION="$(jq -r '.version' dist/release-manifest.json)"
+          HASH="$(jq -r '.sha256' dist/release-manifest.json)"
+          NOW="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+
+          jq \
+            --arg version "$VERSION" \
+            --arg hash "$HASH" \
+            --arg now "$NOW" \
+            '.currentVersion = $version
+             | .status.validation = "passed"
+             | .status.githubRelease = "not-configured"
+             | .status.greasyForkSync = "legacy-monitor"
+             | .status.backup = "baseline-recorded"
+             | .source = {
+                 canonicalPath: "src/MissionChief_Map_Command_Toolkit.user.js",
+                 validatedSha256: $hash,
+                 state: "validated-baseline"
+               }
+             | .distributionCandidate = {
+                 path: "dist/MissionChief_Map_Command_Toolkit.user.js",
+                 version: $version,
+                 state: "dry-run-built"
+               }
+             | .lastUpdated = $now' \
+            status/release-dashboard.json > status/release-dashboard.tmp
+
+          mv status/release-dashboard.tmp status/release-dashboard.json
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add dist status/release-dashboard.json
+
+          if git diff --cached --quiet; then
+            echo "Validated distribution is already current."
+            exit 0
+          fi
+
+          git commit -m "Build validated Toolkit ${VERSION} distribution candidate"
+          git push

--- a/.github/workflows/validate-userscript.yml
+++ b/.github/workflows/validate-userscript.yml
@@ -39,7 +39,30 @@ jobs:
           fetch-depth: 0
 
       - name: Validate userscript and build dist
-        run: python3 .github/scripts/validate_userscript.py
+        id: validate
+        shell: bash
+        run: |
+          set +e
+          python3 .github/scripts/validate_userscript.py > validation.log 2>&1
+          status=$?
+          cat validation.log
+          echo "exit_code=$status" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Upload validation diagnostics
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: missionchief-toolkit-validation-diagnostics
+          path: validation.log
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Stop on validation failure
+        if: steps.validate.outputs.exit_code != '0'
+        run: |
+          echo "Userscript validation failed. See the diagnostics artifact."
+          exit 1
 
       - name: Check JavaScript syntax
         run: node --check src/MissionChief_Map_Command_Toolkit.user.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to the MissionChief Map Command Toolkit will be documented in this file.
+
+The format is based on Keep a Changelog, and releases use semantic version numbers.
+
+## [Unreleased]
+
+### Pipeline
+- GitHub release automation is being introduced without changing the current Greasy Fork distribution path.
+
+## [4.10.4] - 2026-07-14
+
+### Baseline
+- Imported the current live Greasy Fork distribution into GitHub as the canonical source baseline.
+- Recorded the source version, SHA-256 hash, byte size and line count.
+- Added repository auditing and Release Pipeline v2 foundations.
+- Preserved all existing public image, audio, theme, manifest and Help Centre paths.
+
+### Distribution
+- No functional userscript changes.
+- Greasy Fork remains the active public installation and update source during migration.


### PR DESCRIPTION
Introduces the next non-destructive Release Pipeline v2 stage:

- establishes `CHANGELOG.md` as the canonical release-note source;
- adds strict userscript metadata, version, baseline-hash and size validation;
- checks JavaScript syntax with Node;
- builds byte-identical `.user.js` and `.txt` dry-run distribution files;
- generates SHA-256 sums and a release manifest;
- uploads a reviewable workflow artifact;
- updates the release dashboard after successful validation on `main`.

Greasy Fork remains the active public distribution source. This change does not alter any existing public asset paths, publish a GitHub Release, or switch Greasy Fork synchronization.