### PR TITLE
Add one-click Toolkit release dry run

### DIFF
--- a/.github/scripts/prepare_release_bundle.py
+++ b/.github/scripts/prepare_release_bundle.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import shutil
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+DIST = ROOT / "dist"
+CHANGELOG = ROOT / "CHANGELOG.md"
+SOURCE = ROOT / "src" / "MissionChief_Map_Command_Toolkit.user.js"
+OUTPUT = ROOT / "release-bundle"
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"RELEASE PREPARATION ERROR: {message}")
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def extract_release_notes(version: str) -> str:
+    text = CHANGELOG.read_text(encoding="utf-8")
+    pattern = re.compile(
+        rf"^## \[{re.escape(version)}\](?:\s+-\s+\d{{4}}-\d{{2}}-\d{{2}})?\s*$\n(.*?)(?=^## \[|\Z)",
+        re.M | re.S,
+    )
+    match = pattern.search(text)
+    if not match:
+        fail(f"CHANGELOG.md has no section for {version}")
+    notes = match.group(1).strip()
+    if not notes:
+        fail(f"CHANGELOG.md section for {version} is empty")
+    return notes + "\n"
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        fail("usage: prepare_release_bundle.py <version>")
+
+    requested_version = sys.argv[1].strip()
+    if not re.fullmatch(r"\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?", requested_version):
+        fail(f"invalid version: {requested_version}")
+
+    manifest_path = DIST / "release-manifest.json"
+    if not manifest_path.exists():
+        fail("dist/release-manifest.json is missing; run validation first")
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    built_version = str(manifest.get("version", ""))
+    if built_version != requested_version:
+        fail(f"requested version {requested_version} does not match validated dist version {built_version}")
+
+    required = [
+        SOURCE,
+        DIST / "MissionChief_Map_Command_Toolkit.user.js",
+        DIST / "MissionChief_Map_Command_Toolkit.txt",
+        DIST / "SHA256SUMS.txt",
+        manifest_path,
+        CHANGELOG,
+    ]
+    for path in required:
+        if not path.exists():
+            fail(f"required release input is missing: {path.relative_to(ROOT)}")
+
+    source_hash = sha256(SOURCE)
+    dist_hash = sha256(DIST / "MissionChief_Map_Command_Toolkit.user.js")
+    txt_hash = sha256(DIST / "MissionChief_Map_Command_Toolkit.txt")
+    manifest_hash = str(manifest.get("sha256", ""))
+    if len({source_hash, dist_hash, txt_hash, manifest_hash}) != 1:
+        fail("canonical source, distribution files and manifest hashes do not match")
+
+    if OUTPUT.exists():
+        shutil.rmtree(OUTPUT)
+    OUTPUT.mkdir(parents=True)
+
+    versioned_user = OUTPUT / f"MissionChief_Map_Command_Toolkit_v{requested_version}.user.js"
+    versioned_txt = OUTPUT / f"MissionChief_Map_Command_Toolkit_v{requested_version}.txt"
+    shutil.copy2(DIST / "MissionChief_Map_Command_Toolkit.user.js", versioned_user)
+    shutil.copy2(DIST / "MissionChief_Map_Command_Toolkit.txt", versioned_txt)
+    shutil.copy2(DIST / "SHA256SUMS.txt", OUTPUT / "SHA256SUMS.txt")
+
+    notes = extract_release_notes(requested_version)
+    (OUTPUT / f"CHANGELOG-v{requested_version}.md").write_text(
+        f"# MissionChief Map Command Toolkit v{requested_version}\n\n{notes}",
+        encoding="utf-8",
+    )
+
+    release_manifest = {
+        **manifest,
+        "releaseMode": "dry-run",
+        "preparedAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "releaseTag": f"v{requested_version}",
+        "releaseNotesFile": f"CHANGELOG-v{requested_version}.md",
+        "bundleFiles": [
+            versioned_user.name,
+            versioned_txt.name,
+            "SHA256SUMS.txt",
+            f"CHANGELOG-v{requested_version}.md",
+            f"release-manifest-v{requested_version}.json",
+            f"migration-handover-v{requested_version}.md",
+        ],
+    }
+    (OUTPUT / f"release-manifest-v{requested_version}.json").write_text(
+        json.dumps(release_manifest, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    (OUTPUT / f"migration-handover-v{requested_version}.md").write_text(
+        "\n".join(
+            [
+                f"# MissionChief Map Command Toolkit v{requested_version} — migration handover",
+                "",
+                "## Release state",
+                "",
+                "- GitHub canonical source: validated",
+                "- Distribution bundle: prepared in dry-run mode",
+                "- GitHub Release: not published",
+                "- Greasy Fork: unchanged and still serving the live public script",
+                "- Discord release announcement: not sent",
+                "",
+                "## Integrity",
+                "",
+                f"- SHA-256: `{source_hash}`",
+                f"- Source bytes: `{manifest.get('bytes')}`",
+                f"- Source lines: `{manifest.get('lines')}`",
+                "",
+                "## Next approval gate",
+                "",
+                "Configure Greasy Fork code synchronisation to the validated GitHub distribution URL only after the release workflow has passed an end-to-end dry run.",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    print(json.dumps({
+        "version": requested_version,
+        "sha256": source_hash,
+        "bundle": str(OUTPUT.relative_to(ROOT)),
+        "files": sorted(path.name for path in OUTPUT.iterdir()),
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/release-toolkit-dry-run.yml
+++ b/.github/workflows/release-toolkit-dry-run.yml
@@ -1,0 +1,126 @@
+name: Release Toolkit Dry Run
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Validated Toolkit version to prepare"
+        required: true
+        default: "4.10.4"
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: toolkit-release-dry-run
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Validate and prepare release bundle
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out latest main
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Validate canonical source and rebuild distribution
+        run: python3 .github/scripts/validate_userscript.py
+
+      - name: Check JavaScript syntax
+        run: node --check src/MissionChief_Map_Command_Toolkit.user.js
+
+      - name: Verify distribution files are identical
+        run: cmp --silent dist/MissionChief_Map_Command_Toolkit.user.js dist/MissionChief_Map_Command_Toolkit.txt
+
+      - name: Prepare immutable release bundle
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: python3 .github/scripts/prepare_release_bundle.py "$RELEASE_VERSION"
+
+      - name: Verify bundle integrity
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          USER_FILE="release-bundle/MissionChief_Map_Command_Toolkit_v${RELEASE_VERSION}.user.js"
+          TXT_FILE="release-bundle/MissionChief_Map_Command_Toolkit_v${RELEASE_VERSION}.txt"
+          cmp --silent "$USER_FILE" "$TXT_FILE"
+          test "$(sha256sum "$USER_FILE" | awk '{print $1}')" = "$(jq -r '.sha256' "release-bundle/release-manifest-v${RELEASE_VERSION}.json")"
+
+      - name: Upload reviewable release bundle
+        uses: actions/upload-artifact@v6
+        with:
+          name: missionchief-toolkit-v${{ inputs.version }}-release-dry-run
+          path: release-bundle/
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Update release dashboard
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          NOW="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+          HASH="$(jq -r '.sha256' "release-bundle/release-manifest-v${RELEASE_VERSION}.json")"
+
+          jq \
+            --arg version "$RELEASE_VERSION" \
+            --arg hash "$HASH" \
+            --arg now "$NOW" \
+            '.currentVersion = $version
+             | .status.validation = "passed"
+             | .status.githubRelease = "dry-run-ready"
+             | .status.greasyForkSync = "legacy-monitor"
+             | .status.backup = "dry-run-bundle-prepared"
+             | .status.discordRelease = "configured-not-sent-in-dry-run"
+             | .releaseDryRun = {
+                 version: $version,
+                 sha256: $hash,
+                 state: "passed",
+                 githubReleaseCreated: false,
+                 greasyForkChanged: false,
+                 discordPosted: false,
+                 completedAt: $now
+               }
+             | .lastUpdated = $now' \
+            status/release-dashboard.json > status/release-dashboard.tmp
+
+          mv status/release-dashboard.tmp status/release-dashboard.json
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add status/release-dashboard.json
+
+          if git diff --cached --quiet; then
+            echo "Release dashboard already records this dry run."
+            exit 0
+          fi
+
+          git commit -m "Record Toolkit ${RELEASE_VERSION} release dry run"
+          git pull --rebase origin main
+          git push origin HEAD:main
+
+      - name: Write workflow summary
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        shell: bash
+        run: |
+          {
+            echo "# Toolkit v${RELEASE_VERSION} release dry run"
+            echo
+            echo "- ✅ Canonical source validated"
+            echo "- ✅ JavaScript syntax checked"
+            echo "- ✅ Version and changelog matched"
+            echo "- ✅ Immutable backup bundle prepared"
+            echo "- ✅ SHA-256 integrity verified"
+            echo "- ⏸️ GitHub Release not published"
+            echo "- ⏸️ Greasy Fork not changed"
+            echo "- ⏸️ Discord release announcement not sent"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Adds the controlled dry-run stage for Release Pipeline v2:

- introduces a one-click `Release Toolkit Dry Run` workflow;
- revalidates the canonical source and JavaScript syntax;
- requires the requested version to match the validated distribution and canonical changelog;
- prepares an immutable versioned bundle with userscript, text copy, checksums, release manifest, release notes and migration handover;
- uploads the complete bundle as a 30-day review artifact;
- updates the release dashboard only after all dry-run checks pass;
- explicitly does not create a GitHub Release, change Greasy Fork or post to Discord.

No existing public asset paths or live distribution settings are changed.