### PR TITLE
Require verified private backup before release announcement

### DIFF
--- a/.github/scripts/backup_release_to_private_repo.sh
+++ b/.github/scripts/backup_release_to_private_repo.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${RELEASE_VERSION:?RELEASE_VERSION is required}"
+: "${MIGRATION_REPO_TOKEN:?MIGRATION_REPO_TOKEN is required}"
+
+PRIVATE_REPO="Conroy1988/missionchief-map-command-toolkit-private"
+PRIVATE_URL="https://x-access-token:${MIGRATION_REPO_TOKEN}@github.com/${PRIVATE_REPO}.git"
+SOURCE_REPO="${GITHUB_REPOSITORY}"
+SOURCE_COMMIT="${GITHUB_SHA}"
+RELEASE_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/v${RELEASE_VERSION}"
+BUNDLE_DIR="release-bundle"
+TARGET_ROOT="releases/v${RELEASE_VERSION}"
+WORK_DIR="$(mktemp -d)"
+PRIVATE_DIR="${WORK_DIR}/private"
+
+cleanup() {
+  rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+required=(
+  "MissionChief_Map_Command_Toolkit.user.js"
+  "MissionChief_Map_Command_Toolkit.txt"
+  "MissionChief_Map_Command_Toolkit_v${RELEASE_VERSION}.user.js"
+  "MissionChief_Map_Command_Toolkit_v${RELEASE_VERSION}.txt"
+  "CHANGELOG-v${RELEASE_VERSION}.md"
+  "release-manifest-v${RELEASE_VERSION}.json"
+  "SHA256SUMS-v${RELEASE_VERSION}.txt"
+  "migration-handover-v${RELEASE_VERSION}.md"
+)
+
+for file in "${required[@]}"; do
+  test -f "${BUNDLE_DIR}/${file}" || {
+    echo "::error::Required backup file is missing: ${BUNDLE_DIR}/${file}"
+    exit 1
+  }
+done
+
+cmp --silent \
+  "${BUNDLE_DIR}/MissionChief_Map_Command_Toolkit_v${RELEASE_VERSION}.user.js" \
+  "${BUNDLE_DIR}/MissionChief_Map_Command_Toolkit_v${RELEASE_VERSION}.txt"
+
+EXPECTED_HASH="$(jq -r '.sha256' "${BUNDLE_DIR}/release-manifest-v${RELEASE_VERSION}.json")"
+ACTUAL_HASH="$(sha256sum "${BUNDLE_DIR}/MissionChief_Map_Command_Toolkit_v${RELEASE_VERSION}.user.js" | awk '{print $1}')"
+test "$EXPECTED_HASH" = "$ACTUAL_HASH"
+
+git clone --depth 1 "$PRIVATE_URL" "$PRIVATE_DIR"
+cd "$PRIVATE_DIR"
+
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+if [[ -e "$TARGET_ROOT" ]]; then
+  echo "::error::Private backup path already exists: $TARGET_ROOT"
+  exit 1
+fi
+
+mkdir -p "$TARGET_ROOT" current
+cp -a "${GITHUB_WORKSPACE}/${BUNDLE_DIR}/." "$TARGET_ROOT/"
+cp "${GITHUB_WORKSPACE}/status/release-dashboard.json" "$TARGET_ROOT/release-dashboard.json"
+
+jq -n \
+  --arg project "MissionChief Map Command Toolkit" \
+  --arg version "$RELEASE_VERSION" \
+  --arg sourceRepository "$SOURCE_REPO" \
+  --arg sourceCommit "$SOURCE_COMMIT" \
+  --arg releaseUrl "$RELEASE_URL" \
+  --arg sha256 "$ACTUAL_HASH" \
+  --arg backedUpAt "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+  '{
+    project: $project,
+    version: $version,
+    sourceRepository: $sourceRepository,
+    sourceCommit: $sourceCommit,
+    githubRelease: $releaseUrl,
+    sha256: $sha256,
+    greasyForkVerified: true,
+    filesValidated: true,
+    textCopyByteIdentical: true,
+    backedUpAt: $backedUpAt
+  }' > "$TARGET_ROOT/backup-record.json"
+
+rm -rf current/release
+mkdir -p current/release
+cp -a "$TARGET_ROOT/." current/release/
+printf '%s\n' "v${RELEASE_VERSION}" > current/VERSION
+printf '%s\n' "$ACTUAL_HASH" > current/SHA256
+
+cat > current/RELEASE_POINTER.md <<EOF
+# Current validated Toolkit release
+
+- Version: **v${RELEASE_VERSION}**
+- Source repository: \`${SOURCE_REPO}\`
+- Source commit: \`${SOURCE_COMMIT}\`
+- SHA-256: \`${ACTUAL_HASH}\`
+- GitHub Release: ${RELEASE_URL}
+- Private archive: \`${TARGET_ROOT}/\`
+
+The complete validated release is mirrored in \`current/release/\` for rapid recovery.
+EOF
+
+git add "$TARGET_ROOT" current
+
+if git diff --cached --quiet; then
+  echo "::error::Private backup produced no repository changes."
+  exit 1
+fi
+
+git commit -m "Back up Toolkit v${RELEASE_VERSION} validated release"
+git push origin HEAD:main
+BACKUP_COMMIT="$(git rev-parse HEAD)"
+
+echo "backup_commit=${BACKUP_COMMIT}" >> "$GITHUB_OUTPUT"
+echo "backup_repository=${PRIVATE_REPO}" >> "$GITHUB_OUTPUT"
+echo "Private migration backup committed: ${BACKUP_COMMIT}"

--- a/.github/workflows/release-toolkit.yml
+++ b/.github/workflows/release-toolkit.yml
@@ -21,9 +21,9 @@ concurrency:
 
 jobs:
   release:
-    name: Validate, publish and verify Toolkit release
+    name: Validate, publish, back up and verify Toolkit release
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: 45
 
     steps:
       - name: Check out latest main
@@ -37,12 +37,14 @@ jobs:
           RELEASE_VERSION: ${{ inputs.version }}
           CONFIRMATION: ${{ inputs.confirmation }}
           GH_TOKEN: ${{ github.token }}
+          MIGRATION_REPO_TOKEN: ${{ secrets.MIGRATION_REPO_TOKEN }}
         shell: bash
         run: |
           set -euo pipefail
           [[ "$CONFIRMATION" == "RELEASE" ]] || { echo "::error::Type RELEASE exactly to confirm."; exit 1; }
           [[ "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]] || { echo "::error::Invalid release version: $RELEASE_VERSION"; exit 1; }
           [[ "$(jq -r '.greasyFork.syncEnabled' .github/release-settings.json)" == "true" ]] || { echo "::error::Greasy Fork release synchronization is not enabled."; exit 1; }
+          [[ -n "${MIGRATION_REPO_TOKEN:-}" ]] || { echo "::error::MIGRATION_REPO_TOKEN is not configured."; exit 1; }
           gh release view "v${RELEASE_VERSION}" >/dev/null 2>&1 && { echo "::error::GitHub Release v${RELEASE_VERSION} already exists."; exit 1; } || true
 
       - name: Validate canonical source and rebuild distribution
@@ -137,15 +139,25 @@ jobs:
           done
           [[ "$SYNCED" == "true" ]] || { echo "::error::Greasy Fork did not publish version $RELEASE_VERSION within 30 minutes. Discord was not notified."; exit 1; }
 
+      - name: Back up validated release to private migration repository
+        id: private_backup
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+          MIGRATION_REPO_TOKEN: ${{ secrets.MIGRATION_REPO_TOKEN }}
+        shell: bash
+        run: bash .github/scripts/backup_release_to_private_repo.sh
+
       - name: Post verified release to Discord
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
           RELEASE_VERSION: ${{ inputs.version }}
           RELEASE_URL: ${{ github.server_url }}/${{ github.repository }}/releases/tag/v${{ inputs.version }}
+          BACKUP_COMMIT: ${{ steps.private_backup.outputs.backup_commit }}
         shell: bash
         run: |
           set -euo pipefail
           [[ -n "${DISCORD_WEBHOOK_URL:-}" ]] || { echo "::error::DISCORD_RELEASE_WEBHOOK is not configured."; exit 1; }
+          [[ -n "${BACKUP_COMMIT:-}" ]] || { echo "::error::Private backup commit was not recorded."; exit 1; }
           SCRIPT_URL="$(jq -r '.greasyFork.scriptUrl' .github/release-settings.json)"
           INSTALL_URL="$(jq -r '.greasyFork.installUrl' .github/release-settings.json)"
           CHANGELOG="$(cat "release-bundle/CHANGELOG-v${RELEASE_VERSION}.md")"
@@ -154,9 +166,9 @@ jobs:
           TIMESTAMP="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
           jq -n \
             --arg version "$RELEASE_VERSION" --arg changelog "$CHANGELOG" --arg hash "$HASH" \
-            --arg release_url "$RELEASE_URL" --arg script_url "$SCRIPT_URL" \
-            --arg install_url "$INSTALL_URL" --arg timestamp "$TIMESTAMP" \
-            '{username:"MissionChief Toolkit Releases",allowed_mentions:{parse:[]},embeds:[{title:("MissionChief Map Command Toolkit v"+$version+" Released"),description:"Validated on GitHub and verified live on Greasy Fork.",url:$release_url,color:5763719,fields:[{name:"Version",value:("`"+$version+"`"),inline:true},{name:"Validation",value:"✅ Passed",inline:true},{name:"Greasy Fork",value:"✅ Verified",inline:true},{name:"What Changed",value:$changelog,inline:false},{name:"Integrity",value:("SHA-256: `"+$hash+"`"),inline:false},{name:"Links",value:("[GitHub Release]("+$release_url+")\n[View on Greasy Fork]("+$script_url+")\n[Install or update]("+$install_url+")"),inline:false}],footer:{text:"MissionChief Map Command Toolkit"},timestamp:$timestamp}]}' > discord-release-payload.json
+            --arg backup_commit "$BACKUP_COMMIT" --arg release_url "$RELEASE_URL" \
+            --arg script_url "$SCRIPT_URL" --arg install_url "$INSTALL_URL" --arg timestamp "$TIMESTAMP" \
+            '{username:"MissionChief Toolkit Releases",allowed_mentions:{parse:[]},embeds:[{title:("MissionChief Map Command Toolkit v"+$version+" Released"),description:"Validated on GitHub, verified live on Greasy Fork, and archived privately.",url:$release_url,color:5763719,fields:[{name:"Version",value:("`"+$version+"`"),inline:true},{name:"Validation",value:"✅ Passed",inline:true},{name:"Greasy Fork",value:"✅ Verified",inline:true},{name:"Private Backup",value:("✅ `"+$backup_commit+"`"),inline:false},{name:"What Changed",value:$changelog,inline:false},{name:"Integrity",value:("SHA-256: `"+$hash+"`"),inline:false},{name:"Links",value:("[GitHub Release]("+$release_url+")\n[View on Greasy Fork]("+$script_url+")\n[Install or update]("+$install_url+")"),inline:false}],footer:{text:"MissionChief Map Command Toolkit"},timestamp:$timestamp}]}' > discord-release-payload.json
           curl --fail --silent --show-error --max-time 30 --retry 2 --retry-delay 5 \
             --request POST --header "Content-Type: application/json" \
             --data @discord-release-payload.json "${DISCORD_WEBHOOK_URL}?wait=true"
@@ -164,14 +176,16 @@ jobs:
       - name: Record successful release in dashboard
         env:
           RELEASE_VERSION: ${{ inputs.version }}
+          BACKUP_COMMIT: ${{ steps.private_backup.outputs.backup_commit }}
         shell: bash
         run: |
           set -euo pipefail
           NOW="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
           HASH="$(jq -r '.sha256' "release-bundle/release-manifest-v${RELEASE_VERSION}.json")"
           RELEASE_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/v${RELEASE_VERSION}"
-          jq --arg version "$RELEASE_VERSION" --arg hash "$HASH" --arg now "$NOW" --arg releaseUrl "$RELEASE_URL" \
-            '.currentVersion=$version | .status.validation="passed" | .status.githubRelease="published" | .status.greasyForkSync="verified" | .status.backup="github-release-and-workflow-artifact" | .status.discordRelease="posted" | .latestRelease={version:$version,sha256:$hash,githubRelease:$releaseUrl,greasyForkVerified:true,discordPosted:true,completedAt:$now} | .lastUpdated=$now' \
+          jq --arg version "$RELEASE_VERSION" --arg hash "$HASH" --arg now "$NOW" \
+             --arg releaseUrl "$RELEASE_URL" --arg backupCommit "$BACKUP_COMMIT" \
+            '.currentVersion=$version | .status.validation="passed" | .status.githubRelease="published" | .status.greasyForkSync="verified" | .status.backup="private-repository-verified" | .status.discordRelease="posted" | .latestRelease={version:$version,sha256:$hash,githubRelease:$releaseUrl,greasyForkVerified:true,privateBackupCommit:$backupCommit,discordPosted:true,completedAt:$now} | .lastUpdated=$now' \
             status/release-dashboard.json > status/release-dashboard.tmp
           mv status/release-dashboard.tmp status/release-dashboard.json
           git config user.name "github-actions[bot]"
@@ -184,6 +198,7 @@ jobs:
       - name: Write release summary
         env:
           RELEASE_VERSION: ${{ inputs.version }}
+          BACKUP_COMMIT: ${{ steps.private_backup.outputs.backup_commit }}
         shell: bash
         run: |
           {
@@ -195,6 +210,7 @@ jobs:
             echo "- ✅ Stable Greasy Fork release asset published"
             echo "- ✅ GitHub Release published"
             echo "- ✅ Greasy Fork version verified"
+            echo "- ✅ Private migration backup committed: ${BACKUP_COMMIT}"
             echo "- ✅ Discord release announcement posted"
             echo "- ✅ Release dashboard updated"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Completes the cross-repository migration backup stage for Release Pipeline v2.

- validates that `MIGRATION_REPO_TOKEN` is configured before publication;
- copies every complete validated release bundle into the private migration repository;
- stores versioned and current recovery copies, release dashboard snapshot and a machine-readable backup record;
- verifies the userscript hash and byte-identical text copy before backup;
- commits and pushes the private archive before Discord is allowed to announce the release;
- includes the private backup commit SHA in Discord, the public dashboard and the workflow summary;
- treats backup failure as a release failure, preventing a false completion announcement.

No release is triggered by merging this pull request.