### PR TITLE
Add live Toolkit release dashboard

### DIFF
--- a/.github/scripts/generate_release_dashboard.py
+++ b/.github/scripts/generate_release_dashboard.py
@@ -44,6 +44,7 @@ def main() -> None:
     version = data.get("currentVersion", "Unknown")
     latest_version = latest.get("version") or dry_run.get("version") or version
     latest_state = "Verified public release" if latest else "Validated dry run"
+    validated_hash = source.get("validatedSha256") or latest.get("sha256") or dry_run.get("sha256") or "Not yet recorded"
 
     rows = [
         ("Canonical source", source.get("state", "unknown")),
@@ -78,7 +79,7 @@ def main() -> None:
         f"- **Latest recorded version:** `{latest_version}`",
         f"- **State:** {latest_state}",
         f"- **Canonical path:** `{source.get('canonicalPath', 'src/MissionChief_Map_Command_Toolkit.user.js')}`",
-        f"- **Validated SHA-256:** `{source.get('validatedSha256', latest.get('sha256', dry_run.get('sha256', 'Not yet recorded'))}`",
+        f"- **Validated SHA-256:** `{validated_hash}`",
         f"- **Distribution candidate:** `{candidate.get('path', 'dist/MissionChief_Map_Command_Toolkit.user.js')}`",
         "",
         "## Repository health",

--- a/.github/scripts/generate_release_dashboard.py
+++ b/.github/scripts/generate_release_dashboard.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Generate a human-readable release dashboard from status/release-dashboard.json."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SOURCE = ROOT / "status" / "release-dashboard.json"
+OUTPUT = ROOT / "status" / "README.md"
+
+ICONS = {
+    "passed": "🟢",
+    "published": "🟢",
+    "verified": "🟢",
+    "posted": "🟢",
+    "configured": "🟢",
+    "secret-configured": "🟢",
+    "dry-run-ready": "🟡",
+    "dry-run-built": "🟡",
+    "legacy-monitor": "🟡",
+    "not-configured": "⚪",
+}
+
+
+def icon(value: str) -> str:
+    return ICONS.get(value, "🔵")
+
+
+def text(value: object) -> str:
+    return str(value).replace("-", " ").strip().title()
+
+
+def main() -> None:
+    data = json.loads(SOURCE.read_text(encoding="utf-8"))
+    status = data.get("status", {})
+    latest = data.get("latestRelease") or {}
+    dry_run = data.get("releaseDryRun") or {}
+    assets = data.get("assets", {})
+    source = data.get("source", {})
+    candidate = data.get("distributionCandidate", {})
+
+    version = data.get("currentVersion", "Unknown")
+    latest_version = latest.get("version") or dry_run.get("version") or version
+    latest_state = "Verified public release" if latest else "Validated dry run"
+
+    rows = [
+        ("Canonical source", source.get("state", "unknown")),
+        ("Validation", status.get("validation", "unknown")),
+        ("GitHub Release", status.get("githubRelease", "unknown")),
+        ("Greasy Fork", status.get("greasyForkSync", "unknown")),
+        ("Private backup", status.get("backup", "unknown")),
+        ("Discord development", status.get("discordDevelopment", "unknown")),
+        ("Discord releases", status.get("discordRelease", "unknown")),
+        ("Asset audit", status.get("assetAudit", "unknown")),
+    ]
+
+    lines = [
+        "# MissionChief Toolkit Control Panel",
+        "",
+        "> Automatically generated from [`release-dashboard.json`](release-dashboard.json). Do not edit this page manually.",
+        "",
+        f"## Current version: `{version}`",
+        "",
+        "| System | Health | State |",
+        "|---|:---:|---|",
+    ]
+
+    for label, value in rows:
+        value_str = str(value)
+        lines.append(f"| {label} | {icon(value_str)} | {text(value_str)} |")
+
+    lines.extend([
+        "",
+        "## Release state",
+        "",
+        f"- **Latest recorded version:** `{latest_version}`",
+        f"- **State:** {latest_state}",
+        f"- **Canonical path:** `{source.get('canonicalPath', 'src/MissionChief_Map_Command_Toolkit.user.js')}`",
+        f"- **Validated SHA-256:** `{source.get('validatedSha256', latest.get('sha256', dry_run.get('sha256', 'Not yet recorded'))}`",
+        f"- **Distribution candidate:** `{candidate.get('path', 'dist/MissionChief_Map_Command_Toolkit.user.js')}`",
+        "",
+        "## Repository health",
+        "",
+        f"- **Discovered media files:** {assets.get('discoveredFiles', 'Unknown')}",
+        f"- **Referenced hosted paths:** {assets.get('referencedPaths', 'Unknown')}",
+        f"- **Missing referenced paths:** {assets.get('missingReferencedPaths', 'Unknown')}",
+        f"- **Last dashboard update:** `{data.get('lastUpdated', 'Unknown')}`",
+        "",
+        "## Release channels",
+        "",
+        f"- Development activity → `{data.get('channels', {}).get('development', 'Mission-Chief-Dev')}`",
+        f"- Verified releases → `{data.get('channels', {}).get('releases', 'Mission-Chief')}`",
+        "",
+        "## Release path",
+        "",
+        "```text",
+        "Canonical source",
+        "      ↓",
+        "Validation and bundle build",
+        "      ↓",
+        "GitHub Release",
+        "      ↓",
+        "Greasy Fork webhook and verification",
+        "      ↓",
+        "Private migration backup",
+        "      ↓",
+        "Discord release confirmation",
+        "```",
+        "",
+        "---",
+        "",
+        "The JSON file remains the machine-readable source of truth. This page is regenerated automatically whenever release state changes.",
+    ])
+
+    OUTPUT.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    print(f"Generated {OUTPUT.relative_to(ROOT)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/update-release-dashboard.yml
+++ b/.github/workflows/update-release-dashboard.yml
@@ -1,0 +1,66 @@
+name: Update Release Dashboard
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "status/release-dashboard.json"
+      - ".github/scripts/generate_release_dashboard.py"
+      - ".github/workflows/update-release-dashboard.yml"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-release-dashboard
+  cancel-in-progress: true
+
+jobs:
+  update:
+    name: Generate Toolkit control panel
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out latest main
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Validate dashboard JSON
+        run: python3 -m json.tool status/release-dashboard.json >/dev/null
+
+      - name: Generate human-readable dashboard
+        run: python3 .github/scripts/generate_release_dashboard.py
+
+      - name: Commit dashboard update
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add status/README.md
+
+          if git diff --cached --quiet; then
+            echo "Dashboard is already current."
+            exit 0
+          fi
+
+          git commit -m "Refresh Toolkit release dashboard"
+          git pull --rebase origin main
+          git push origin HEAD:main
+
+      - name: Write workflow summary
+        shell: bash
+        run: |
+          VERSION="$(jq -r '.currentVersion' status/release-dashboard.json)"
+          {
+            echo "# MissionChief Toolkit dashboard"
+            echo
+            echo "- ✅ Dashboard JSON validated"
+            echo "- ✅ Human-readable control panel generated"
+            echo "- ✅ Current version: ${VERSION}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/status/README.md
+++ b/status/README.md
@@ -1,0 +1,56 @@
+# MissionChief Toolkit Control Panel
+
+> Automatically generated from [`release-dashboard.json`](release-dashboard.json). Do not edit this page manually.
+
+## Current version: `4.10.4`
+
+| System | Health | State |
+|---|:---:|---|
+| Canonical source | 🔵 | Validated Baseline |
+| Validation | 🟢 | Passed |
+| GitHub Release | 🟡 | Dry Run Ready |
+| Greasy Fork | 🟡 | Legacy Monitor |
+| Private backup | 🔵 | Dry Run Bundle Prepared |
+| Discord development | 🟢 | Configured |
+| Discord releases | 🔵 | Configured Not Sent In Dry Run |
+| Asset audit | 🟢 | Passed |
+
+## Release state
+
+- **Latest recorded version:** `4.10.4`
+- **State:** Validated dry run
+- **Canonical path:** `src/MissionChief_Map_Command_Toolkit.user.js`
+- **Validated SHA-256:** `37952e796f3b11b3ce9bcaee860e7bd3d206afbc9c7de9fac63fd8d940427c82`
+- **Distribution candidate:** `dist/MissionChief_Map_Command_Toolkit.user.js`
+
+## Repository health
+
+- **Discovered media files:** 28
+- **Referenced hosted paths:** 25
+- **Missing referenced paths:** 0
+- **Last dashboard update:** `2026-07-14T16:05:00Z`
+
+## Release channels
+
+- Development activity → `Mission-Chief-Dev`
+- Verified releases → `Mission-Chief`
+
+## Release path
+
+```text
+Canonical source
+      ↓
+Validation and bundle build
+      ↓
+GitHub Release
+      ↓
+Greasy Fork webhook and verification
+      ↓
+Private migration backup
+      ↓
+Discord release confirmation
+```
+
+---
+
+The JSON file remains the machine-readable source of truth. This page is regenerated automatically whenever release state changes.


### PR DESCRIPTION
Adds the first live human-readable Toolkit control panel:

- generates `status/README.md` from the machine-readable release dashboard;
- adds automatic regeneration whenever release state changes;
- shows validation, GitHub Release, Greasy Fork, Discord, backup and asset health in one place;
- keeps `status/release-dashboard.json` as the source of truth;
- makes no changes to the userscript, public assets, Greasy Fork or Discord release behaviour.

No public release is triggered by merging this pull request.