### PR TITLE
Add release readiness and recovery safeguards

### DIFF
--- a/.github/release-settings.json
+++ b/.github/release-settings.json
@@ -11,6 +11,6 @@
   "release": {
     "discordSecret": "DISCORD_RELEASE_WEBHOOK",
     "requireGreasyForkVerificationBeforeDiscord": true,
-    "externalMigrationBackup": "not-configured"
+    "externalMigrationBackup": "Conroy1988/missionchief-map-command-toolkit-private"
   }
 }

--- a/.github/workflows/release-readiness-check.yml
+++ b/.github/workflows/release-readiness-check.yml
@@ -1,0 +1,123 @@
+name: Release Readiness Check
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Toolkit version to validate without publishing"
+        required: true
+        default: "4.10.4"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: toolkit-release-readiness
+  cancel-in-progress: false
+
+jobs:
+  readiness:
+    name: Verify release pipeline readiness
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out latest main
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Validate required secrets
+        env:
+          DISCORD_RELEASE_WEBHOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
+          MIGRATION_REPO_TOKEN: ${{ secrets.MIGRATION_REPO_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ -n "${DISCORD_RELEASE_WEBHOOK:-}" ]] || { echo "::error::DISCORD_RELEASE_WEBHOOK is not configured."; exit 1; }
+          [[ -n "${MIGRATION_REPO_TOKEN:-}" ]] || { echo "::error::MIGRATION_REPO_TOKEN is not configured."; exit 1; }
+          echo "Required release secrets are configured."
+
+      - name: Validate release settings
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]] || { echo "::error::Invalid version: $RELEASE_VERSION"; exit 1; }
+          [[ "$(jq -r '.greasyFork.syncEnabled' .github/release-settings.json)" == "true" ]] || { echo "::error::Greasy Fork synchronization is disabled."; exit 1; }
+          [[ "$(jq -r '.release.externalMigrationBackup' .github/release-settings.json)" == "Conroy1988/missionchief-map-command-toolkit-private" ]] || { echo "::error::Private migration repository is not configured correctly."; exit 1; }
+
+      - name: Validate canonical userscript
+        run: python3 .github/scripts/validate_userscript.py
+
+      - name: Check JavaScript syntax
+        run: node --check src/MissionChief_Map_Command_Toolkit.user.js
+
+      - name: Verify distribution parity
+        run: cmp --silent dist/MissionChief_Map_Command_Toolkit.user.js dist/MissionChief_Map_Command_Toolkit.txt
+
+      - name: Prepare release bundle without publishing
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: python3 .github/scripts/prepare_release_bundle.py "$RELEASE_VERSION"
+
+      - name: Verify bundle integrity
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          USER_FILE="release-bundle/MissionChief_Map_Command_Toolkit_v${RELEASE_VERSION}.user.js"
+          TXT_FILE="release-bundle/MissionChief_Map_Command_Toolkit_v${RELEASE_VERSION}.txt"
+          MANIFEST="release-bundle/release-manifest-v${RELEASE_VERSION}.json"
+          cmp --silent "$USER_FILE" "$TXT_FILE"
+          EXPECTED_HASH="$(jq -r '.sha256' "$MANIFEST")"
+          ACTUAL_HASH="$(sha256sum "$USER_FILE" | awk '{print $1}')"
+          [[ "$EXPECTED_HASH" == "$ACTUAL_HASH" ]] || { echo "::error::Release bundle SHA-256 mismatch."; exit 1; }
+
+      - name: Verify private migration repository access
+        env:
+          MIGRATION_REPO_TOKEN: ${{ secrets.MIGRATION_REPO_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git ls-remote "https://x-access-token:${MIGRATION_REPO_TOKEN}@github.com/Conroy1988/missionchief-map-command-toolkit-private.git" HEAD >/dev/null
+          echo "Private migration repository access verified."
+
+      - name: Verify Greasy Fork endpoints
+        shell: bash
+        run: |
+          set -euo pipefail
+          META_URL="$(jq -r '.greasyFork.metadataUrl' .github/release-settings.json)"
+          SCRIPT_URL="$(jq -r '.greasyFork.scriptUrl' .github/release-settings.json)"
+          curl --fail --silent --show-error --location --max-time 30 "$META_URL" -o greasyfork.meta.js
+          curl --fail --silent --show-error --location --max-time 30 "$SCRIPT_URL" -o /dev/null
+          LIVE_VERSION="$(sed -nE 's|^//[[:space:]]*@version[[:space:]]+(.+)$|\1|p' greasyfork.meta.js | head -n 1 | xargs)"
+          [[ -n "$LIVE_VERSION" ]] || { echo "::error::Could not read the current Greasy Fork version."; exit 1; }
+          echo "Current Greasy Fork version: $LIVE_VERSION"
+
+      - name: Write readiness summary
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        shell: bash
+        run: |
+          HASH="$(jq -r '.sha256' "release-bundle/release-manifest-v${RELEASE_VERSION}.json")"
+          {
+            echo "# Toolkit v${RELEASE_VERSION} release readiness"
+            echo
+            echo "- ✅ Required repository secrets configured"
+            echo "- ✅ Release settings enabled"
+            echo "- ✅ Canonical userscript validated"
+            echo "- ✅ JavaScript syntax checked"
+            echo "- ✅ Distribution files are byte-identical"
+            echo "- ✅ Changelog and release bundle prepared"
+            echo "- ✅ SHA-256 verified: \`${HASH}\`"
+            echo "- ✅ Private migration repository access verified"
+            echo "- ✅ Greasy Fork endpoints reachable"
+            echo "- ⏸️ No GitHub Release created"
+            echo "- ⏸️ Greasy Fork not changed"
+            echo "- ⏸️ Discord not notified"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/RELEASE_RECOVERY.md
+++ b/docs/RELEASE_RECOVERY.md
@@ -1,3 +1,112 @@
-# Release Recovery
+# Release Recovery and Failure Handling
 
-This file will be replaced through the release-recovery-checklist branch.
+This guide describes how to recover the MissionChief Map Command Toolkit release pipeline without creating duplicate releases, repeated Discord announcements, or inconsistent Greasy Fork state.
+
+## Standard pre-release procedure
+
+Before every public release:
+
+1. Confirm the canonical userscript contains the intended `@version`.
+2. Confirm `CHANGELOG.md` contains a matching section for that exact version.
+3. Run **Actions → Release Readiness Check** with the intended version.
+4. Continue only when every readiness step is green.
+5. Run **Actions → Release Toolkit**.
+6. Enter the exact version and type `RELEASE`.
+
+The readiness workflow does not create a GitHub Release, change Greasy Fork, post to Discord, or write to the private migration repository.
+
+## Release checkpoints
+
+The production workflow proceeds in this order:
+
+```text
+Canonical validation
+      ↓
+Release bundle and hashes
+      ↓
+GitHub Release
+      ↓
+Greasy Fork webhook and version verification
+      ↓
+Private migration backup
+      ↓
+Discord release announcement
+      ↓
+Dashboard update
+```
+
+A later checkpoint is never treated as successful when an earlier checkpoint failed.
+
+## Recovery by failure stage
+
+### Validation or bundle preparation failed
+
+No public state has changed.
+
+- Correct the source, metadata, changelog, or distribution mismatch.
+- Run **Release Readiness Check** again.
+- Start a new **Release Toolkit** run only after readiness passes.
+
+### GitHub Release creation failed
+
+Check whether tag `vX.Y.Z` or a release with that version already exists.
+
+- When no release exists, correct the reported permission or file problem and start a new production run.
+- When a partial release exists, inspect its assets before deciding whether to delete and recreate it.
+- Never create a second release under a different tag for the same Toolkit version.
+
+### GitHub Release exists but Greasy Fork did not update
+
+Do not post a manual Discord announcement.
+
+1. Verify the GitHub Release contains `MissionChief_Map_Command_Toolkit.user.js`.
+2. Verify Greasy Fork Source Syncing still points to the `releases/latest/download` URL.
+3. Inspect the GitHub webhook delivery for the Release event.
+4. Redeliver the webhook when the payload failed.
+5. Use Greasy Fork **Update and sync now** only after confirming the release asset is correct.
+6. Verify the Greasy Fork metadata endpoint reports the expected version.
+
+### Greasy Fork updated but private backup failed
+
+The public release is live, but the release is not complete.
+
+- Do not send a manual release post.
+- Fix or renew `MIGRATION_REPO_TOKEN`.
+- Confirm the token has Contents read/write permission for the private repository.
+- Re-run the failed backup-capable workflow job or perform a controlled recovery run.
+- Confirm the private repository commit contains the complete versioned bundle and current recovery copy.
+
+### Backup succeeded but Discord failed
+
+- Verify `DISCORD_RELEASE_WEBHOOK` still targets `Mission-Chief`.
+- Re-run only the failed Discord job when available.
+- Confirm the dashboard has not already recorded `discordPosted: true` before manually retrying.
+- Never use the development webhook for a public release.
+
+### Dashboard update failed after all public actions succeeded
+
+- Treat the release as published, but dashboard state as stale.
+- Re-run the failed dashboard job or update `status/release-dashboard.json` from the verified release state.
+- Regenerate `status/README.md` with `.github/scripts/generate_release_dashboard.py`.
+
+## Duplicate prevention
+
+- Do not use **Re-run all jobs** after a GitHub Release has already been created unless the workflow is known to be idempotent at that checkpoint.
+- Prefer **Re-run failed jobs**.
+- Do not publish the same version twice.
+- Do not manually post to Discord while a workflow retry is pending.
+- Do not change the Greasy Fork source back to `main/dist`.
+
+## Private recovery verification
+
+For any archived release, the following must agree:
+
+- userscript `@version`;
+- versioned directory name;
+- release manifest version;
+- changelog heading;
+- GitHub tag;
+- SHA-256 recorded in `SHA256SUMS` and the manifest;
+- byte identity of `.user.js` and `.txt`.
+
+The private repository is the authoritative disaster-recovery archive. The public GitHub Release is the distribution archive. Greasy Fork remains the installation endpoint.


### PR DESCRIPTION
Adds the final pre-release safety and recovery layer for Release Pipeline v2:

- introduces a one-click `Release Readiness Check` workflow that validates secrets, settings, source, syntax, distribution parity, changelog, bundle integrity, private repository access and Greasy Fork reachability without publishing anything;
- records the configured private migration repository in release settings;
- adds a formal recovery guide covering failures at each release checkpoint, duplicate prevention and private archive verification;
- does not create a GitHub Release, change Greasy Fork, post to Discord or write a backup when merged.

This gives every future release a clean go/no-go check before `Release Toolkit` is run.