### PR TITLE
[Release Trigger] Toolkit v4.11.0 Smart Bookmark Labels

### DIFF
--- a/.github/release-triggers/v4.11.0-smart-bookmarks.md
+++ b/.github/release-triggers/v4.11.0-smart-bookmarks.md
@@ -3,3 +3,5 @@
 This branch exists solely to emit an observable pull-request event which dispatches the validated bootstrap workflow on `main`.
 
 Expected source SHA-256: `528a6aa829b8e6f5fb3f0c421e74959ff3dba5c2fedb5065dfa254fccf5a014f`
+
+Diagnostic retry: 1

--- a/.github/release-triggers/v4.11.0-smart-bookmarks.md
+++ b/.github/release-triggers/v4.11.0-smart-bookmarks.md
@@ -4,4 +4,4 @@ This branch exists solely to emit an observable pull-request event which dispatc
 
 Expected source SHA-256: `528a6aa829b8e6f5fb3f0c421e74959ff3dba5c2fedb5065dfa254fccf5a014f`
 
-Diagnostic retry: 1
+Diagnostic retry: 2

--- a/.github/release-triggers/v4.11.0-smart-bookmarks.md
+++ b/.github/release-triggers/v4.11.0-smart-bookmarks.md
@@ -1,0 +1,5 @@
+# Toolkit v4.11.0 Smart Bookmark Labels release trigger
+
+This branch exists solely to emit an observable pull-request event which dispatches the validated bootstrap workflow on `main`.
+
+Expected source SHA-256: `528a6aa829b8e6f5fb3f0c421e74959ff3dba5c2fedb5065dfa254fccf5a014f`


### PR DESCRIPTION
Dispatches the one-time validated v4.11.0 bootstrap workflow on `main`.

No Toolkit source is merged from this branch. The bootstrap restores the exact v4.10.4 baseline, applies the deterministic Smart Bookmark Labels patch, validates the resulting v4.11.0 source, commits canonical source and distribution files, then invokes Release Readiness Check and Release Toolkit.

Expected v4.11.0 SHA-256: `528a6aa829b8e6f5fb3f0c421e74959ff3dba5c2fedb5065dfa254fccf5a014f`

---

**Closed as superseded.** Toolkit v4.11.0 was completed and subsequently superseded by the fully released v4.11.2 pipeline. Audit confirmed this branch contains only the one-time release trigger marker and no unique production code.