### PR TITLE
[Release Retry] Toolkit v4.11.0 Production Release

### DIFF
--- a/.github/release-triggers/v4.11.0-production-retry.md
+++ b/.github/release-triggers/v4.11.0-production-retry.md
@@ -1,0 +1,5 @@
+# Toolkit v4.11.0 production release retry
+
+Retries the official `Release Toolkit` workflow after correcting the versioned checksum bundle filename.
+
+Canonical source SHA-256: `528a6aa829b8e6f5fb3f0c421e74959ff3dba5c2fedb5065dfa254fccf5a014f`


### PR DESCRIPTION
Retries the official production release pipeline after correcting the checksum bundle filename mismatch.

Canonical v4.11.0 source and distribution validation already passed.

Expected source SHA-256: `528a6aa829b8e6f5fb3f0c421e74959ff3dba5c2fedb5065dfa254fccf5a014f`

---

**Closed as superseded.** The corrected pipeline completed and has since released v4.11.2. Audit confirmed this branch contains only a one-time retry marker and no unique production code.