### PR TITLE
[Check] Toolkit v4.11.0 Distribution Handoff

### DIFF
--- a/.github/release-triggers/v4.11.0-distribution-handoff-check.md
+++ b/.github/release-triggers/v4.11.0-distribution-handoff-check.md
@@ -1,0 +1,3 @@
+# Toolkit v4.11.0 distribution handoff check
+
+Checks the GitHub latest release asset and Greasy Fork metadata version independently.


### PR DESCRIPTION
Checks the published GitHub latest-release asset and Greasy Fork live metadata independently while the production release workflow is in its verification window.

---

**Closed as superseded.** Distribution handoff was completed and later releases are verified by the current production pipeline. Audit confirmed this branch contains only a temporary handoff-check marker and no unique production code.