### PR TITLE
[Webhook Retry] Toolkit v4.11.0 Greasy Fork Sync

### DIFF
--- a/.github/release-triggers/v4.11.0-greasyfork-webhook-retry.md
+++ b/.github/release-triggers/v4.11.0-greasyfork-webhook-retry.md
@@ -1,0 +1,3 @@
+# Toolkit v4.11.0 Greasy Fork webhook retry
+
+Re-saves the existing published GitHub release without changing its user-facing content, emitting a fresh release update event for the configured Greasy Fork webhook.


### PR DESCRIPTION
Re-saves the existing published v4.11.0 GitHub Release with identical title and notes, explicitly retaining it as the latest release. This emits a fresh release update event for the configured Greasy Fork webhook while the official production verifier remains active.

---

**Closed as superseded.** Greasy Fork synchronization completed and the current release pipeline now includes verified announcement-state reconciliation. Audit confirmed this branch contains only a one-time webhook retry marker and no unique production code.