### PR TITLE
[Recreate] Toolkit v4.11.0 Corrected Release

### DIFF
--- a/.github/release-triggers/v4.11.0-corrected-recreation.md
+++ b/.github/release-triggers/v4.11.0-corrected-recreation.md
@@ -1,0 +1,5 @@
+# Toolkit v4.11.0 corrected release recreation
+
+Removes the failed release/tag pair and reruns the corrected production pipeline with a root-level Greasy Fork source mirror included in the release tag.
+
+Validated userscript SHA-256 remains `528a6aa829b8e6f5fb3f0c421e74959ff3dba5c2fedb5065dfa254fccf5a014f`.


### PR DESCRIPTION
Recreates the v4.11.0 GitHub release through the corrected production pipeline.

The corrected workflow commits a root-level stable userscript mirror before tagging, matching Greasy Fork's release-webhook implementation. The Toolkit source, feature set, version and validated SHA-256 remain unchanged.

Validated SHA-256: `528a6aa829b8e6f5fb3f0c421e74959ff3dba5c2fedb5065dfa254fccf5a014f`

---

**Closed as superseded.** The corrected release was completed and superseded by v4.11.2. Audit confirmed this branch contains only a one-time recreation marker and no unique production code.