### PR TITLE
Prevent duplicate Discord release announcements

### DIFF
--- a/.github/workflows/greasyfork-release-monitor.yml
+++ b/.github/workflows/greasyfork-release-monitor.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: greasyfork-release-fallback-monitor
+  group: toolkit-production-release
   cancel-in-progress: false
 
 jobs:
@@ -25,13 +25,14 @@ jobs:
           ref: main
           fetch-depth: 0
 
-      - name: Read live and announced versions
+      - name: Read live and announcement state
         id: version
         shell: bash
         run: |
           set -euo pipefail
           META_URL="https://update.greasyfork.org/scripts/586018/MissionChief%20Map%20Command%20Toolkit.meta.js"
           STATE_FILE=".github/greasyfork-version.txt"
+          DASHBOARD_FILE="status/release-dashboard.json"
 
           LIVE_VERSION="$(
             curl --fail --silent --show-error --location --compressed --max-time 30 \
@@ -42,14 +43,78 @@ jobs:
             xargs
           )"
           ANNOUNCED_VERSION="$(tr -d '\r\n ' < "$STATE_FILE" 2>/dev/null || true)"
+          DASHBOARD_VERSION="$(jq -r '.latestRelease.version // empty' "$DASHBOARD_FILE" 2>/dev/null || true)"
+          DASHBOARD_GREASYFORK="$(jq -r '.latestRelease.greasyForkVerified // false' "$DASHBOARD_FILE" 2>/dev/null || true)"
+          DASHBOARD_DISCORD="$(jq -r '.latestRelease.discordPosted // false' "$DASHBOARD_FILE" 2>/dev/null || true)"
+
+          DASHBOARD_ANNOUNCED=false
+          if [[ "$DASHBOARD_VERSION" == "$LIVE_VERSION" &&
+                "$DASHBOARD_GREASYFORK" == "true" &&
+                "$DASHBOARD_DISCORD" == "true" ]]; then
+            DASHBOARD_ANNOUNCED=true
+          fi
+
+          echo "Live Greasy Fork version: ${LIVE_VERSION:-unavailable}"
+          echo "Fallback tracker version: ${ANNOUNCED_VERSION:-none}"
+          echo "Dashboard release version: ${DASHBOARD_VERSION:-none}"
+          echo "Dashboard already announced: $DASHBOARD_ANNOUNCED"
 
           echo "live=$LIVE_VERSION" >> "$GITHUB_OUTPUT"
           echo "announced=$ANNOUNCED_VERSION" >> "$GITHUB_OUTPUT"
+          echo "dashboard_announced=$DASHBOARD_ANNOUNCED" >> "$GITHUB_OUTPUT"
+
           if [[ -n "$ANNOUNCED_VERSION" && "$LIVE_VERSION" != "$ANNOUNCED_VERSION" ]]; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
+            if [[ "$DASHBOARD_ANNOUNCED" == "true" ]]; then
+              echo "changed=false" >> "$GITHUB_OUTPUT"
+              echo "reconcile=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "changed=true" >> "$GITHUB_OUTPUT"
+              echo "reconcile=false" >> "$GITHUB_OUTPUT"
+            fi
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "reconcile=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Reconcile tracker from verified release dashboard
+        if: steps.version.outputs.reconcile == 'true'
+        env:
+          CURRENT_VERSION: ${{ steps.version.outputs.live }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          STATE_FILE=".github/greasyfork-version.txt"
+          DASHBOARD_FILE="status/release-dashboard.json"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          for attempt in 1 2 3; do
+            git fetch origin main --prune
+            git reset --hard origin/main
+
+            REMOTE_STATE="$(tr -d '\r\n ' < "$STATE_FILE" 2>/dev/null || true)"
+            DASHBOARD_VERSION="$(jq -r '.latestRelease.version // empty' "$DASHBOARD_FILE" 2>/dev/null || true)"
+            DASHBOARD_GREASYFORK="$(jq -r '.latestRelease.greasyForkVerified // false' "$DASHBOARD_FILE" 2>/dev/null || true)"
+            DASHBOARD_DISCORD="$(jq -r '.latestRelease.discordPosted // false' "$DASHBOARD_FILE" 2>/dev/null || true)"
+
+            [[ "$REMOTE_STATE" == "$CURRENT_VERSION" ]] && exit 0
+
+            if [[ "$DASHBOARD_VERSION" != "$CURRENT_VERSION" ||
+                  "$DASHBOARD_GREASYFORK" != "true" ||
+                  "$DASHBOARD_DISCORD" != "true" ]]; then
+              echo "::warning::The verified dashboard state changed before reconciliation. The fallback tracker was not modified."
+              exit 0
+            fi
+
+            printf '%s\n' "$CURRENT_VERSION" > "$STATE_FILE"
+            git add "$STATE_FILE"
+            git commit -m "Reconcile announced Toolkit version ${CURRENT_VERSION}"
+            git push origin HEAD:main && exit 0
+            sleep 5
+          done
+
+          echo "::error::Could not reconcile the fallback announcement tracker after three attempts."
+          exit 1
 
       - name: Read unannounced changelog entries
         id: changelog
@@ -74,7 +139,19 @@ jobs:
           set -euo pipefail
           git fetch origin main --prune
           REMOTE_STATE="$(git show origin/main:.github/greasyfork-version.txt 2>/dev/null | tr -d '\r\n ' || true)"
-          if [[ "$REMOTE_STATE" == "$PREVIOUS_VERSION" && "$REMOTE_STATE" != "$CURRENT_VERSION" ]]; then
+          REMOTE_DASHBOARD="$(git show origin/main:status/release-dashboard.json 2>/dev/null || true)"
+          DASHBOARD_VERSION="$(jq -r '.latestRelease.version // empty' <<< "$REMOTE_DASHBOARD" 2>/dev/null || true)"
+          DASHBOARD_GREASYFORK="$(jq -r '.latestRelease.greasyForkVerified // false' <<< "$REMOTE_DASHBOARD" 2>/dev/null || true)"
+          DASHBOARD_DISCORD="$(jq -r '.latestRelease.discordPosted // false' <<< "$REMOTE_DASHBOARD" 2>/dev/null || true)"
+
+          if [[ "$REMOTE_STATE" == "$CURRENT_VERSION" ]]; then
+            echo "pending=false" >> "$GITHUB_OUTPUT"
+          elif [[ "$DASHBOARD_VERSION" == "$CURRENT_VERSION" &&
+                  "$DASHBOARD_GREASYFORK" == "true" &&
+                  "$DASHBOARD_DISCORD" == "true" ]]; then
+            echo "The verified release dashboard already records this Discord announcement."
+            echo "pending=false" >> "$GITHUB_OUTPUT"
+          elif [[ "$REMOTE_STATE" == "$PREVIOUS_VERSION" && "$REMOTE_STATE" != "$CURRENT_VERSION" ]]; then
             echo "pending=true" >> "$GITHUB_OUTPUT"
           else
             echo "pending=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/reconcile-release-announcement-state.yml
+++ b/.github/workflows/reconcile-release-announcement-state.yml
@@ -1,0 +1,88 @@
+name: Reconcile Release Announcement State
+
+on:
+  workflow_run:
+    workflows:
+      - Release Toolkit
+    types:
+      - completed
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: toolkit-production-release
+  cancel-in-progress: false
+
+jobs:
+  reconcile:
+    name: Synchronize release announcement tracker
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out latest main
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Verify completed release state
+        id: release
+        shell: bash
+        run: |
+          set -euo pipefail
+          DASHBOARD_FILE="status/release-dashboard.json"
+          VERSION="$(jq -r '.latestRelease.version // empty' "$DASHBOARD_FILE")"
+          GREASYFORK_VERIFIED="$(jq -r '.latestRelease.greasyForkVerified // false' "$DASHBOARD_FILE")"
+          DISCORD_POSTED="$(jq -r '.latestRelease.discordPosted // false' "$DASHBOARD_FILE")"
+
+          [[ -n "$VERSION" ]] || { echo "::error::The release dashboard has no latest release version."; exit 1; }
+          [[ "$GREASYFORK_VERIFIED" == "true" ]] || { echo "::error::The latest release is not verified on Greasy Fork."; exit 1; }
+          [[ "$DISCORD_POSTED" == "true" ]] || { echo "::error::The latest release is not recorded as announced to Discord."; exit 1; }
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Reconcile fallback announcement tracker
+        env:
+          CURRENT_VERSION: ${{ steps.release.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          STATE_FILE=".github/greasyfork-version.txt"
+          DASHBOARD_FILE="status/release-dashboard.json"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          for attempt in 1 2 3; do
+            git fetch origin main --prune
+            git reset --hard origin/main
+
+            REMOTE_STATE="$(tr -d '\r\n ' < "$STATE_FILE" 2>/dev/null || true)"
+            DASHBOARD_VERSION="$(jq -r '.latestRelease.version // empty' "$DASHBOARD_FILE" 2>/dev/null || true)"
+            DASHBOARD_GREASYFORK="$(jq -r '.latestRelease.greasyForkVerified // false' "$DASHBOARD_FILE" 2>/dev/null || true)"
+            DASHBOARD_DISCORD="$(jq -r '.latestRelease.discordPosted // false' "$DASHBOARD_FILE" 2>/dev/null || true)"
+
+            [[ "$REMOTE_STATE" == "$CURRENT_VERSION" ]] && {
+              echo "Fallback tracker already records Toolkit ${CURRENT_VERSION}."
+              exit 0
+            }
+
+            if [[ "$DASHBOARD_VERSION" != "$CURRENT_VERSION" ||
+                  "$DASHBOARD_GREASYFORK" != "true" ||
+                  "$DASHBOARD_DISCORD" != "true" ]]; then
+              echo "::error::The verified dashboard state changed before tracker reconciliation."
+              exit 1
+            fi
+
+            printf '%s\n' "$CURRENT_VERSION" > "$STATE_FILE"
+            git add "$STATE_FILE"
+            git commit -m "Reconcile announced Toolkit version ${CURRENT_VERSION}"
+            git push origin HEAD:main && exit 0
+            sleep 5
+          done
+
+          echo "::error::Could not reconcile the release announcement tracker after three attempts."
+          exit 1


### PR DESCRIPTION
## What changed

- makes the Greasy Fork fallback monitor share the production release concurrency lock, so it cannot race the primary release workflow;
- checks `status/release-dashboard.json` before posting and suppresses the fallback message when the live Greasy Fork version is already verified and recorded as announced;
- silently reconciles `.github/greasyfork-version.txt` from the verified dashboard instead of posting a duplicate;
- adds a post-release reconciliation workflow that advances the fallback tracker immediately after a successful `Release Toolkit` run;
- keeps the genuine fallback path intact for versions that are live on Greasy Fork but were not successfully announced by the primary pipeline.

## Root cause

The primary release workflow and fallback monitor used separate announcement state. The primary route posted v4.11.2 and updated the release dashboard, while the fallback tracker still contained v4.11.1. The scheduled monitor therefore treated v4.11.2 as unannounced and posted it again.

## Validation

- both workflow files parse as YAML;
- the fallback decision path was tested for matching tracker, stale tracker with verified dashboard, and genuinely unannounced live versions;
- the branch changes only release-announcement coordination files;
- no userscript, Greasy Fork release, theme, asset, or public version is changed.