### PR TITLE
Add performance regression guardrails

### DIFF
--- a/.github/PERFORMANCE_BUDGET.md
+++ b/.github/PERFORMANCE_BUDGET.md
@@ -1,0 +1,42 @@
+# Toolkit performance budget
+
+The Toolkit uses a static CI guardrail to detect changes that are likely to increase startup work or long-lived browser processing before they are released.
+
+## What is measured
+
+The checker records:
+
+- source bytes and line count;
+- estimated embedded CSS bytes and rule blocks;
+- `setInterval` and `setTimeout` call sites;
+- `MutationObserver` and `ResizeObserver` constructions;
+- `requestAnimationFrame` call sites;
+- event-listener and selector call sites;
+- document startup hooks;
+- required startup instrumentation and userscript metadata markers.
+
+These are workload indicators, not a substitute for real browser profiling. A static increase does not automatically prove that runtime performance became worse, but abrupt increases require review.
+
+## Comparison rules
+
+- Pull requests compare the candidate source against the target `main` commit.
+- Pushes to `main` compare against the previous `main` commit.
+- Release Readiness compares the candidate against the latest versioned release tag.
+- When no comparison source is available, absolute source-size limits still apply.
+
+The version-controlled policy is stored in `.github/performance-budget.json`.
+
+## Warnings and failures
+
+Small increases above a review threshold create GitHub Actions warnings but do not block development. Larger increases or absolute-limit violations fail the check and block Release Readiness.
+
+A legitimate feature may require a budget adjustment. Update the policy in the same pull request and explain the reason in its `revision` and `rationale` fields. Budget changes are therefore visible in review rather than hidden in workflow code.
+
+## Diagnostics
+
+Every run uploads:
+
+- `performance-budget-report.json` for machine-readable metrics;
+- `performance-budget-report.md` for the workflow summary.
+
+For reported runtime problems, also use the structured Performance Report issue form and include `window.__MCMS_STARTUP_METRICS__` where available.

--- a/.github/performance-budget.json
+++ b/.github/performance-budget.json
@@ -1,0 +1,65 @@
+{
+  "schemaVersion": 1,
+  "revision": "2026-07-14-initial",
+  "rationale": "Initial guardrails are calibrated to Toolkit v4.11.2 and permit normal feature growth while blocking abrupt startup-workload expansion.",
+  "requiredSourceFragments": [
+    "@run-at       document-start",
+    "__MCMS_STARTUP_METRICS__"
+  ],
+  "absoluteLimits": {
+    "bytes": 1900000,
+    "lines": 31000
+  },
+  "relativeLimits": {
+    "bytes": {
+      "warnDelta": 35000,
+      "warnPercent": 2.0,
+      "failDelta": 120000,
+      "failPercent": 6.0
+    },
+    "lines": {
+      "warnDelta": 700,
+      "warnPercent": 2.0,
+      "failDelta": 1800,
+      "failPercent": 6.0
+    },
+    "css_bytes": {
+      "warnDelta": 25000,
+      "warnPercent": 4.0,
+      "failDelta": 65000,
+      "failPercent": 10.0
+    },
+    "css_rule_blocks": {
+      "warnDelta": 25,
+      "failDelta": 100
+    },
+    "set_interval_calls": {
+      "warnDelta": 1,
+      "failDelta": 3
+    },
+    "set_timeout_calls": {
+      "warnDelta": 5,
+      "failDelta": 20
+    },
+    "mutation_observers": {
+      "warnDelta": 1,
+      "failDelta": 3
+    },
+    "resize_observers": {
+      "warnDelta": 1,
+      "failDelta": 2
+    },
+    "request_animation_frame_calls": {
+      "warnDelta": 5,
+      "failDelta": 20
+    },
+    "event_listener_calls": {
+      "warnDelta": 20,
+      "failDelta": 75
+    },
+    "startup_hook_calls": {
+      "warnDelta": 2,
+      "failDelta": 6
+    }
+  }
+}

--- a/.github/performance-budget.json
+++ b/.github/performance-budget.json
@@ -8,7 +8,17 @@
   ],
   "absoluteLimits": {
     "bytes": 1900000,
-    "lines": 31000
+    "lines": 31000,
+    "css_bytes": 950000,
+    "css_rule_blocks": 7000,
+    "set_interval_calls": 4,
+    "set_timeout_calls": 25,
+    "mutation_observers": 8,
+    "resize_observers": 4,
+    "request_animation_frame_calls": 20,
+    "event_listener_calls": 120,
+    "query_selector_calls": 400,
+    "startup_hook_calls": 10
   },
   "relativeLimits": {
     "bytes": {

--- a/.github/scripts/check_performance_budget.py
+++ b/.github/scripts/check_performance_budget.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Static performance-regression guardrails for the MissionChief Toolkit.
+
+The checker compares a candidate userscript with a base userscript and applies
+version-controlled absolute and relative budgets. It intentionally measures
+workload indicators rather than attempting to benchmark MissionChief in CI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+METRIC_LABELS = {
+    "bytes": "Source bytes",
+    "lines": "Source lines",
+    "nonempty_lines": "Non-empty lines",
+    "css_bytes": "Estimated embedded CSS bytes",
+    "css_rule_blocks": "Estimated embedded CSS rule blocks",
+    "set_interval_calls": "setInterval calls",
+    "set_timeout_calls": "setTimeout calls",
+    "mutation_observers": "MutationObserver constructions",
+    "resize_observers": "ResizeObserver constructions",
+    "request_animation_frame_calls": "requestAnimationFrame calls",
+    "event_listener_calls": "addEventListener calls",
+    "query_selector_calls": "querySelector/querySelectorAll calls",
+    "startup_hook_calls": "DOMContentLoaded/load startup hooks",
+}
+
+PATTERNS = {
+    "set_interval_calls": re.compile(r"\bsetInterval\s*\("),
+    "set_timeout_calls": re.compile(r"\bsetTimeout\s*\("),
+    "mutation_observers": re.compile(r"\bnew\s+(?:pageWindow\.)?MutationObserver\s*\("),
+    "resize_observers": re.compile(r"\bnew\s+(?:pageWindow\.)?ResizeObserver\s*\("),
+    "request_animation_frame_calls": re.compile(r"\brequestAnimationFrame\s*\("),
+    "event_listener_calls": re.compile(r"\.addEventListener\s*\("),
+    "query_selector_calls": re.compile(r"\.(?:querySelector|querySelectorAll)\s*\("),
+    "startup_hook_calls": re.compile(
+        r"\.addEventListener\s*\(\s*['\"](?:DOMContentLoaded|load|readystatechange)['\"]"
+    ),
+}
+
+TEMPLATE_LITERAL = re.compile(r"`((?:\\.|[^`])*)`", re.DOTALL)
+CSS_SIGNAL = re.compile(
+    r"(?:!important|--[a-zA-Z0-9_-]+\s*:|(?:display|position|color|background|border|font|padding|margin|width|height|opacity|transform|animation|z-index)\s*:)",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class Finding:
+    level: str
+    metric: str
+    message: str
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--candidate", required=True, type=Path)
+    parser.add_argument("--base", type=Path)
+    parser.add_argument("--policy", required=True, type=Path)
+    parser.add_argument("--json-output", required=True, type=Path)
+    parser.add_argument("--markdown-output", required=True, type=Path)
+    return parser.parse_args()
+
+
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        raise SystemExit(f"Cannot read {path}: {exc}") from exc
+
+
+def embedded_css_metrics(text: str) -> tuple[int, int]:
+    css_bytes = 0
+    rule_blocks = 0
+    for match in TEMPLATE_LITERAL.finditer(text):
+        value = match.group(1)
+        if "{" not in value or "}" not in value or not CSS_SIGNAL.search(value):
+            continue
+        css_bytes += len(value.encode("utf-8"))
+        rule_blocks += value.count("{")
+    return css_bytes, rule_blocks
+
+
+def collect_metrics(path: Path) -> dict[str, int]:
+    text = read_text(path)
+    css_bytes, css_rule_blocks = embedded_css_metrics(text)
+    lines = text.splitlines()
+    metrics: dict[str, int] = {
+        "bytes": len(text.encode("utf-8")),
+        "lines": len(lines),
+        "nonempty_lines": sum(1 for line in lines if line.strip()),
+        "css_bytes": css_bytes,
+        "css_rule_blocks": css_rule_blocks,
+    }
+    metrics.update({name: len(pattern.findall(text)) for name, pattern in PATTERNS.items()})
+    return metrics
+
+
+def load_policy(path: Path) -> dict[str, Any]:
+    try:
+        policy = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise SystemExit(f"Cannot read performance policy {path}: {exc}") from exc
+    if policy.get("schemaVersion") != 1:
+        raise SystemExit("Unsupported performance-budget schemaVersion")
+    return policy
+
+
+def format_delta(candidate: int, base: int | None) -> str:
+    if base is None:
+        return "n/a"
+    delta = candidate - base
+    if base:
+        percent = (delta / base) * 100
+        return f"{delta:+,} ({percent:+.2f}%)"
+    return f"{delta:+,}"
+
+
+def evaluate(
+    candidate: dict[str, int],
+    base: dict[str, int] | None,
+    policy: dict[str, Any],
+    candidate_text: str,
+) -> list[Finding]:
+    findings: list[Finding] = []
+
+    for fragment in policy.get("requiredSourceFragments", []):
+        if fragment not in candidate_text:
+            findings.append(
+                Finding("failure", "required_source_fragment", f"Required source fragment is missing: {fragment}")
+            )
+
+    for metric, limit in policy.get("absoluteLimits", {}).items():
+        value = candidate.get(metric)
+        if value is None:
+            findings.append(Finding("failure", metric, f"Policy references unknown metric: {metric}"))
+        elif value > int(limit):
+            findings.append(
+                Finding(
+                    "failure",
+                    metric,
+                    f"{METRIC_LABELS.get(metric, metric)} is {value:,}; absolute limit is {int(limit):,}.",
+                )
+            )
+
+    if base is None:
+        return findings
+
+    for metric, limits in policy.get("relativeLimits", {}).items():
+        if metric not in candidate or metric not in base:
+            findings.append(Finding("failure", metric, f"Policy references unknown metric: {metric}"))
+            continue
+
+        current = candidate[metric]
+        previous = base[metric]
+        delta = current - previous
+        percent = (delta / previous * 100) if previous else (100.0 if delta > 0 else 0.0)
+
+        fail_delta = limits.get("failDelta")
+        fail_percent = limits.get("failPercent")
+        warn_delta = limits.get("warnDelta")
+        warn_percent = limits.get("warnPercent")
+
+        fail_by_delta = fail_delta is not None and delta > int(fail_delta)
+        fail_by_percent = fail_percent is not None and percent > float(fail_percent)
+        if fail_delta is not None and fail_percent is not None:
+            failed = fail_by_delta and fail_by_percent
+        else:
+            failed = fail_by_delta or fail_by_percent
+
+        warn_by_delta = warn_delta is not None and delta > int(warn_delta)
+        warn_by_percent = warn_percent is not None and percent > float(warn_percent)
+        if warn_delta is not None and warn_percent is not None:
+            warned = warn_by_delta and warn_by_percent
+        else:
+            warned = warn_by_delta or warn_by_percent
+
+        label = METRIC_LABELS.get(metric, metric)
+        if failed:
+            findings.append(
+                Finding(
+                    "failure",
+                    metric,
+                    f"{label} increased from {previous:,} to {current:,} ({format_delta(current, previous)}), exceeding the failure budget.",
+                )
+            )
+        elif warned:
+            findings.append(
+                Finding(
+                    "warning",
+                    metric,
+                    f"{label} increased from {previous:,} to {current:,} ({format_delta(current, previous)}), exceeding the review threshold.",
+                )
+            )
+
+    return findings
+
+
+def build_markdown(
+    candidate: dict[str, int],
+    base: dict[str, int] | None,
+    findings: list[Finding],
+    policy: dict[str, Any],
+) -> str:
+    failures = [finding for finding in findings if finding.level == "failure"]
+    result = "FAILED" if failures else "PASSED"
+
+    lines = [
+        "# Toolkit performance budget",
+        "",
+        f"**Result:** {result}",
+        "",
+        "| Metric | Base | Candidate | Change |",
+        "|---|---:|---:|---:|",
+    ]
+    for metric, label in METRIC_LABELS.items():
+        candidate_value = candidate[metric]
+        base_value = base[metric] if base else None
+        lines.append(
+            f"| {label} | {base_value if base_value is not None else 'n/a'} | {candidate_value} | {format_delta(candidate_value, base_value)} |"
+        )
+
+    lines.extend(["", "## Findings", ""])
+    if not findings:
+        lines.append("- ✅ No performance-budget regressions detected.")
+    else:
+        for finding in findings:
+            icon = "❌" if finding.level == "failure" else "⚠️"
+            lines.append(f"- {icon} {finding.message}")
+
+    lines.extend(
+        [
+            "",
+            "## Policy",
+            "",
+            f"- Revision: `{policy.get('revision', 'unknown')}`",
+            f"- Rationale: {policy.get('rationale', 'Not recorded')}",
+            "- This is a static regression screen, not a browser benchmark.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    args = parse_args()
+    policy = load_policy(args.policy)
+    candidate_text = read_text(args.candidate)
+    candidate_metrics = collect_metrics(args.candidate)
+    base_metrics = collect_metrics(args.base) if args.base and args.base.exists() else None
+    findings = evaluate(candidate_metrics, base_metrics, policy, candidate_text)
+
+    payload = {
+        "schemaVersion": 1,
+        "policyRevision": policy.get("revision"),
+        "candidate": candidate_metrics,
+        "base": base_metrics,
+        "findings": [finding.__dict__ for finding in findings],
+        "result": "failure" if any(f.level == "failure" for f in findings) else "success",
+    }
+    args.json_output.parent.mkdir(parents=True, exist_ok=True)
+    args.markdown_output.parent.mkdir(parents=True, exist_ok=True)
+    args.json_output.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    args.markdown_output.write_text(
+        build_markdown(candidate_metrics, base_metrics, findings, policy), encoding="utf-8"
+    )
+
+    for finding in findings:
+        annotation = "error" if finding.level == "failure" else "warning"
+        print(f"::{annotation} title=Toolkit performance budget::{finding.message}")
+
+    print(args.markdown_output.read_text(encoding="utf-8"))
+    return 1 if any(finding.level == "failure" for finding in findings) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test_performance_budget.py
+++ b/.github/scripts/test_performance_budget.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Self-tests for the static Toolkit performance-budget checker."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import check_performance_budget as budget
+
+
+class PerformanceBudgetTests(unittest.TestCase):
+    def write_source(self, directory: Path, name: str, text: str) -> Path:
+        path = directory / name
+        path.write_text(text, encoding="utf-8")
+        return path
+
+    def test_embedded_css_and_runtime_primitives_are_counted(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = self.write_source(
+                root,
+                "candidate.user.js",
+                """// @run-at document-start
+const css = `#panel { display: block; color: white; }`;
+setInterval(() => {}, 1000);
+new MutationObserver(() => {});
+document.addEventListener('DOMContentLoaded', () => {});
+""",
+            )
+            metrics = budget.collect_metrics(source)
+            self.assertEqual(metrics["set_interval_calls"], 1)
+            self.assertEqual(metrics["mutation_observers"], 1)
+            self.assertEqual(metrics["startup_hook_calls"], 1)
+            self.assertGreater(metrics["css_bytes"], 0)
+            self.assertEqual(metrics["css_rule_blocks"], 1)
+
+    def test_required_fragment_failure_is_reported(self) -> None:
+        candidate = {metric: 0 for metric in budget.METRIC_LABELS}
+        findings = budget.evaluate(
+            candidate,
+            None,
+            {"requiredSourceFragments": ["required-marker"], "absoluteLimits": {}},
+            "ordinary source",
+        )
+        self.assertTrue(any(finding.level == "failure" for finding in findings))
+
+    def test_warning_threshold_does_not_become_failure(self) -> None:
+        base = {metric: 0 for metric in budget.METRIC_LABELS}
+        candidate = dict(base)
+        candidate["set_timeout_calls"] = 2
+        findings = budget.evaluate(
+            candidate,
+            base,
+            {
+                "absoluteLimits": {},
+                "relativeLimits": {"set_timeout_calls": {"warnDelta": 1, "failDelta": 4}},
+            },
+            "",
+        )
+        self.assertEqual([finding.level for finding in findings], ["warning"])
+
+    def test_large_runtime_primitive_increase_fails(self) -> None:
+        base = {metric: 0 for metric in budget.METRIC_LABELS}
+        candidate = dict(base)
+        candidate["mutation_observers"] = 5
+        findings = budget.evaluate(
+            candidate,
+            base,
+            {
+                "absoluteLimits": {},
+                "relativeLimits": {"mutation_observers": {"warnDelta": 1, "failDelta": 3}},
+            },
+            "",
+        )
+        self.assertTrue(any(finding.level == "failure" for finding in findings))
+
+    def test_percent_and_delta_must_both_exceed_combined_budget(self) -> None:
+        base = {metric: 100 for metric in budget.METRIC_LABELS}
+        candidate = dict(base)
+        candidate["bytes"] = 111
+        findings = budget.evaluate(
+            candidate,
+            base,
+            {
+                "absoluteLimits": {},
+                "relativeLimits": {
+                    "bytes": {
+                        "warnDelta": 20,
+                        "warnPercent": 5,
+                        "failDelta": 30,
+                        "failPercent": 10,
+                    }
+                },
+            },
+            "",
+        )
+        self.assertEqual(findings, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/performance-regression-check.yml
+++ b/.github/workflows/performance-regression-check.yml
@@ -1,0 +1,116 @@
+name: Performance Regression Check
+
+on:
+  pull_request:
+    paths:
+      - "src/MissionChief_Map_Command_Toolkit.user.js"
+      - ".github/performance-budget.json"
+      - ".github/scripts/check_performance_budget.py"
+      - ".github/workflows/performance-regression-check.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "src/MissionChief_Map_Command_Toolkit.user.js"
+      - ".github/performance-budget.json"
+      - ".github/scripts/check_performance_budget.py"
+      - ".github/workflows/performance-regression-check.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: toolkit-performance-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  performance:
+    name: Check static performance budget
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Resolve comparison source
+        id: base
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          SOURCE="src/MissionChief_Map_Command_Toolkit.user.js"
+          BASE_REF=""
+
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            BASE_REF="${PR_BASE_SHA:-}"
+          elif [[ "$EVENT_NAME" == "push" && -n "${PUSH_BEFORE_SHA:-}" && ! "$PUSH_BEFORE_SHA" =~ ^0+$ ]]; then
+            BASE_REF="$PUSH_BEFORE_SHA"
+          else
+            BASE_REF="$(git tag --merged HEAD --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' | head -n 1 || true)"
+            [[ -n "$BASE_REF" ]] || BASE_REF="HEAD^"
+          fi
+
+          if git cat-file -e "${BASE_REF}:${SOURCE}" 2>/dev/null; then
+            git show "${BASE_REF}:${SOURCE}" > /tmp/performance-base.user.js
+            echo "available=true" >> "$GITHUB_OUTPUT"
+            echo "ref=$BASE_REF" >> "$GITHUB_OUTPUT"
+            echo "Comparison source: $BASE_REF"
+          else
+            echo "::warning::No comparison source was available; only absolute budgets will be enforced."
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "ref=none" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run performance budget
+        id: budget
+        shell: bash
+        run: |
+          set +e
+          ARGS=(
+            --candidate src/MissionChief_Map_Command_Toolkit.user.js
+            --policy .github/performance-budget.json
+            --json-output performance-budget-report.json
+            --markdown-output performance-budget-report.md
+          )
+          if [[ "${{ steps.base.outputs.available }}" == "true" ]]; then
+            ARGS+=(--base /tmp/performance-base.user.js)
+          fi
+          python3 .github/scripts/check_performance_budget.py "${ARGS[@]}"
+          STATUS=$?
+          echo "exit_code=$STATUS" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Publish performance summary
+        if: always()
+        shell: bash
+        run: |
+          if [[ -f performance-budget-report.md ]]; then
+            cat performance-budget-report.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::error::Performance report was not created."
+            exit 1
+          fi
+
+      - name: Upload performance diagnostics
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: missionchief-toolkit-performance-budget
+          path: |
+            performance-budget-report.json
+            performance-budget-report.md
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Stop on performance regression
+        if: steps.budget.outputs.exit_code != '0'
+        run: |
+          echo "Static performance-budget checks failed. Review the workflow summary and diagnostics artifact."
+          exit 1

--- a/.github/workflows/performance-regression-check.yml
+++ b/.github/workflows/performance-regression-check.yml
@@ -6,6 +6,7 @@ on:
       - "src/MissionChief_Map_Command_Toolkit.user.js"
       - ".github/performance-budget.json"
       - ".github/scripts/check_performance_budget.py"
+      - ".github/scripts/test_performance_budget.py"
       - ".github/workflows/performance-regression-check.yml"
   push:
     branches:
@@ -14,6 +15,7 @@ on:
       - "src/MissionChief_Map_Command_Toolkit.user.js"
       - ".github/performance-budget.json"
       - ".github/scripts/check_performance_budget.py"
+      - ".github/scripts/test_performance_budget.py"
       - ".github/workflows/performance-regression-check.yml"
   workflow_dispatch:
 
@@ -35,6 +37,9 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+
+      - name: Run performance checker self-tests
+        run: python3 .github/scripts/test_performance_budget.py
 
       - name: Resolve comparison source
         id: base

--- a/.github/workflows/release-readiness-check.yml
+++ b/.github/workflows/release-readiness-check.yml
@@ -56,6 +56,73 @@ jobs:
       - name: Check JavaScript syntax
         run: node --check src/MissionChief_Map_Command_Toolkit.user.js
 
+      - name: Resolve released performance baseline
+        id: performance_base
+        shell: bash
+        run: |
+          set -euo pipefail
+          SOURCE="src/MissionChief_Map_Command_Toolkit.user.js"
+          BASE_REF="$(git tag --merged HEAD --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' | head -n 1 || true)"
+          [[ -n "$BASE_REF" ]] || BASE_REF="HEAD^"
+
+          if git cat-file -e "${BASE_REF}:${SOURCE}" 2>/dev/null; then
+            git show "${BASE_REF}:${SOURCE}" > /tmp/performance-base.user.js
+            echo "available=true" >> "$GITHUB_OUTPUT"
+            echo "ref=$BASE_REF" >> "$GITHUB_OUTPUT"
+            echo "Release performance baseline: $BASE_REF"
+          else
+            echo "::warning::No released performance baseline is available; only absolute budgets will be enforced."
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "ref=none" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check release performance budget
+        id: performance
+        shell: bash
+        run: |
+          set +e
+          ARGS=(
+            --candidate src/MissionChief_Map_Command_Toolkit.user.js
+            --policy .github/performance-budget.json
+            --json-output performance-budget-report.json
+            --markdown-output performance-budget-report.md
+          )
+          if [[ "${{ steps.performance_base.outputs.available }}" == "true" ]]; then
+            ARGS+=(--base /tmp/performance-base.user.js)
+          fi
+          python3 .github/scripts/check_performance_budget.py "${ARGS[@]}"
+          STATUS=$?
+          echo "exit_code=$STATUS" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Publish release performance summary
+        if: always()
+        shell: bash
+        run: |
+          if [[ -f performance-budget-report.md ]]; then
+            cat performance-budget-report.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::error::Performance report was not created."
+            exit 1
+          fi
+
+      - name: Upload release performance diagnostics
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: missionchief-toolkit-release-performance-budget
+          path: |
+            performance-budget-report.json
+            performance-budget-report.md
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Stop on release performance regression
+        if: steps.performance.outputs.exit_code != '0'
+        run: |
+          echo "Release performance-budget checks failed. Review the workflow summary and diagnostics artifact."
+          exit 1
+
       - name: Verify distribution parity
         run: cmp --silent dist/MissionChief_Map_Command_Toolkit.user.js dist/MissionChief_Map_Command_Toolkit.txt
 
@@ -137,6 +204,7 @@ jobs:
             echo "- ✅ Release settings enabled"
             echo "- ✅ Canonical userscript validated"
             echo "- ✅ JavaScript syntax checked"
+            echo "- ✅ Static performance budget passed"
             echo "- ✅ Distribution files are byte-identical"
             echo "- ✅ Changelog and release bundle prepared"
             echo "- ✅ SHA-256 verified: \`${HASH}\`"


### PR DESCRIPTION
## What changed

- adds a static performance-budget analyser for the canonical userscript;
- compares pull requests with `main`, pushes with the previous `main` commit, and Release Readiness with the latest versioned release tag;
- measures source size, embedded CSS, timers, observers, animation-frame calls, event listeners, selectors and startup hooks;
- creates warnings for review-level growth and failures for abrupt or absolute-budget regressions;
- uploads JSON and Markdown diagnostics for every performance run;
- makes Release Readiness fail before publication when the performance budget is exceeded;
- documents how the policy can be reviewed and deliberately revised for legitimate feature growth.

## Initial policy

The initial limits are calibrated around Toolkit v4.11.2:

- absolute source ceiling: 1.9 MB / 31,000 lines;
- warning thresholds for moderate source, CSS and startup-primitive growth;
- failure thresholds for abrupt expansion;
- required preservation of document-start metadata and startup metrics instrumentation.

## Safety

- no userscript source, theme, distribution file, version or Greasy Fork release is changed;
- the check is static and deterministic;
- smaller increases warn rather than block;
- policy changes remain version-controlled and reviewable.