### PR TITLE
Preserve verified release state during validation

### DIFF
--- a/.github/scripts/generate_release_dashboard.py
+++ b/.github/scripts/generate_release_dashboard.py
@@ -17,10 +17,17 @@ ICONS = {
     "posted": "🟢",
     "configured": "🟢",
     "secret-configured": "🟢",
+    "validated": "🟢",
+    "validated-canonical-source": "🟢",
+    "private-repository-verified": "🟢",
     "dry-run-ready": "🟡",
     "dry-run-built": "🟡",
     "legacy-monitor": "🟡",
+    "pending-release": "🟡",
     "not-configured": "⚪",
+    "not-published": "⚪",
+    "not-created": "⚪",
+    "not-posted": "⚪",
 }
 
 

--- a/.github/scripts/reconcile_validation_dashboard.py
+++ b/.github/scripts/reconcile_validation_dashboard.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Reconcile canonical-validation results without destroying verified release state."""
+from __future__ import annotations
+
+import argparse
+import json
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def reconcile(dashboard: dict, manifest: dict, now: str) -> dict:
+    data = deepcopy(dashboard)
+    version = str(manifest.get("version") or "").strip()
+    sha256 = str(manifest.get("sha256") or "").strip()
+    if not version or not sha256:
+        raise ValueError("release manifest must contain version and sha256")
+
+    latest = data.get("latestRelease") or {}
+    latest_matches = str(latest.get("version") or "") == version
+    greasy_verified = latest_matches and latest.get("greasyForkVerified") is True
+    github_published = latest_matches and bool(str(latest.get("githubRelease") or "").strip())
+    backup_verified = latest_matches and bool(str(latest.get("privateBackupCommit") or "").strip())
+    discord_posted = latest_matches and latest.get("discordPosted") is True
+
+    status = data.setdefault("status", {})
+    status["validation"] = "passed"
+    status["githubRelease"] = "published" if github_published else "not-published"
+    status["greasyForkSync"] = "verified" if greasy_verified else "pending-release"
+    status["backup"] = "private-repository-verified" if backup_verified else "not-created"
+    status["discordRelease"] = "posted" if discord_posted else "not-posted"
+
+    data["currentVersion"] = version
+    data["source"] = {
+        "canonicalPath": "src/MissionChief_Map_Command_Toolkit.user.js",
+        "validatedSha256": sha256,
+        "state": "validated-canonical-source",
+    }
+    data["distributionCandidate"] = {
+        "path": "dist/MissionChief_Map_Command_Toolkit.user.js",
+        "version": version,
+        "state": "validated",
+    }
+
+    if latest_matches and greasy_verified:
+        data.pop("pendingRelease", None)
+
+    data["lastUpdated"] = now
+    return data
+
+
+def self_test() -> None:
+    base = {
+        "currentVersion": "4.11.1",
+        "status": {
+            "validation": "unknown",
+            "githubRelease": "published",
+            "greasyForkSync": "verified",
+            "backup": "private-repository-verified",
+            "discordDevelopment": "configured",
+            "discordRelease": "posted",
+            "assetAudit": "passed",
+        },
+        "pendingRelease": {"version": "4.11.0"},
+        "latestRelease": {
+            "version": "4.11.2",
+            "githubRelease": "https://github.test/releases/v4.11.2",
+            "greasyForkVerified": True,
+            "privateBackupCommit": "abc123",
+            "discordPosted": True,
+        },
+    }
+    manifest = {"version": "4.11.2", "sha256": "f" * 64}
+    result = reconcile(base, manifest, "2026-01-01T00:00:00Z")
+    assert result["status"]["githubRelease"] == "published"
+    assert result["status"]["greasyForkSync"] == "verified"
+    assert result["status"]["backup"] == "private-repository-verified"
+    assert result["status"]["discordRelease"] == "posted"
+    assert result["status"]["discordDevelopment"] == "configured"
+    assert result["status"]["assetAudit"] == "passed"
+    assert "pendingRelease" not in result
+    assert result["latestRelease"] == base["latestRelease"]
+
+    future = reconcile(base, {"version": "4.12.0", "sha256": "a" * 64}, "2026-01-02T00:00:00Z")
+    assert future["status"]["githubRelease"] == "not-published"
+    assert future["status"]["greasyForkSync"] == "pending-release"
+    assert future["status"]["backup"] == "not-created"
+    assert future["status"]["discordRelease"] == "not-posted"
+    assert "pendingRelease" in future
+    assert future["latestRelease"] == base["latestRelease"]
+
+    try:
+        reconcile({}, {"version": "", "sha256": ""}, "now")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("invalid manifest was accepted")
+
+    print("Dashboard reconciliation self-tests passed.")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dashboard", type=Path, default=Path("status/release-dashboard.json"))
+    parser.add_argument("--manifest", type=Path, default=Path("dist/release-manifest.json"))
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--now")
+    parser.add_argument("--self-test", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.self_test:
+        self_test()
+        return 0
+    dashboard = json.loads(args.dashboard.read_text(encoding="utf-8"))
+    manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
+    result = reconcile(dashboard, manifest, args.now or utc_now())
+    output = args.output or args.dashboard
+    output.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+    print(f"Reconciled validation dashboard for Toolkit {result['currentVersion']}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/validate-userscript.yml
+++ b/.github/workflows/validate-userscript.yml
@@ -6,6 +6,7 @@ on:
       - "src/MissionChief_Map_Command_Toolkit.user.js"
       - "CHANGELOG.md"
       - ".github/scripts/validate_userscript.py"
+      - ".github/scripts/reconcile_validation_dashboard.py"
       - ".github/workflows/validate-userscript.yml"
       - "status/source-baseline.json"
   push:
@@ -15,6 +16,7 @@ on:
       - "src/MissionChief_Map_Command_Toolkit.user.js"
       - "CHANGELOG.md"
       - ".github/scripts/validate_userscript.py"
+      - ".github/scripts/reconcile_validation_dashboard.py"
       - ".github/workflows/validate-userscript.yml"
       - "status/source-baseline.json"
   workflow_dispatch:
@@ -37,6 +39,9 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+
+      - name: Validate dashboard reconciliation logic
+        run: python3 .github/scripts/reconcile_validation_dashboard.py --self-test
 
       - name: Validate userscript and build dist
         id: validate
@@ -89,57 +94,7 @@ jobs:
           set -euo pipefail
 
           VERSION="$(jq -r '.version' dist/release-manifest.json)"
-          HASH="$(jq -r '.sha256' dist/release-manifest.json)"
-          NOW="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-
-          jq \
-            --arg version "$VERSION" \
-            --arg hash "$HASH" \
-            --arg now "$NOW" \
-            '.currentVersion = $version
-             | .status.validation = "passed"
-             | .status.githubRelease = (
-                 if .latestRelease.version == $version and ((.latestRelease.githubRelease // "") | length) > 0
-                 then "published"
-                 else (.status.githubRelease // "not-configured")
-                 end
-               )
-             | .status.greasyForkSync = (
-                 if .latestRelease.version == $version and .latestRelease.greasyForkVerified == true
-                 then "verified"
-                 else (.status.greasyForkSync // "legacy-monitor")
-                 end
-               )
-             | .status.backup = (
-                 if .latestRelease.version == $version and ((.latestRelease.privateBackupCommit // "") | length) > 0
-                 then "private-repository-verified"
-                 else (.status.backup // "baseline-recorded")
-                 end
-               )
-             | .status.discordRelease = (
-                 if .latestRelease.version == $version and .latestRelease.discordPosted == true
-                 then "posted"
-                 else (.status.discordRelease // "not-configured")
-                 end
-               )
-             | .source = {
-                 canonicalPath: "src/MissionChief_Map_Command_Toolkit.user.js",
-                 validatedSha256: $hash,
-                 state: "validated-canonical-source"
-               }
-             | .distributionCandidate = {
-                 path: "dist/MissionChief_Map_Command_Toolkit.user.js",
-                 version: $version,
-                 state: "validated"
-               }
-             | if .latestRelease.version == $version and .latestRelease.greasyForkVerified == true
-               then del(.pendingRelease)
-               else .
-               end
-             | .lastUpdated = $now' \
-            status/release-dashboard.json > status/release-dashboard.tmp
-
-          mv status/release-dashboard.tmp status/release-dashboard.json
+          python3 .github/scripts/reconcile_validation_dashboard.py
           python3 .github/scripts/generate_release_dashboard.py
 
           git config user.name "github-actions[bot]"

--- a/.github/workflows/validate-userscript.yml
+++ b/.github/workflows/validate-userscript.yml
@@ -98,27 +98,53 @@ jobs:
             --arg now "$NOW" \
             '.currentVersion = $version
              | .status.validation = "passed"
-             | .status.githubRelease = "not-configured"
-             | .status.greasyForkSync = "legacy-monitor"
-             | .status.backup = "baseline-recorded"
+             | .status.githubRelease = (
+                 if .latestRelease.version == $version and ((.latestRelease.githubRelease // "") | length) > 0
+                 then "published"
+                 else (.status.githubRelease // "not-configured")
+                 end
+               )
+             | .status.greasyForkSync = (
+                 if .latestRelease.version == $version and .latestRelease.greasyForkVerified == true
+                 then "verified"
+                 else (.status.greasyForkSync // "legacy-monitor")
+                 end
+               )
+             | .status.backup = (
+                 if .latestRelease.version == $version and ((.latestRelease.privateBackupCommit // "") | length) > 0
+                 then "private-repository-verified"
+                 else (.status.backup // "baseline-recorded")
+                 end
+               )
+             | .status.discordRelease = (
+                 if .latestRelease.version == $version and .latestRelease.discordPosted == true
+                 then "posted"
+                 else (.status.discordRelease // "not-configured")
+                 end
+               )
              | .source = {
                  canonicalPath: "src/MissionChief_Map_Command_Toolkit.user.js",
                  validatedSha256: $hash,
-                 state: "validated-baseline"
+                 state: "validated-canonical-source"
                }
              | .distributionCandidate = {
                  path: "dist/MissionChief_Map_Command_Toolkit.user.js",
                  version: $version,
-                 state: "dry-run-built"
+                 state: "validated"
                }
+             | if .latestRelease.version == $version and .latestRelease.greasyForkVerified == true
+               then del(.pendingRelease)
+               else .
+               end
              | .lastUpdated = $now' \
             status/release-dashboard.json > status/release-dashboard.tmp
 
           mv status/release-dashboard.tmp status/release-dashboard.json
+          python3 .github/scripts/generate_release_dashboard.py
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add dist status/release-dashboard.json
+          git add dist status/release-dashboard.json status/README.md
 
           if git diff --cached --quiet; then
             echo "Validated distribution is already current."
@@ -126,4 +152,5 @@ jobs:
           fi
 
           git commit -m "Build validated Toolkit ${VERSION} distribution candidate"
-          git push
+          git pull --rebase origin main
+          git push origin HEAD:main

--- a/status/README.md
+++ b/status/README.md
@@ -2,25 +2,25 @@
 
 > Automatically generated from [`release-dashboard.json`](release-dashboard.json). Do not edit this page manually.
 
-## Current version: `4.10.4`
+## Current version: `4.11.2`
 
 | System | Health | State |
 |---|:---:|---|
-| Canonical source | 🔵 | Validated Baseline |
+| Canonical source | 🟢 | Validated Canonical Source |
 | Validation | 🟢 | Passed |
-| GitHub Release | 🔵 | Ready For First Production Release |
-| Greasy Fork | 🔵 | Release Webhook Configured |
-| Private backup | 🔵 | Private Repository Ready |
+| GitHub Release | 🟢 | Published |
+| Greasy Fork | 🟢 | Verified |
+| Private backup | 🟢 | Private Repository Verified |
 | Discord development | 🟢 | Configured |
-| Discord releases | 🟢 | Configured |
+| Discord releases | 🟢 | Posted |
 | Asset audit | 🟢 | Passed |
 
 ## Release state
 
-- **Latest recorded version:** `4.10.4`
-- **State:** Validated dry run
+- **Latest recorded version:** `4.11.2`
+- **State:** Verified public release
 - **Canonical path:** `src/MissionChief_Map_Command_Toolkit.user.js`
-- **Validated SHA-256:** `37952e796f3b11b3ce9bcaee860e7bd3d206afbc9c7de9fac63fd8d940427c82`
+- **Validated SHA-256:** `b0df1dcf5823a61dbf6760734ee189a0d0370aa40fa279d4ce0954c0803c8e1f`
 - **Distribution candidate:** `dist/MissionChief_Map_Command_Toolkit.user.js`
 
 ## Repository health
@@ -28,7 +28,7 @@
 - **Discovered media files:** 28
 - **Referenced hosted paths:** 25
 - **Missing referenced paths:** 0
-- **Last dashboard update:** `2026-07-14T18:13:26Z`
+- **Last dashboard update:** `2026-07-15T00:33:37Z`
 
 ## Release channels
 

--- a/status/release-dashboard.json
+++ b/status/release-dashboard.json
@@ -6,9 +6,9 @@
   "distribution": "Greasy Fork",
   "status": {
     "validation": "passed",
-    "githubRelease": "not-configured",
-    "greasyForkSync": "legacy-monitor",
-    "backup": "baseline-recorded",
+    "githubRelease": "published",
+    "greasyForkSync": "verified",
+    "backup": "private-repository-verified",
     "discordDevelopment": "configured",
     "discordRelease": "posted",
     "assetAudit": "passed",
@@ -28,26 +28,12 @@
   "source": {
     "canonicalPath": "src/MissionChief_Map_Command_Toolkit.user.js",
     "validatedSha256": "b0df1dcf5823a61dbf6760734ee189a0d0370aa40fa279d4ce0954c0803c8e1f",
-    "state": "validated-baseline"
+    "state": "validated-canonical-source"
   },
   "distributionCandidate": {
     "path": "dist/MissionChief_Map_Command_Toolkit.user.js",
     "version": "4.11.2",
-    "state": "dry-run-built"
-  },
-  "pendingRelease": {
-    "version": "4.11.0",
-    "sha256": "528a6aa829b8e6f5fb3f0c421e74959ff3dba5c2fedb5065dfa254fccf5a014f",
-    "githubRelease": "https://github.com/Conroy1988/missionchief-toolkit-assets/releases/tag/v4.11.0",
-    "githubReleasePublished": true,
-    "greasyForkExpectedVersion": "4.11.0",
-    "greasyForkObservedVersion": "4.10.4",
-    "greasyForkVerified": false,
-    "privateBackupCommitted": false,
-    "discordPosted": false,
-    "workflowRun": "https://github.com/Conroy1988/missionchief-toolkit-assets/actions/runs/29362435779",
-    "state": "awaiting-greasyfork-synchronization",
-    "recordedAt": "2026-07-14T20:10:40Z"
+    "state": "validated"
   },
   "releaseDryRun": {
     "version": "4.10.4",


### PR DESCRIPTION
Fixes the post-validation dashboard regression exposed after PR #31:

- replaces hard-coded legacy status resets with release-aware reconciliation from `latestRelease`;
- preserves published GitHub, verified Greasy Fork, private backup and Discord state when validating the current released version;
- shows explicit pending states when validating a future unreleased version;
- removes the obsolete v4.11.0 pending-release block after a newer verified release exists;
- adds deterministic reconciliation self-tests;
- regenerates the human-readable control panel for v4.11.2;
- improves green status rendering for canonical source and private backup states.

No userscript, version, public release, Greasy Fork script, private archive or Discord announcement is changed.