### PR TITLE
Add operational monitoring and roadmap controls

### DIFF
--- a/.github/actions-security-policy.json
+++ b/.github/actions-security-policy.json
@@ -13,6 +13,7 @@
     ".github/workflows/github-pages.yml": ["id-token", "pages"],
     ".github/workflows/greasyfork-release-monitor.yml": ["contents"],
     ".github/workflows/import-canonical-userscript.yml": ["contents"],
+    ".github/workflows/pages-production-monitor.yml": ["issues"],
     ".github/workflows/prepare-release-rollback.yml": ["contents", "issues", "pull-requests"],
     ".github/workflows/reconcile-release-announcement-state.yml": ["contents"],
     ".github/workflows/release-recovery.yml": ["contents"],

--- a/.github/documentation-contract.json
+++ b/.github/documentation-contract.json
@@ -32,7 +32,6 @@
     "Critical View",
     "Transport Watcher",
     "Vehicle Code Status",
-    "Coverage Heat Map",
     "Smart Bookmark Labels",
     "Alliance Credits",
     "Tablet Mode",

--- a/.github/documentation-contract.json
+++ b/.github/documentation-contract.json
@@ -1,0 +1,49 @@
+{
+  "schemaVersion": 1,
+  "project": {
+    "repository": "https://github.com/Conroy1988/missionchief-toolkit-assets",
+    "issues": "https://github.com/Conroy1988/missionchief-toolkit-assets/issues",
+    "releases": "https://github.com/Conroy1988/missionchief-toolkit-assets/releases",
+    "pages": "https://conroy1988.github.io/missionchief-toolkit-assets/"
+  },
+  "themes": [
+    "Map Command",
+    "Cyberpunk",
+    "Fallout 4",
+    "Umbrella",
+    "Factorio"
+  ],
+  "modes": [
+    "Desktop",
+    "Tablet",
+    "iOS Mobile"
+  ],
+  "shortcuts": [
+    {"key": "1", "action": "Toggle My Missions"},
+    {"key": "2", "action": "Toggle Alliance Missions"},
+    {"key": "3", "action": "Toggle Vehicles"},
+    {"key": "4", "action": "Toggle My Buildings"},
+    {"key": "5", "action": "Toggle Alliance Credits"},
+    {"key": "6", "action": "Toggle Mission Age"},
+    {"key": "V", "action": "Open or close Vehicle Code Status"}
+  ],
+  "requiredSourceTokens": [
+    "Mission Age Watch",
+    "Critical View",
+    "Transport Watcher",
+    "Vehicle Code Status",
+    "Coverage Heat Map",
+    "Smart Bookmark Labels",
+    "Alliance Credits",
+    "Tablet Mode",
+    "iOS Mobile Mode",
+    "Cyberpunk",
+    "Fallout",
+    "Umbrella",
+    "Factorio"
+  ],
+  "installUrls": [
+    "https://update.greasyfork.org/scripts/586018/MissionChief%20Map%20Command%20Toolkit.user.js",
+    "https://greasyfork.org/en/scripts/586018-missionchief-map-command-toolkit"
+  ]
+}

--- a/.github/pages-monitor-policy.json
+++ b/.github/pages-monitor-policy.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": 1,
+  "baseUrl": "https://conroy1988.github.io/missionchief-toolkit-assets/",
+  "timeoutSeconds": 25,
+  "routes": [
+    {"path": "", "contentType": "text/html", "requiredText": ["MissionChief Map Command Toolkit"]},
+    {"path": "features/", "contentType": "text/html", "requiredText": ["Features", "Mission Age Watch"]},
+    {"path": "themes/", "contentType": "text/html", "requiredText": ["Themes", "Cyberpunk", "Factorio"]},
+    {"path": "docs/", "contentType": "text/html", "requiredText": ["Documentation", "Installation"]},
+    {"path": "changelog/", "contentType": "text/html", "requiredText": ["Changelog"]},
+    {"path": "status/", "contentType": "text/html", "requiredText": ["Status"]},
+    {"path": "assets/site.css", "contentType": "text/css", "minimumBytes": 1000},
+    {"path": "assets/site.js", "contentType": "javascript", "minimumBytes": 500}
+  ]
+}

--- a/.github/scripts/check_documentation_drift.py
+++ b/.github/scripts/check_documentation_drift.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Validate public documentation against the canonical Toolkit contract."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def userscript_version(source: str) -> str:
+    match = re.search(r"^//\s*@version\s+([^\s]+)\s*$", source, re.MULTILINE)
+    if not match:
+        raise ValueError("Canonical userscript has no @version metadata entry")
+    return match.group(1)
+
+
+def audit(root: Path) -> dict[str, Any]:
+    contract = load_json(root / ".github/documentation-contract.json")
+    site = load_json(root / "docs/site-data.json")
+    dashboard = load_json(root / "status/release-dashboard.json")
+    source = (root / "src/MissionChief_Map_Command_Toolkit.user.js").read_text(encoding="utf-8")
+
+    failures: list[str] = []
+    warnings: list[str] = []
+    version = userscript_version(source)
+    dashboard_versions = {
+        str(dashboard.get("currentVersion", "")),
+        str(dashboard.get("latestRelease", {}).get("version", "")),
+    }
+    dashboard_versions.discard("")
+    if dashboard_versions != {version}:
+        failures.append(
+            f"Version drift: userscript={version}, dashboard={sorted(dashboard_versions)}"
+        )
+
+    site_project = site.get("project", {})
+    for key, expected in contract.get("project", {}).items():
+        actual = site_project.get(key)
+        if actual != expected:
+            failures.append(f"Project URL drift for {key}: expected {expected!r}, found {actual!r}")
+
+    themes = [item.get("name") for item in site.get("themes", [])]
+    if themes != contract.get("themes", []):
+        failures.append(f"Theme catalogue drift: expected {contract.get('themes', [])}, found {themes}")
+    if len(themes) != len(set(themes)):
+        failures.append("Theme catalogue contains duplicate names")
+
+    modes = [item.get("name") for item in site.get("modes", [])]
+    if modes != contract.get("modes", []):
+        failures.append(f"Operating-mode drift: expected {contract.get('modes', [])}, found {modes}")
+
+    shortcuts = [
+        {"key": str(item.get("key", "")), "action": str(item.get("action", ""))}
+        for item in site.get("shortcuts", [])
+    ]
+    if shortcuts != contract.get("shortcuts", []):
+        failures.append("Keyboard-shortcut documentation differs from the approved contract")
+    keys = [item["key"].upper() for item in shortcuts]
+    if len(keys) != len(set(keys)):
+        failures.append("Keyboard-shortcut documentation contains duplicate keys")
+
+    source_lower = source.lower()
+    for token in contract.get("requiredSourceTokens", []):
+        if str(token).lower() not in source_lower:
+            failures.append(f"Documented capability token is absent from canonical source: {token}")
+
+    repository_text = "\n".join(
+        path.read_text(encoding="utf-8", errors="replace")
+        for path in [root / "README.md", root / "docs/site-data.json", root / ".github/release-settings.json"]
+        if path.exists()
+    )
+    for url in contract.get("installUrls", []):
+        if url not in repository_text:
+            failures.append(f"Supported installation URL is absent from repository documentation: {url}")
+
+    feature_names: list[str] = []
+    visuals: list[str] = []
+    categories = site.get("featureCategories", [])
+    for category in categories:
+        name = str(category.get("name", "")).strip()
+        if not name:
+            failures.append("Feature category has no name")
+        for feature in category.get("features", []):
+            feature_name = str(feature.get("name", "")).strip()
+            visual = str(feature.get("visual", "")).strip()
+            if not feature_name:
+                failures.append(f"Feature in category {name!r} has no name")
+            if not visual:
+                failures.append(f"Feature {feature_name!r} has no visual identifier")
+            feature_names.append(feature_name)
+            visuals.append(visual)
+
+    if len(feature_names) != len(set(feature_names)):
+        failures.append("Feature catalogue contains duplicate names")
+    if len(visuals) != len(set(visuals)):
+        failures.append("Feature catalogue contains duplicate visual identifiers")
+    if len(feature_names) < 10:
+        failures.append("Feature catalogue unexpectedly contains fewer than ten features")
+
+    media_roadmap = site.get("mediaRoadmap", [])
+    if len(media_roadmap) < 5:
+        warnings.append("Visual media roadmap is unusually small")
+
+    return {
+        "schemaVersion": 1,
+        "status": "failed" if failures else "passed",
+        "userscriptVersion": version,
+        "documentedThemes": themes,
+        "documentedModes": modes,
+        "documentedShortcuts": shortcuts,
+        "featureCount": len(feature_names),
+        "failures": failures,
+        "warnings": warnings,
+    }
+
+
+def markdown(report: dict[str, Any]) -> str:
+    icon = "✅" if report["status"] == "passed" else "❌"
+    lines = [
+        "# Documentation Drift Audit",
+        "",
+        f"{icon} **Status:** {report['status'].upper()}",
+        "",
+        f"- Toolkit version: **{report['userscriptVersion']}**",
+        f"- Features: **{report['featureCount']}**",
+        f"- Themes: **{len(report['documentedThemes'])}**",
+        f"- Modes: **{len(report['documentedModes'])}**",
+        f"- Shortcuts: **{len(report['documentedShortcuts'])}**",
+    ]
+    if report["failures"]:
+        lines.extend(["", "## Failures", *[f"- {item}" for item in report["failures"]]])
+    if report["warnings"]:
+        lines.extend(["", "## Warnings", *[f"- {item}" for item in report["warnings"]]])
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--json-output", default="documentation-drift-report.json")
+    parser.add_argument("--markdown-output", default="documentation-drift-report.md")
+    args = parser.parse_args()
+
+    report = audit(Path(args.root).resolve())
+    Path(args.json_output).write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    Path(args.markdown_output).write_text(markdown(report), encoding="utf-8")
+    print(markdown(report))
+    return 1 if report["failures"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/check_pages_live.py
+++ b/.github/scripts/check_pages_live.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Verify the deployed GitHub Pages site and current release marker."""
+from __future__ import annotations
+
+import argparse
+import json
+import ssl
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def fetch(url: str, timeout: int) -> tuple[int, str, bytes, str]:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "*/*",
+            "Cache-Control": "no-cache",
+            "User-Agent": "missionchief-toolkit-pages-monitor/1.0",
+        },
+    )
+    context = ssl.create_default_context()
+    with urllib.request.urlopen(request, timeout=timeout, context=context) as response:
+        return (
+            int(response.status),
+            response.headers.get("Content-Type", ""),
+            response.read(),
+            response.geturl(),
+        )
+
+
+def audit(root: Path) -> dict[str, Any]:
+    policy = load_json(root / ".github/pages-monitor-policy.json")
+    dashboard = load_json(root / "status/release-dashboard.json")
+    version = str(dashboard.get("currentVersion") or dashboard.get("latestRelease", {}).get("version") or "")
+    base_url = str(policy["baseUrl"])
+    timeout = int(policy.get("timeoutSeconds", 25))
+    failures: list[str] = []
+    checks: list[dict[str, Any]] = []
+
+    for route in policy.get("routes", []):
+        path = str(route.get("path", ""))
+        url = urllib.parse.urljoin(base_url, path)
+        check: dict[str, Any] = {"path": path, "url": url, "status": "failed"}
+        try:
+            status, content_type, body, final_url = fetch(url, timeout)
+            text = body.decode("utf-8", errors="replace")
+            check.update({
+                "httpStatus": status,
+                "contentType": content_type,
+                "bytes": len(body),
+                "finalUrl": final_url,
+            })
+            if status != 200:
+                failures.append(f"{path or '/'} returned HTTP {status}")
+            expected_type = str(route.get("contentType", ""))
+            if expected_type and expected_type.lower() not in content_type.lower():
+                failures.append(
+                    f"{path or '/'} returned content type {content_type!r}; expected {expected_type!r}"
+                )
+            minimum = int(route.get("minimumBytes", 1))
+            if len(body) < minimum:
+                failures.append(f"{path or '/'} returned only {len(body)} bytes; expected at least {minimum}")
+            for required in route.get("requiredText", []):
+                if str(required) not in text:
+                    failures.append(f"{path or '/'} is missing required text: {required}")
+            if path == "" and version and version not in text:
+                failures.append(f"Home page does not expose current Toolkit version {version}")
+            if not any(item.startswith(path or "/") for item in failures):
+                check["status"] = "passed"
+        except (urllib.error.URLError, TimeoutError, OSError) as error:
+            message = f"{path or '/'} could not be fetched: {error}"
+            failures.append(message)
+            check["error"] = str(error)
+        checks.append(check)
+
+    return {
+        "schemaVersion": 1,
+        "status": "failed" if failures else "passed",
+        "checkedAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "baseUrl": base_url,
+        "expectedVersion": version,
+        "checks": checks,
+        "failures": failures,
+    }
+
+
+def markdown(report: dict[str, Any]) -> str:
+    icon = "✅" if report["status"] == "passed" else "❌"
+    lines = [
+        "# GitHub Pages Production Health",
+        "",
+        f"{icon} **Status:** {report['status'].upper()}",
+        "",
+        f"- Site: {report['baseUrl']}",
+        f"- Expected Toolkit version: **{report['expectedVersion']}**",
+        f"- Routes checked: **{len(report['checks'])}**",
+        f"- Checked: `{report['checkedAt']}`",
+        "",
+        "## Route results",
+    ]
+    for check in report["checks"]:
+        route_icon = "✅" if check.get("status") == "passed" else "❌"
+        lines.append(
+            f"- {route_icon} `{check['path'] or '/'}` — {check.get('httpStatus', 'unavailable')}, "
+            f"{check.get('bytes', 0)} bytes"
+        )
+    if report["failures"]:
+        lines.extend(["", "## Failures", *[f"- {item}" for item in report["failures"]]])
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--json-output", default="pages-production-health.json")
+    parser.add_argument("--markdown-output", default="pages-production-health.md")
+    args = parser.parse_args()
+    report = audit(Path(args.root).resolve())
+    Path(args.json_output).write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    Path(args.markdown_output).write_text(markdown(report), encoding="utf-8")
+    print(markdown(report))
+    return 1 if report["failures"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/prepare_release_plan.py
+++ b/.github/scripts/prepare_release_plan.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Prepare a read-only release recommendation and draft notes."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+
+
+def parse_version(value: str) -> tuple[int, int, int]:
+    match = SEMVER_RE.fullmatch(value.strip().lstrip("v"))
+    if not match:
+        raise ValueError(f"Invalid semantic version: {value}")
+    return tuple(int(part) for part in match.groups())
+
+
+def format_version(value: tuple[int, int, int]) -> str:
+    return ".".join(str(part) for part in value)
+
+
+def bump(current: tuple[int, int, int], level: str) -> tuple[int, int, int]:
+    major, minor, patch = current
+    if level == "major":
+        return major + 1, 0, 0
+    if level == "minor":
+        return major, minor + 1, 0
+    return major, minor, patch + 1
+
+
+def sha256(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def labels(pr: dict[str, Any]) -> set[str]:
+    result = set()
+    for item in pr.get("labels", []):
+        if isinstance(item, dict):
+            result.add(str(item.get("name", "")).lower())
+        else:
+            result.add(str(item).lower())
+    return result
+
+
+def classify(pr: dict[str, Any]) -> tuple[str, str]:
+    title = str(pr.get("title", "")).strip()
+    lower = title.lower()
+    pr_labels = labels(pr)
+    if "breaking" in lower or "breaking-change" in pr_labels or "major" in pr_labels:
+        return "Breaking changes", "major"
+    if "enhancement" in pr_labels or lower.startswith(("feat", "add ", "introduce ")):
+        return "Features", "minor"
+    if "bug" in pr_labels or lower.startswith(("fix", "repair", "prevent", "correct")):
+        return "Fixes", "patch"
+    if "area: release pipeline" in pr_labels or any(word in lower for word in ("workflow", "release", "github", "pipeline", "audit")):
+        return "Infrastructure", "patch"
+    if any(word in lower for word in ("document", "readme", "docs", "guide")):
+        return "Documentation", "patch"
+    return "Other changes", "patch"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--pull-requests", required=True)
+    parser.add_argument("--release-level", choices=["auto", "patch", "minor", "major"], default="auto")
+    parser.add_argument("--proposed-version", default="")
+    parser.add_argument("--since", default="")
+    parser.add_argument("--json-output", default="release-plan.json")
+    parser.add_argument("--markdown-output", default="release-plan.md")
+    args = parser.parse_args()
+
+    root = Path.cwd()
+    dashboard = json.loads((root / "status/release-dashboard.json").read_text(encoding="utf-8"))
+    current_text = str(dashboard.get("currentVersion") or dashboard.get("latestRelease", {}).get("version"))
+    current = parse_version(current_text)
+    release_time = str(dashboard.get("latestRelease", {}).get("releasedAt") or "")
+    since = args.since.strip() or release_time
+    since_dt = datetime.fromisoformat(since.replace("Z", "+00:00")) if since else None
+
+    pull_requests = json.loads(Path(args.pull_requests).read_text(encoding="utf-8"))
+    merged: list[dict[str, Any]] = []
+    for pr in pull_requests:
+        merged_at = pr.get("merged_at") or pr.get("mergedAt")
+        if not merged_at:
+            continue
+        merged_dt = datetime.fromisoformat(str(merged_at).replace("Z", "+00:00"))
+        if since_dt and merged_dt <= since_dt:
+            continue
+        merged.append(pr)
+
+    severity = {"patch": 0, "minor": 1, "major": 2}
+    categories: dict[str, list[dict[str, Any]]] = {}
+    automatic_level = "patch"
+    for pr in sorted(merged, key=lambda item: str(item.get("merged_at") or item.get("mergedAt"))):
+        category, level = classify(pr)
+        if severity[level] > severity[automatic_level]:
+            automatic_level = level
+        categories.setdefault(category, []).append(pr)
+
+    selected_level = automatic_level if args.release_level == "auto" else args.release_level
+    recommended = bump(current, selected_level)
+    proposed = parse_version(args.proposed_version) if args.proposed_version.strip() else recommended
+    if proposed <= current:
+        raise SystemExit(f"Proposed version {format_version(proposed)} must be higher than {current_text}")
+
+    proposed_text = format_version(proposed)
+    changelog = (root / "CHANGELOG.md").read_text(encoding="utf-8")
+    changelog_ready = bool(re.search(rf"^##\s+\[?v?{re.escape(proposed_text)}\]?\b", changelog, re.MULTILINE))
+
+    source_path = root / "src/MissionChief_Map_Command_Toolkit.user.js"
+    dist_path = root / "dist/MissionChief_Map_Command_Toolkit.user.js"
+    report = {
+        "schemaVersion": 1,
+        "generatedAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "currentVersion": current_text,
+        "recommendedLevel": selected_level,
+        "recommendedVersion": format_version(recommended),
+        "proposedVersion": proposed_text,
+        "since": since,
+        "mergedPullRequestCount": len(merged),
+        "changelogSectionPresent": changelog_ready,
+        "canonicalSha256": sha256(source_path),
+        "distributionSha256": sha256(dist_path),
+        "categories": {
+            category: [
+                {
+                    "number": pr.get("number"),
+                    "title": pr.get("title"),
+                    "url": pr.get("html_url") or pr.get("url"),
+                    "mergedAt": pr.get("merged_at") or pr.get("mergedAt"),
+                    "labels": sorted(labels(pr)),
+                }
+                for pr in items
+            ]
+            for category, items in categories.items()
+        },
+        "publishesNothing": True,
+    }
+
+    order = ["Breaking changes", "Features", "Fixes", "Infrastructure", "Documentation", "Other changes"]
+    lines = [
+        "# MissionChief Toolkit Release Plan",
+        "",
+        "> This plan is advisory and publishes nothing.",
+        "",
+        f"- Current version: **{current_text}**",
+        f"- Recommended level: **{selected_level}**",
+        f"- Recommended version: **{format_version(recommended)}**",
+        f"- Proposed version: **{proposed_text}**",
+        f"- Merged pull requests since `{since or 'repository history start'}`: **{len(merged)}**",
+        f"- Changelog section present: **{'yes' if changelog_ready else 'no'}**",
+        f"- Canonical SHA-256: `{report['canonicalSha256'] or 'unavailable'}`",
+        f"- Distribution SHA-256: `{report['distributionSha256'] or 'unavailable'}`",
+    ]
+    for category in order:
+        items = report["categories"].get(category, [])
+        if not items:
+            continue
+        lines.extend(["", f"## {category}"])
+        for item in items:
+            number = f"#{item['number']}" if item.get("number") else "PR"
+            lines.append(f"- {number} — {item['title']}")
+    lines.extend([
+        "",
+        "## Operator gates",
+        "",
+        "- [ ] Confirm semantic version",
+        "- [ ] Confirm changelog section and public wording",
+        "- [ ] Review affected features, themes and operating modes",
+        "- [ ] Run Release Readiness Check",
+        "- [ ] Confirm GitHub Release, Greasy Fork, private backup and Discord targets",
+        "- [ ] Publish only through the production release workflow",
+        "",
+    ])
+
+    Path(args.json_output).write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    Path(args.markdown_output).write_text("\n".join(lines), encoding="utf-8")
+    print("\n".join(lines))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/branch-cleanup-audit.yml
+++ b/.github/workflows/branch-cleanup-audit.yml
@@ -1,0 +1,96 @@
+name: Branch Cleanup Audit
+
+run-name: Branch cleanup candidates
+
+on:
+  schedule:
+    - cron: "11 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+
+    steps:
+      - name: Check out latest main
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Inventory safely removable branches
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin '+refs/heads/*:refs/remotes/origin/*' --prune
+          gh pr list --state open --limit 500 --json headRefName > /tmp/open-prs.json
+          jq -r '.[].headRefName' /tmp/open-prs.json | sort -u > /tmp/open-heads.txt
+
+          : > /tmp/candidates.txt
+          : > /tmp/protected.txt
+          while IFS= read -r ref; do
+            branch="${ref#origin/}"
+            [[ "$branch" == "main" || "$branch" == "HEAD" ]] && continue
+            if grep -Fxq "$branch" /tmp/open-heads.txt; then
+              echo "$branch — open pull request" >> /tmp/protected.txt
+              continue
+            fi
+            if git merge-base --is-ancestor "origin/$branch" origin/main; then
+              echo "$branch" >> /tmp/candidates.txt
+            else
+              echo "$branch — not fully merged" >> /tmp/protected.txt
+            fi
+          done < <(git for-each-ref --format='%(refname:short)' refs/remotes/origin | sort)
+
+          sort -u -o /tmp/candidates.txt /tmp/candidates.txt
+          sort -u -o /tmp/protected.txt /tmp/protected.txt
+          jq -n \
+            --rawfile candidates /tmp/candidates.txt \
+            --rawfile protected /tmp/protected.txt \
+            '{
+              generatedAt: (now | todateiso8601),
+              mode: "read-only",
+              candidates: ($candidates | split("\n") | map(select(length > 0))),
+              protectedOrUnmerged: ($protected | split("\n") | map(select(length > 0)))
+            }' > branch-cleanup-report.json
+
+          {
+            echo '# Branch Cleanup Audit'
+            echo
+            echo '> This workflow is read-only and deletes nothing.'
+            echo
+            echo '## Fully merged candidates'
+            if [[ -s /tmp/candidates.txt ]]; then
+              sed 's/^/- `/' /tmp/candidates.txt | sed 's/$/`/'
+            else
+              echo '- None'
+            fi
+            echo
+            echo '## Preserved branches'
+            if [[ -s /tmp/protected.txt ]]; then
+              sed 's/^/- /' /tmp/protected.txt
+            else
+              echo '- None'
+            fi
+          } > branch-cleanup-report.md
+
+      - name: Publish branch audit summary
+        run: cat branch-cleanup-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload branch audit
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: branch-cleanup-audit
+          path: |
+            branch-cleanup-report.json
+            branch-cleanup-report.md
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/documentation-drift-check.yml
+++ b/.github/workflows/documentation-drift-check.yml
@@ -1,0 +1,67 @@
+name: Documentation Drift Check
+
+run-name: Documentation drift · ${{ github.event_name }}
+
+on:
+  pull_request:
+    paths:
+      - ".github/documentation-contract.json"
+      - ".github/scripts/check_documentation_drift.py"
+      - ".github/workflows/documentation-drift-check.yml"
+      - ".github/release-settings.json"
+      - "docs/site-data.json"
+      - "status/release-dashboard.json"
+      - "src/MissionChief_Map_Command_Toolkit.user.js"
+      - "README.md"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/documentation-contract.json"
+      - ".github/scripts/check_documentation_drift.py"
+      - ".github/workflows/documentation-drift-check.yml"
+      - ".github/release-settings.json"
+      - "docs/site-data.json"
+      - "status/release-dashboard.json"
+      - "src/MissionChief_Map_Command_Toolkit.user.js"
+      - "README.md"
+  schedule:
+    - cron: "23 4 * * 3"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: documentation-drift-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  audit:
+    name: Compare documentation with canonical Toolkit state
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Run documentation contract audit
+        run: python3 .github/scripts/check_documentation_drift.py
+
+      - name: Publish audit summary
+        if: always()
+        run: cat documentation-drift-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload documentation diagnostics
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: documentation-drift-audit
+          path: |
+            documentation-drift-report.json
+            documentation-drift-report.md
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/pages-production-monitor.yml
+++ b/.github/workflows/pages-production-monitor.yml
@@ -3,6 +3,12 @@ name: GitHub Pages Production Monitor
 run-name: Pages production health · ${{ github.event_name }}
 
 on:
+  pull_request:
+    paths:
+      - ".github/pages-monitor-policy.json"
+      - ".github/scripts/check_pages_live.py"
+      - ".github/workflows/pages-production-monitor.yml"
+      - "status/release-dashboard.json"
   workflow_run:
     workflows:
       - GitHub Pages Documentation
@@ -17,8 +23,8 @@ permissions:
   issues: write
 
 concurrency:
-  group: toolkit-pages-production-monitor
-  cancel-in-progress: false
+  group: toolkit-pages-production-monitor-${{ github.event_name == 'pull_request' && github.event.pull_request.number || 'production' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   monitor:
@@ -26,10 +32,10 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - name: Check out latest main
+      - name: Check out monitored source
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
-          ref: main
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || 'main' }}
           persist-credentials: false
 
       - name: Check live GitHub Pages deployment
@@ -58,7 +64,7 @@ jobs:
           retention-days: 30
 
       - name: Reconcile persistent incident
-        if: always()
+        if: always() && github.event_name != 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_COMMITS_WEBHOOK }}

--- a/.github/workflows/pages-production-monitor.yml
+++ b/.github/workflows/pages-production-monitor.yml
@@ -1,0 +1,126 @@
+name: GitHub Pages Production Monitor
+
+run-name: Pages production health · ${{ github.event_name }}
+
+on:
+  workflow_run:
+    workflows:
+      - GitHub Pages Documentation
+    types:
+      - completed
+  schedule:
+    - cron: "37 */6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: toolkit-pages-production-monitor
+  cancel-in-progress: false
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out latest main
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Check live GitHub Pages deployment
+        id: health
+        shell: bash
+        run: |
+          set +e
+          python3 .github/scripts/check_pages_live.py
+          STATUS=$?
+          echo "exit_code=$STATUS" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Publish monitor summary
+        if: always()
+        run: cat pages-production-health.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload production diagnostics
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: github-pages-production-health
+          path: |
+            pages-production-health.json
+            pages-production-health.md
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Reconcile persistent incident
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_COMMITS_WEBHOOK }}
+          HEALTH_EXIT: ${{ steps.health.outputs.exit_code }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          TITLE='[Automated] GitHub Pages production health incident'
+          MARKER='<!-- missionchief-pages-production-health -->'
+          ISSUE_JSON="$(gh issue list --state all --search '"'"'GitHub Pages production health incident'"'"' in:title' --json number,state,title --limit 20)"
+          ISSUE_NUMBER="$(jq -r --arg title "$TITLE" '.[] | select(.title == $title) | .number' <<< "$ISSUE_JSON" | head -n 1)"
+          ISSUE_STATE="$(jq -r --arg title "$TITLE" '.[] | select(.title == $title) | .state' <<< "$ISSUE_JSON" | head -n 1)"
+
+          post_discord() {
+            local heading="$1"
+            local description="$2"
+            local color="$3"
+            [[ -n "${DISCORD_WEBHOOK:-}" ]] || return 0
+            jq -n \
+              --arg title "$heading" \
+              --arg description "$description" \
+              --arg url "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+              --argjson color "$color" \
+              '{embeds:[{title:$title,description:$description,url:$url,color:$color,footer:{text:"MissionChief Map Command Toolkit · GitHub Pages monitor"}}]}' |
+              curl --fail --silent --show-error \
+                --header 'Content-Type: application/json' \
+                --data-binary @- \
+                "$DISCORD_WEBHOOK" >/dev/null
+          }
+
+          if [[ "$HEALTH_EXIT" != "0" ]]; then
+            {
+              echo "$MARKER"
+              echo
+              cat pages-production-health.md
+              echo
+              echo "Workflow: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            } > /tmp/pages-incident.md
+
+            if [[ -z "$ISSUE_NUMBER" ]]; then
+              ISSUE_URL="$(gh issue create \
+                --title "$TITLE" \
+                --body-file /tmp/pages-incident.md \
+                --label 'bug' \
+                --label 'needs-triage' \
+                --label 'priority: high' \
+                --label 'area: release pipeline')"
+              post_discord '❌ GitHub Pages health incident' "The public Toolkit documentation site failed one or more live production checks. Incident: ${ISSUE_URL}" 15158332
+            elif [[ "$ISSUE_STATE" == "CLOSED" ]]; then
+              gh issue reopen "$ISSUE_NUMBER"
+              gh issue edit "$ISSUE_NUMBER" --body-file /tmp/pages-incident.md
+              gh issue comment "$ISSUE_NUMBER" --body "The production health incident has recurred. See the updated diagnostic body and workflow run."
+              post_discord '❌ GitHub Pages incident recurred' "The public Toolkit documentation site has failed live checks again. Incident #${ISSUE_NUMBER}." 15158332
+            else
+              gh issue edit "$ISSUE_NUMBER" --body-file /tmp/pages-incident.md
+              gh issue comment "$ISSUE_NUMBER" --body "Scheduled recheck still fails. Diagnostic state was refreshed by workflow run ${GITHUB_RUN_ID}."
+            fi
+            exit 1
+          fi
+
+          if [[ -n "$ISSUE_NUMBER" && "$ISSUE_STATE" == "OPEN" ]]; then
+            gh issue comment "$ISSUE_NUMBER" --body "✅ Live GitHub Pages checks recovered successfully in workflow run ${GITHUB_RUN_ID}."
+            gh issue close "$ISSUE_NUMBER" --reason completed
+            post_discord '✅ GitHub Pages recovered' "The public Toolkit documentation site has passed all live production checks. Incident #${ISSUE_NUMBER} was closed." 5763719
+          fi

--- a/.github/workflows/release-planning.yml
+++ b/.github/workflows/release-planning.yml
@@ -1,8 +1,14 @@
 name: Prepare Release Plan
 
-run-name: Release plan · ${{ inputs.release_level }} · ${{ inputs.proposed_version || 'recommended' }}
+run-name: Release plan · ${{ inputs.release_level || 'auto' }} · ${{ inputs.proposed_version || 'recommended' }}
 
 on:
+  pull_request:
+    paths:
+      - ".github/scripts/prepare_release_plan.py"
+      - ".github/workflows/release-planning.yml"
+      - "status/release-dashboard.json"
+      - "CHANGELOG.md"
   workflow_dispatch:
     inputs:
       release_level:
@@ -29,7 +35,7 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: toolkit-release-plan
+  group: toolkit-release-plan-${{ github.event_name == 'pull_request' && github.event.pull_request.number || 'operator' }}
   cancel-in-progress: true
 
 jobs:
@@ -38,10 +44,10 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - name: Check out latest main
+      - name: Check out planning source
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
-          ref: main
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || 'main' }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -57,17 +63,21 @@ jobs:
 
       - name: Prepare advisory release plan
         shell: bash
+        env:
+          RELEASE_LEVEL: ${{ inputs.release_level || 'auto' }}
+          PROPOSED_VERSION: ${{ inputs.proposed_version || '' }}
+          SINCE: ${{ inputs.since || '' }}
         run: |
           set -euo pipefail
           ARGS=(
             --pull-requests merged-pull-requests.json
-            --release-level '${{ inputs.release_level }}'
+            --release-level "$RELEASE_LEVEL"
           )
-          if [[ -n '${{ inputs.proposed_version }}' ]]; then
-            ARGS+=(--proposed-version '${{ inputs.proposed_version }}')
+          if [[ -n "$PROPOSED_VERSION" ]]; then
+            ARGS+=(--proposed-version "$PROPOSED_VERSION")
           fi
-          if [[ -n '${{ inputs.since }}' ]]; then
-            ARGS+=(--since '${{ inputs.since }}')
+          if [[ -n "$SINCE" ]]; then
+            ARGS+=(--since "$SINCE")
           fi
           python3 .github/scripts/prepare_release_plan.py "${ARGS[@]}"
 

--- a/.github/workflows/release-planning.yml
+++ b/.github/workflows/release-planning.yml
@@ -1,0 +1,86 @@
+name: Prepare Release Plan
+
+run-name: Release plan · ${{ inputs.release_level }} · ${{ inputs.proposed_version || 'recommended' }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_level:
+        description: Semantic version level to evaluate
+        required: true
+        type: choice
+        default: auto
+        options:
+          - auto
+          - patch
+          - minor
+          - major
+      proposed_version:
+        description: Optional exact version without the v prefix
+        required: false
+        type: string
+      since:
+        description: Optional ISO-8601 lower bound for merged pull requests
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: toolkit-release-plan
+  cancel-in-progress: true
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out latest main
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Collect merged pull requests
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh api --paginate --slurp \
+            "repos/${GITHUB_REPOSITORY}/pulls?state=closed&sort=updated&direction=desc&per_page=100" |
+            jq 'add' > merged-pull-requests.json
+
+      - name: Prepare advisory release plan
+        shell: bash
+        run: |
+          set -euo pipefail
+          ARGS=(
+            --pull-requests merged-pull-requests.json
+            --release-level '${{ inputs.release_level }}'
+          )
+          if [[ -n '${{ inputs.proposed_version }}' ]]; then
+            ARGS+=(--proposed-version '${{ inputs.proposed_version }}')
+          fi
+          if [[ -n '${{ inputs.since }}' ]]; then
+            ARGS+=(--since '${{ inputs.since }}')
+          fi
+          python3 .github/scripts/prepare_release_plan.py "${ARGS[@]}"
+
+      - name: Publish operator summary
+        run: cat release-plan.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload release-plan artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: missionchief-toolkit-release-plan
+          path: |
+            release-plan.json
+            release-plan.md
+            merged-pull-requests.json
+          if-no-files-found: error
+          retention-days: 30

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,64 @@
+# MissionChief Map Command Toolkit Roadmap
+
+This roadmap separates verified infrastructure, active Toolkit development and repository-administration work that requires GitHub account controls.
+
+## Completed foundation
+
+- Canonical userscript source and byte-identical distribution generation
+- Release Readiness and production publication workflows
+- GitHub Release, Greasy Fork, private migration backup and Discord coordination
+- Duplicate-announcement protection and partial release recovery
+- Reviewed rollback-candidate preparation
+- Performance regression budgets
+- Code-integrity and userscript-structure auditing
+- Public asset-health monitoring
+- Structured issue forms and managed labels
+- GitHub Pages documentation site
+- GitHub Actions supply-chain pinning, permission auditing and Dependabot
+- Documentation contract and live Pages monitoring
+- Read-only release planning
+
+## Active Toolkit development
+
+### Smart map presentation
+
+- Continue reducing bookmark footprint without damaging theme identity.
+- Extend intelligent label shortening and user overrides where real-world place names expose gaps.
+- Preserve Desktop, Tablet and iOS behaviour.
+
+### Operational intelligence
+
+- Continue Mission Age Watch, Critical View, Mission Inspector and transport-state refinement.
+- Expand live selector resilience when MissionChief changes markup.
+- Preserve deferred startup and on-demand interface construction.
+
+### Performance
+
+- Measure startup and first-interaction costs on large accounts.
+- Reduce unnecessary observers, selectors and eager controls.
+- Keep CI budgets calibrated to real regressions rather than normal feature growth.
+
+## Documentation and community
+
+- Capture real Desktop, Tablet and iOS screenshots.
+- Record short demonstrations for major workflows and themes.
+- Enable GitHub Discussions and create a public GitHub Project when repository administration permits.
+- Add media to the generated Pages gallery using the documented capture manifest.
+
+## Repository architecture
+
+- Move generated release state away from protected source where practical.
+- Introduce a narrowly scoped GitHub App identity for release automation.
+- Rehearse the complete release and recovery pipeline under that identity.
+- Enable strict PR-only protection only after the rehearsal passes.
+
+## Optional administration
+
+- Configure a repository social-preview image.
+- Consider a custom documentation domain.
+- Delete obsolete merged branches after reviewing the generated branch-cleanup candidates.
+- Review Dependabot Action updates and upstream Node.js runtime migrations.
+
+## Decision rule
+
+Public Toolkit releases remain separate from repository-only infrastructure work. A repository improvement does not increase the Toolkit version unless the canonical userscript or user-facing distribution changes.

--- a/docs/DISCUSSIONS_AND_PROJECT_SETUP.md
+++ b/docs/DISCUSSIONS_AND_PROJECT_SETUP.md
@@ -1,0 +1,48 @@
+# GitHub Discussions and Public Project Setup
+
+These repository features require account-level GitHub administration and are not enabled by repository file changes alone.
+
+## Recommended Discussions categories
+
+1. **Announcements** — maintainer release and operational notices; announcement format.
+2. **Help and troubleshooting** — user questions that are not confirmed bugs; question-and-answer format.
+3. **Feature ideas** — early proposals before a formal structured feature request; open discussion format.
+4. **Show and tell** — user layouts, themes and operational workflows; open discussion format.
+5. **General** — relevant conversation that does not fit another category.
+
+Keep confirmed bugs, performance regressions and actionable feature specifications in structured Issues.
+
+## Recommended public Project
+
+Create a repository Project named **MissionChief Toolkit Roadmap** with these workflow fields:
+
+- Status: Proposed, Investigating, Approved, In development, Testing, Ready for release, Released, Declined
+- Priority: Critical, High, Normal, Low
+- Area: Missions, Vehicles, Map, Interface, Mobile, Themes, Finance, Release pipeline, Documentation
+- Target release: free-text or iteration field
+- Operating mode: Desktop, Tablet, iOS, All
+
+Recommended views:
+
+- **Development board** grouped by Status
+- **Release candidates** filtered to Ready for release
+- **Performance and reliability** filtered to performance/release-pipeline areas
+- **Public roadmap** excluding private or security-sensitive work
+
+## Enabling Discussions
+
+1. Open repository **Settings**.
+2. Under **General → Features**, enable **Discussions**.
+3. Open the new **Discussions** tab.
+4. Create or rename categories using the structure above.
+5. Restrict announcement creation to maintainers where appropriate.
+
+## Creating the Project
+
+1. Open the repository **Projects** tab.
+2. Create a new table or board project.
+3. Add the fields and views above.
+4. Link existing open issues and future feature requests.
+5. Publish only work suitable for public visibility.
+
+Do not expose private migration details, credentials, security reports or unreleased exploit information in Discussions or the public Project.

--- a/docs/RELEASE_PLANNING.md
+++ b/docs/RELEASE_PLANNING.md
@@ -1,0 +1,31 @@
+# Release Planning Workflow
+
+`Prepare Release Plan` is a read-only operator aid. It never creates a tag, GitHub Release, Greasy Fork update, private backup or Discord announcement.
+
+## Inputs
+
+- **Release level:** automatic, patch, minor or major
+- **Proposed version:** optional exact semantic version
+- **Since:** optional ISO-8601 lower bound for merged pull requests
+
+## Output
+
+The workflow produces a Markdown operator brief and machine-readable JSON containing:
+
+- current, recommended and proposed versions;
+- merged pull requests since the current release;
+- categorised draft release notes;
+- changelog-section readiness;
+- canonical and distribution SHA-256 values;
+- a final operator-gate checklist.
+
+## Recommended operation
+
+1. Run the planner before editing the final changelog.
+2. Review the suggested semantic version and categorisation.
+3. Update the canonical changelog and any user-facing documentation.
+4. Run Release Readiness Check.
+5. Confirm the exact source hash, distribution targets and release notes.
+6. Publish only through `Release Toolkit`.
+
+The planner is advisory. Release Readiness and the production release workflow remain authoritative.

--- a/docs/REPOSITORY_ADMIN_CHECKLIST.md
+++ b/docs/REPOSITORY_ADMIN_CHECKLIST.md
@@ -1,0 +1,48 @@
+# Repository Administration Checklist
+
+This checklist covers GitHub settings that cannot be completed through normal repository commits.
+
+## Already configured or verified
+
+- [x] Repository is public
+- [x] GitHub Pages uses GitHub Actions
+- [x] Pages deployment succeeds
+- [x] `main` deletion protection enabled
+- [x] `main` force-push protection enabled
+- [x] Structured issue forms active
+- [x] Managed repository labels synchronised
+
+## Manual account-level actions
+
+### Community
+
+- [ ] Enable GitHub Discussions
+- [ ] Create recommended Discussion categories
+- [ ] Create and publish the MissionChief Toolkit Roadmap Project
+
+### Repository presentation
+
+- [ ] Upload a repository social-preview image
+- [ ] Review repository description and topic tags
+- [ ] Decide whether to configure a custom Pages domain
+- [ ] Configure DNS and Pages HTTPS enforcement if a custom domain is chosen
+
+### Branch and access administration
+
+- [ ] Review obsolete merged branches and delete confirmed-safe candidates
+- [ ] Review repository collaborators and installed GitHub Apps
+- [ ] Confirm secret access is limited to required workflows
+- [ ] Review Dependabot pull requests before merging Action updates
+
+### Future strict protection
+
+- [ ] Complete `docs/BRANCH_PROTECTION_MIGRATION.md`
+- [ ] Introduce a narrowly scoped release GitHub App
+- [ ] Rehearse normal release and every partial-recovery path
+- [ ] Require pull requests and required status checks
+- [ ] Require conversation resolution
+- [ ] Block direct human pushes to `main`
+
+## Node.js Action warnings
+
+Official GitHub Actions may temporarily emit runtime deprecation warnings while GitHub moves hosted actions between Node.js generations. Current actions are pinned and Dependabot monitors updates. Replace pins only through reviewed Dependabot or maintenance pull requests after the new action commit is verified.

--- a/docs/VISUAL_CAPTURE_PLAN.md
+++ b/docs/VISUAL_CAPTURE_PLAN.md
@@ -1,0 +1,64 @@
+# Visual Documentation Capture Plan
+
+The public documentation gallery must use real Toolkit captures. Generated mock MissionChief screens must not be presented as operational evidence.
+
+## Capture standards
+
+- Use the latest verified Toolkit release.
+- Use the default Map Command theme for baseline captures.
+- Redact player names, alliance chat, coordinates that identify private locations, account balances where sensitive, and personal browser information.
+- Keep the MissionChief map and Toolkit controls readable at normal browser zoom.
+- Prefer PNG for static captures and MP4/WebM source plus an optimised GIF fallback for short demonstrations.
+- Do not include copyrighted music or private Discord content.
+
+## Required static captures
+
+| File | Mode | Subject |
+|---|---|---|
+| `desktop-map-command-overview.png` | Desktop | Full Toolkit dock and shortcut bar |
+| `desktop-mission-age-watch.png` | Desktop | Mission Age Watch with multiple states |
+| `desktop-critical-view.png` | Desktop | Critical View and Mission Inspector |
+| `desktop-coverage-heat-map.png` | Desktop | Coverage Heat Map on an operational area |
+| `desktop-smart-bookmarks.png` | Desktop | Compact bookmark labels and full-name preview |
+| `desktop-vehicle-code-status.png` | Desktop | Vehicle code counts including Out of Service |
+| `tablet-overview.png` | Tablet | Landscape layout fitted to available map space |
+| `ios-overview.png` | iOS Mobile | Safari/Tampermonkey mobile-safe controls |
+| `theme-map-command.png` | Desktop | Default theme |
+| `theme-cyberpunk.png` | Desktop | Cyberpunk theme |
+| `theme-fallout.png` | Desktop | Fallout 4 theme |
+| `theme-umbrella.png` | Desktop | Umbrella theme |
+| `theme-factorio.png` | Desktop | Factorio theme |
+
+## Required short demonstrations
+
+| File | Maximum duration | Workflow |
+|---|---:|---|
+| `mission-age-watch-demo.webm` | 20 s | Open, refresh, zoom and inspect a mission |
+| `coverage-heat-map-demo.webm` | 15 s | Enable, inspect and disable coverage |
+| `smart-bookmarks-demo.webm` | 15 s | Generated label, tooltip/long press and manual override |
+| `critical-view-demo.webm` | 20 s | Open critical workflow and Mission Inspector |
+| `payout-presentation-demo.webm` | 20 s | Completion banner, counter and history |
+| `responsive-modes-demo.webm` | 20 s | Desktop, Tablet and iOS layout comparison |
+
+## File locations
+
+Store approved sources under:
+
+```text
+docs/media/screenshots/
+docs/media/demos/
+```
+
+The Pages generator should reference only reviewed files committed to those locations. Keep raw editing projects outside the public repository.
+
+## Review checklist
+
+- [ ] Current Toolkit version visible or recorded in metadata
+- [ ] No personal or alliance-sensitive information visible
+- [ ] Theme and operating mode correctly named
+- [ ] Text remains readable at documentation-page width
+- [ ] Motion capture has no long idle section
+- [ ] File size is reasonable for GitHub Pages
+- [ ] Alt text and caption prepared
+- [ ] Capture added to `docs/site-data.json`
+- [ ] Documentation and asset-health checks pass


### PR DESCRIPTION
Adds documentation-drift enforcement, live GitHub Pages production monitoring with persistent incident reconciliation, read-only release planning, weekly branch-cleanup auditing, the public project roadmap, real-media capture standards and account-level administration checklists. All new external Actions are pinned to immutable commits. No Toolkit userscript, runtime theme, public release or distribution asset changes are included.