### PR TITLE
Skip Discord development posts for Dependabot PRs

### DIFF
--- a/.github/workflows/discord-development-status.yml
+++ b/.github/workflows/discord-development-status.yml
@@ -34,7 +34,8 @@ jobs:
       github.event_name == 'workflow_run' ||
       (
         github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.full_name == github.repository
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.actor != 'dependabot[bot]'
       )
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
Prevents false workflow failures on Dependabot pull requests, where GitHub intentionally withholds repository secrets. Normal internal pull requests and all release/readiness workflow-run notifications continue unchanged. No Toolkit source or public release change.