### PR TITLE
Add GitHub-synced Greasy Fork description

### DIFF
--- a/docs/greasyfork-description.md
+++ b/docs/greasyfork-description.md
@@ -1,0 +1,67 @@
+# MissionChief Map Command Toolkit
+
+A configurable command-centre enhancement for MissionChief, combining advanced map controls, mission intelligence, operational alerts, financial reporting and visual customisation in one userscript.
+
+**Greasy Fork is the official installation and automatic-update channel. GitHub is the canonical development source and documentation home.**
+
+## Main features
+
+- Advanced map controls and visibility tools
+- Mission Age Watch, Critical View and Mission Inspector
+- Transport alerts and guarded Transport Sweep
+- Resource-gap and vehicle intelligence
+- Smart bookmarks, Map Jump and saved profiles
+- Coverage rings and Coverage Heat Map
+- Financial analysis and optional Discord reporting
+- Cinematic payout presentations and interface themes
+- Responsive Desktop, Tablet and iOS operating modes
+- Performance-aware startup, monitoring and cleanup
+
+## Installation and updates
+
+1. Install a userscript manager such as Tampermonkey.
+2. Select **Install this script** above.
+3. Open or refresh MissionChief.
+4. Click the Toolkit control or press `M`.
+
+Only enable one copy of the Toolkit at a time.
+
+Updates are published through a validated GitHub release pipeline and delivered automatically through Greasy Fork.
+
+## Documentation and support
+
+- [Documentation centre](https://conroy1988.github.io/missionchief-toolkit-assets/)
+- [GitHub source repository](https://github.com/Conroy1988/missionchief-toolkit-assets)
+- [Latest release and changelog](https://github.com/Conroy1988/missionchief-toolkit-assets/releases/latest)
+- [Report a bug or performance problem](https://github.com/Conroy1988/missionchief-toolkit-assets/issues/new/choose)
+
+Please include the Toolkit version, browser, userscript manager and reproduction steps when reporting a problem.
+
+## Privacy and permissions
+
+- No advertising, analytics or user tracking
+- No hardcoded Discord webhook or private credentials
+- Optional Discord webhook details are entered by the user and stored locally
+- Discord communication occurs only when the user tests or posts a report
+- Exported Toolkit settings do not include the Discord webhook
+- MissionChief information is processed in the browser to provide enabled Toolkit features
+
+## Compatibility
+
+The Toolkit supports the MissionChief sites listed above and is primarily developed for MissionChief UK.
+
+It includes responsive Desktop, Tablet and iOS modes. Browser behaviour may vary, so compatibility problems should be reported through GitHub.
+
+## Important information
+
+This Toolkit is unofficial and is not affiliated with MissionChief, SHPlay GmbH or Discord.
+
+MissionChief may change its interface without notice. Such changes can temporarily affect Toolkit features.
+
+Any user-initiated automation, including Transport Sweep, should be used responsibly and in accordance with your alliance rules.
+
+## Licence
+
+Released under the MIT Licence.
+
+Developed and maintained by Conroy1988.


### PR DESCRIPTION
## What changed

- added `docs/greasyfork-description.md` as the canonical Greasy Fork Additional Info page
- replaced the former feature dump with a concise installation, feature, privacy, compatibility and support overview
- linked the documentation centre, source repository, latest release and structured issue forms

## Why

Greasy Fork can synchronize Additional Info from a Markdown URL. Keeping this content in GitHub makes it reviewable, version-controlled and easier to keep current without duplicating documentation manually.

## User impact

No userscript code, version, release, settings or runtime behaviour changes. After merge, Greasy Fork can synchronize from:

`https://raw.githubusercontent.com/Conroy1988/missionchief-toolkit-assets/main/docs/greasyfork-description.md`

## Validation

- Markdown structure reviewed
- links use stable public project locations
- no alternate userscript installation source is promoted
- no executable or release-pipeline files changed