### PR TITLE
Correct README version references to 4.11.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Operational map command, monitoring and presentation suite for MissionChief UK**
 
 [![Greasy Fork](https://img.shields.io/badge/Install-Greasy%20Fork-670000?logo=tampermonkey&logoColor=white)](https://greasyfork.org/en/scripts/586018-missionchief-map-command-toolkit)
-[![Current Version](https://img.shields.io/badge/version-4.11.2-2563eb)](status/README.md)
+[![Current Version](https://img.shields.io/badge/version-4.11.4-2563eb)](status/README.md)
 [![Documentation](https://img.shields.io/badge/docs-GitHub%20Pages-28a9ff)](https://conroy1988.github.io/missionchief-toolkit-assets/)
 [![Validation](https://img.shields.io/badge/validation-passed-16a34a)](../../actions/workflows/validate-userscript.yml)
 [![Release Readiness](https://img.shields.io/badge/release%20readiness-passed-16a34a)](../../actions/workflows/release-readiness-check.yml)
@@ -30,7 +30,7 @@ GitHub is the canonical source of truth. Greasy Fork remains the supported publi
 | Component | State |
 |---|---|
 | Canonical source | ✅ GitHub |
-| Current validated version | `4.11.2` |
+| Current validated version | `4.11.4` |
 | Validation | ✅ Passed |
 | Release readiness | ✅ Passed |
 | Asset dependency audit | ✅ Passed |


### PR DESCRIPTION
## Summary

Updates the public README to match the currently verified Toolkit release.

## Changes

- version badge: `4.11.2` → `4.11.4`
- release-health table: `4.11.2` → `4.11.4`

## Scope

Documentation-only correction. No userscript source, distribution file, release state, workflow or public asset is changed.