### PR TITLE
Add permanent owner-authorized release command

### DIFF
--- a/.github/workflows/owner-release-command.yml
+++ b/.github/workflows/owner-release-command.yml
@@ -1,0 +1,105 @@
+name: Owner Release Command
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+
+concurrency:
+  group: toolkit-owner-release-command
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Dispatch verified Toolkit release
+    if: >-
+      github.event.issue.pull_request == null &&
+      startsWith(github.event.comment.body, '/release-toolkit ')
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+
+    steps:
+      - name: Authorize owner command
+        id: command
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$COMMENT_AUTHOR" == "Conroy1988" ]] || { echo "::error::Only Conroy1988 may dispatch a production release."; exit 1; }
+          [[ "$AUTHOR_ASSOCIATION" == "OWNER" ]] || { echo "::error::Release command author is not the repository owner."; exit 1; }
+          if [[ "$COMMENT_BODY" =~ ^/release-toolkit[[:space:]]+([0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?)[[:space:]]+RELEASE[[:space:]]*$ ]]; then
+            VERSION="${BASH_REMATCH[1]}"
+          else
+            echo "::error::Expected: /release-toolkit X.Y.Z RELEASE"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check out current main
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Verify requested version is release-ready
+        env:
+          VERSION: ${{ steps.command.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          SOURCE="src/MissionChief_Map_Command_Toolkit.user.js"
+          grep -Eq "^//[[:space:]]*@version[[:space:]]+${VERSION//./\\.}[[:space:]]*$" "$SOURCE"
+          test "$(jq -r '.currentVersion' status/release-dashboard.json)" = "$VERSION"
+          test "$(jq -r '.status.validation' status/release-dashboard.json)" = "passed"
+          test "$(jq -r '.status.releaseReadiness' status/release-dashboard.json)" = "passed"
+          test "$(jq -r '.distributionCandidate.version' status/release-dashboard.json)" = "$VERSION"
+          test "$(jq -r '.distributionCandidate.state' status/release-dashboard.json)" = "validated"
+
+      - name: Record release dispatch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.command.outputs.version }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        shell: bash
+        run: |
+          gh issue comment "$ISSUE_NUMBER" --body "Production release v${VERSION} has been authorized. The permanent release workflow is now running with all GitHub Release, Greasy Fork, private-backup and Discord safeguards enabled."
+
+      - name: Dispatch and await production release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.command.outputs.version }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          STARTED_AT="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+          gh workflow run release-toolkit.yml --ref main -f version="$VERSION" -f confirmation=RELEASE
+
+          RUN_ID=""
+          for attempt in {1..60}; do
+            RUN_ID="$(gh run list --workflow release-toolkit.yml --event workflow_dispatch --branch main --limit 30 --json databaseId,createdAt -q "map(select(.createdAt >= \"${STARTED_AT}\")) | sort_by(.createdAt) | reverse | .[0].databaseId // empty")"
+            [[ -n "$RUN_ID" ]] && break
+            sleep 2
+          done
+          [[ -n "$RUN_ID" ]] || { echo "::error::The newly dispatched production release run was not found."; exit 1; }
+
+          gh issue comment "$ISSUE_NUMBER" --body "Toolkit v${VERSION} production release is running as Actions run \`${RUN_ID}\`."
+          gh run watch "$RUN_ID" --exit-status
+          gh issue comment "$ISSUE_NUMBER" --body "Toolkit v${VERSION} completed the guarded production release workflow successfully."
+
+      - name: Record guarded failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.command.outputs.version }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        shell: bash
+        run: |
+          gh issue comment "$ISSUE_NUMBER" --body "Toolkit v${VERSION:-unknown} release stopped at a guarded check. No publication safeguard was bypassed. Command diagnostics: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"


### PR DESCRIPTION
## Summary

Adds a permanent owner-only issue command for dispatching the existing guarded production release workflow.

## Command

`/release-toolkit X.Y.Z RELEASE`

## Safeguards

- accepts commands only from repository owner `Conroy1988` with OWNER association;
- requires an exact semantic version and explicit `RELEASE` confirmation;
- verifies the requested version matches the canonical source and validated release dashboard;
- dispatches the existing `release-toolkit.yml` workflow rather than duplicating publication logic;
- preserves GitHub Release, Greasy Fork verification, private backup and Discord gates;
- records dispatch, success or guarded failure on the originating Issue.

This replaces recurring one-time release dispatch workflows with a permanent controlled route.