### PR TITLE
Phase 4: reconcile release dashboard and generated control panel

### DIFF
--- a/.github/workflows/release-toolkit.yml
+++ b/.github/workflows/release-toolkit.yml
@@ -196,12 +196,22 @@ jobs:
           RELEASE_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/v${RELEASE_VERSION}"
           jq --arg version "$RELEASE_VERSION" --arg hash "$HASH" --arg now "$NOW" \
              --arg releaseUrl "$RELEASE_URL" --arg backupCommit "$BACKUP_COMMIT" \
-            '.currentVersion=$version | .status.validation="passed" | .status.githubRelease="published" | .status.greasyForkSync="verified" | .status.backup="private-repository-verified" | .status.discordRelease="posted" | .latestRelease={version:$version,sha256:$hash,githubRelease:$releaseUrl,greasyForkVerified:true,privateBackupCommit:$backupCommit,discordPosted:true,completedAt:$now} | .lastUpdated=$now' \
+            '.currentVersion=$version |
+             .status.validation="passed" |
+             .status.githubRelease="published" |
+             .status.greasyForkSync="verified" |
+             .status.backup="private-repository-verified" |
+             .status.discordRelease="posted" |
+             .status.releaseReadiness="passed" |
+             .releaseReadiness={version:$version,state:"passed",requiredSecrets:true,privateRepositoryReadWrite:true,greasyForkMetadataVerified:true,publicReleaseCreated:false,completedAt:$now} |
+             .latestRelease={version:$version,sha256:$hash,githubRelease:$releaseUrl,greasyForkVerified:true,privateBackupCommit:$backupCommit,discordPosted:true,completedAt:$now} |
+             .lastUpdated=$now' \
             status/release-dashboard.json > status/release-dashboard.tmp
           mv status/release-dashboard.tmp status/release-dashboard.json
+          python3 .github/scripts/generate_release_dashboard.py
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add status/release-dashboard.json
+          git add status/release-dashboard.json status/README.md
           git commit -m "Record Toolkit ${RELEASE_VERSION} verified release"
           git pull --rebase origin main
           git push origin HEAD:main
@@ -224,5 +234,5 @@ jobs:
             echo "- ✅ Greasy Fork version verified"
             echo "- ✅ Private migration backup committed: ${BACKUP_COMMIT}"
             echo "- ✅ Discord release announcement posted"
-            echo "- ✅ Release dashboard updated"
+            echo "- ✅ Release dashboard and generated control panel updated"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/status/README.md
+++ b/status/README.md
@@ -8,16 +8,16 @@
 |---|:---:|---|
 | Canonical source | 🟢 | Validated Canonical Source |
 | Validation | 🟢 | Passed |
-| GitHub Release | ⚪ | Not Published |
-| Greasy Fork | 🟡 | Pending Release |
-| Private backup | ⚪ | Not Created |
+| GitHub Release | 🟢 | Published |
+| Greasy Fork | 🟢 | Verified |
+| Private backup | 🟢 | Private Repository Verified |
 | Discord development | 🟢 | Configured |
-| Discord releases | ⚪ | Not Posted |
+| Discord releases | 🟢 | Posted |
 | Asset audit | 🟢 | Passed |
 
 ## Release state
 
-- **Latest recorded version:** `4.13.0`
+- **Latest recorded version:** `4.13.1`
 - **State:** Verified public release
 - **Canonical path:** `src/MissionChief_Map_Command_Toolkit.user.js`
 - **Validated SHA-256:** `dede1999c8121c7bc73d644711d8b1258e3598db5118aad9da6b0731e038f69c`
@@ -28,7 +28,7 @@
 - **Discovered media files:** 28
 - **Referenced hosted paths:** 25
 - **Missing referenced paths:** 0
-- **Last dashboard update:** `2026-07-16T02:27:12Z`
+- **Last dashboard update:** `2026-07-16T02:32:51Z`
 
 ## Release channels
 

--- a/status/release-dashboard.json
+++ b/status/release-dashboard.json
@@ -45,13 +45,13 @@
     "completedAt": "2026-07-14T16:05:00Z"
   },
   "releaseReadiness": {
-    "version": "4.10.4",
+    "version": "4.13.1",
     "state": "passed",
     "requiredSecrets": true,
     "privateRepositoryReadWrite": true,
     "greasyForkMetadataVerified": true,
     "publicReleaseCreated": false,
-    "completedAt": "2026-07-14T18:13:26Z"
+    "completedAt": "2026-07-16T02:32:51Z"
   },
   "latestRelease": {
     "version": "4.13.1",


### PR DESCRIPTION
## Objective

Continue #58 by fixing an audit-discovered release-state inconsistency and preventing it from recurring.

## Finding

The v4.13.1 production workflow correctly updated `status/release-dashboard.json`, but it did not regenerate `status/README.md`. The human-readable control panel therefore continued to show v4.13.1 as unpublished even after GitHub Release, Greasy Fork, private backup and Discord had all completed.

The detailed `releaseReadiness` record also remained pinned to an older version even though current-version readiness had passed.

## Changes

- Reconcile the current v4.13.1 dashboard's detailed readiness record.
- Regenerate the current control panel from the verified release state.
- Update the permanent production workflow to:
  - record current-version readiness in the detailed dashboard object;
  - regenerate `status/README.md` after every successful production release;
  - commit the JSON dashboard and generated control panel together.

## Safety

- No Toolkit source, distribution, setting, theme, payout or public asset changes.
- No publication or verification gate removed.
- The change only makes generated release state internally consistent and prevents stale public status after future releases.

Part of #58.