### PR TITLE
Upgrade README operational command hero

### DIFF
--- a/docs/media/readme-hero.svg
+++ b/docs/media/readme-hero.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 640" role="img" aria-labelledby="title desc">
-  <title id="title">MissionChief Map Command Toolkit operational suite</title>
-  <desc id="desc">A multi-system command dashboard showing mission intelligence, fleet awareness, map coverage, finance and seven equal interface themes.</desc>
+  <title id="title">MissionChief Map Command Toolkit live operational command map</title>
+  <desc id="desc">A professional command dashboard showing mission intelligence, fleet awareness, finance and a detailed live operational map with critical incidents, deployed units, buildings and activity tracking.</desc>
   <defs>
     <linearGradient id="bg" x1="70" y1="30" x2="1510" y2="620" gradientUnits="userSpaceOnUse">
       <stop stop-color="#050911"/>
@@ -21,8 +21,20 @@
       <stop offset=".52" stop-color="#6BF5B2"/>
       <stop offset="1" stop-color="#FFD166"/>
     </linearGradient>
+    <radialGradient id="criticalGlow">
+      <stop stop-color="#FF405F" stop-opacity=".34"/>
+      <stop offset=".48" stop-color="#FF405F" stop-opacity=".12"/>
+      <stop offset="1" stop-color="#FF405F" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="unitGlow">
+      <stop stop-color="#58F5A7" stop-opacity=".22"/>
+      <stop offset="1" stop-color="#58F5A7" stop-opacity="0"/>
+    </radialGradient>
     <pattern id="grid" width="52" height="52" patternUnits="userSpaceOnUse">
       <path d="M52 0H0V52" fill="none" stroke="#63DFFF" stroke-opacity=".05"/>
+    </pattern>
+    <pattern id="mapGrid" width="32" height="32" patternUnits="userSpaceOnUse">
+      <path d="M32 0H0V32" fill="none" stroke="#4EC9E8" stroke-opacity=".055"/>
     </pattern>
     <filter id="shadow" x="-30%" y="-30%" width="160%" height="180%">
       <feDropShadow dx="0" dy="18" stdDeviation="20" flood-color="#000" flood-opacity=".62"/>
@@ -31,7 +43,11 @@
       <feGaussianBlur stdDeviation="7" result="b"/>
       <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
     </filter>
-    <clipPath id="mapClip"><rect x="910" y="55" width="625" height="456" rx="34"/></clipPath>
+    <filter id="smallGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="3.5" result="b"/>
+      <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <clipPath id="mapClip"><rect x="890" y="55" width="650" height="456" rx="34"/></clipPath>
   </defs>
 
   <rect width="1600" height="640" rx="34" fill="url(#bg)"/>
@@ -39,6 +55,7 @@
   <circle cx="1380" cy="80" r="300" fill="#15D7FF" opacity=".07"/>
   <circle cx="1230" cy="590" r="340" fill="#55F0A7" opacity=".045"/>
 
+  <!-- Left command panel -->
   <g transform="translate(58 52)" filter="url(#shadow)">
     <rect width="810" height="459" rx="34" fill="url(#panel)" stroke="#4BD7F7" stroke-opacity=".28" stroke-width="2"/>
     <path d="M34 1h235l24 24h473" fill="none" stroke="#67E4FF" stroke-opacity=".48" stroke-width="3"/>
@@ -51,7 +68,7 @@
       <text x="65" y="44" fill="#91A9BC" font-family="Segoe UI,Arial,sans-serif" font-size="13" font-weight="700" letter-spacing="2.2">MAP COMMAND TOOLKIT</text>
     </g>
 
-    <text x="43" y="142" fill="#F4FAFF" font-family="Segoe UI,Arial,sans-serif" font-size="58" font-weight="800" letter-spacing="-2">One map. Every operational layer.</text>
+    <text x="43" y="142" fill="#F4FAFF" font-family="Segoe UI,Arial,sans-serif" font-size="48" font-weight="800" letter-spacing="-1.7">One map. Every operational layer.</text>
     <text x="45" y="190" fill="#A4BACE" font-family="Segoe UI,Arial,sans-serif" font-size="21">Mission control, live fleet state, geographic coverage, finance</text>
     <text x="45" y="221" fill="#A4BACE" font-family="Segoe UI,Arial,sans-serif" font-size="21">and cinematic presentation — coordinated in one userscript.</text>
 
@@ -89,49 +106,155 @@
     <text x="45" y="421" fill="#637D91" font-family="Segoe UI,Arial,sans-serif" font-size="14" font-weight="700" letter-spacing="1.4">DESKTOP · TABLET · iOS · ECONOMY MODE · VERIFIED DELIVERY</text>
   </g>
 
+  <!-- Live operational command map -->
   <g clip-path="url(#mapClip)" filter="url(#shadow)">
-    <rect x="910" y="55" width="625" height="456" rx="34" fill="#07111C" stroke="#3BCDEC" stroke-opacity=".29" stroke-width="2"/>
-    <path d="M890 170c115-47 182 21 284-28 109-53 232-40 390 34v360H890Z" fill="#0D2130"/>
-    <g fill="none" stroke="#42BFD8" stroke-width="2" opacity=".3">
-      <path d="M880 145c131-61 194 16 297-35 110-55 230-41 398 29"/>
-      <path d="M878 201c135-48 200 24 303-20 114-48 237-34 398 42"/>
-      <path d="M879 268c145-36 203 32 311-7 120-42 231-18 389 55"/>
-      <path d="M890 345c122-28 206 36 312 6 113-32 219-7 362 50"/>
-      <path d="M900 425c125-24 205 27 311 10 118-20 210 7 339 57"/>
-    </g>
-    <path d="M954 446c95-111 166-79 229-169 61-87 138-92 265-156" fill="none" stroke="#61F0AD" stroke-width="3" stroke-dasharray="9 10" opacity=".52"/>
+    <rect x="890" y="55" width="650" height="456" rx="34" fill="#06111D" stroke="#3BCDEC" stroke-opacity=".34" stroke-width="2"/>
+    <rect x="890" y="55" width="650" height="456" fill="url(#mapGrid)"/>
 
-    <g transform="translate(1010 176)">
-      <circle r="38" fill="#092A39" stroke="#48DFF7" stroke-width="3"/>
-      <circle r="13" fill="#E0FFFF" stroke="#36DDF4" stroke-width="6" filter="url(#glow)"/>
-      <path d="M0-59v19M0 40v19M-59 0h19M40 0h19" stroke="#55E6F7" stroke-width="4" stroke-linecap="round"/>
-    </g>
-    <g transform="translate(1287 156)">
-      <circle r="44" fill="#241018" stroke="#FF5875" stroke-width="3"/>
-      <path d="M0-22 19 19H-19L0-22Z" fill="#FF7088"/>
-      <rect x="-3" y="27" width="6" height="11" rx="3" fill="#FFD7DF"/>
-    </g>
-    <g transform="translate(1428 314)">
-      <circle r="34" fill="#11291F" stroke="#63EEA9" stroke-width="3"/>
-      <path d="m-13 2 8 8 19-24" fill="none" stroke="#B8FFD7" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+    <!-- Map terrain and river -->
+    <path d="M858 428c110-32 166-5 242-39 73-33 111-93 191-109 79-16 143 19 285-15v265H858Z" fill="#081C2A"/>
+    <path d="M864 435c112-43 173-16 246-52 84-42 113-109 203-124 80-13 142 28 272-12" fill="none" stroke="#0D3B58" stroke-width="32" opacity=".74"/>
+    <path d="M864 435c112-43 173-16 246-52 84-42 113-109 203-124 80-13 142 28 272-12" fill="none" stroke="#176287" stroke-width="3" opacity=".52"/>
+
+    <!-- Road network -->
+    <g fill="none" stroke-linecap="round">
+      <path d="M900 166 984 132 1052 153 1116 112 1192 127 1261 95 1342 117 1447 80 1548 108" stroke="#1A5874" stroke-width="3" opacity=".58"/>
+      <path d="M902 223 981 244 1048 211 1139 231 1216 194 1297 216 1371 181 1458 207 1545 181" stroke="#21708B" stroke-width="2.5" opacity=".56"/>
+      <path d="M895 309 977 285 1056 309 1133 279 1218 306 1296 278 1389 305 1461 273 1543 291" stroke="#1C6983" stroke-width="2.5" opacity=".52"/>
+      <path d="M930 493 975 426 1039 397 1082 333 1145 299 1184 229 1233 184 1270 111 1302 58" stroke="#1C5A78" stroke-width="2" opacity=".52"/>
+      <path d="M1040 520 1071 452 1124 409 1168 345 1245 319 1298 255 1374 222 1433 153 1498 125" stroke="#217C91" stroke-width="2.5" opacity=".52"/>
+      <path d="M899 102 953 141 1001 194 1038 260 1092 296 1118 369 1170 424 1207 509" stroke="#174A68" stroke-width="2" opacity=".5"/>
+      <path d="M986 58 1014 111 1077 170 1115 222 1171 257 1217 335 1285 389 1325 510" stroke="#1B536E" stroke-width="2" opacity=".5"/>
+      <path d="M1385 57 1360 123 1391 189 1370 250 1418 315 1406 381 1461 439 1490 509" stroke="#1A536E" stroke-width="2" opacity=".5"/>
     </g>
 
-    <g transform="translate(950 80)">
-      <rect width="203" height="63" rx="17" fill="#0A1927" stroke="#31C7EA" stroke-opacity=".45"/>
-      <text x="18" y="25" fill="#69E6FF" font-family="Segoe UI,Arial,sans-serif" font-size="12" font-weight="800" letter-spacing="1.8">LIVE OPERATIONS</text>
-      <text x="18" y="49" fill="#F1FAFF" font-family="Segoe UI,Arial,sans-serif" font-size="21" font-weight="800">MAP SYNCHRONISED</text>
+    <!-- District contours -->
+    <g fill="none" stroke="#3AB6D1" stroke-width="1.3" opacity=".17">
+      <path d="M922 126c76-48 165-39 222 6 59 47 132 51 215 9 80-40 141-32 210 6"/>
+      <path d="M909 186c72-37 142-28 208 10 72 42 146 45 221 4 80-43 144-37 211-4"/>
+      <path d="M907 258c90-43 166-29 230 5 75 40 134 35 215-7 74-38 132-34 202-4"/>
+      <path d="M903 348c86-40 157-28 224 6 67 34 146 38 226 1 70-33 126-31 198-5"/>
+      <path d="M921 442c81-36 153-32 218-2 78 36 149 35 220-1 69-34 125-29 176-5"/>
     </g>
 
-    <g transform="translate(1022 372)">
-      <rect width="435" height="92" rx="20" fill="#091522" fill-opacity=".95" stroke="#4BD7F7" stroke-opacity=".25"/>
-      <text x="20" y="27" fill="#7D9BB0" font-family="Segoe UI,Arial,sans-serif" font-size="12" font-weight="800" letter-spacing="1.4">OPERATIONAL TREND</text>
-      <path d="M22 70 81 59 133 63 185 39 244 49 305 25 365 34 411 17" fill="none" stroke="url(#line)" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
-      <g fill="#E9FFFF">
-        <circle cx="81" cy="59" r="4"/><circle cx="185" cy="39" r="4"/><circle cx="305" cy="25" r="4"/><circle cx="411" cy="17" r="4"/>
+    <!-- Header -->
+    <g transform="translate(918 78)">
+      <rect width="235" height="66" rx="16" fill="#081827" fill-opacity=".96" stroke="#28C8EB" stroke-opacity=".38"/>
+      <text x="18" y="25" fill="#54DFFF" font-family="Segoe UI,Arial,sans-serif" font-size="12" font-weight="800" letter-spacing="2.1">LIVE OPERATIONS</text>
+      <text x="18" y="49" fill="#F2FAFF" font-family="Segoe UI,Arial,sans-serif" font-size="17" font-weight="800">MAP INTELLIGENCE OVERVIEW</text>
+    </g>
+
+    <!-- KPI rail -->
+    <g transform="translate(1168 75)" font-family="Segoe UI,Arial,sans-serif">
+      <g>
+        <circle cx="28" cy="31" r="25" fill="#082431" stroke="#2CD9F8" stroke-width="2"/>
+        <circle cx="28" cy="31" r="8" fill="#BDFBFF" stroke="#35DFF7" stroke-width="4"/>
+        <path d="M28 12v8M28 42v8M9 31h8M39 31h8" stroke="#56E6F7" stroke-width="2" stroke-linecap="round"/>
+        <text x="65" y="29" fill="#FFFFFF" font-size="25" font-weight="800">24</text>
+        <text x="65" y="48" fill="#8FA9BB" font-size="11" font-weight="800" letter-spacing="1.1">MISSIONS</text>
       </g>
+      <g transform="translate(125)">
+        <circle cx="28" cy="31" r="25" fill="#251019" stroke="#FF4768" stroke-width="2"/>
+        <path d="M28 17 40 40H16L28 17Z" fill="#FF5D78"/>
+        <rect x="26" y="43" width="4" height="5" rx="2" fill="#FFE0E6"/>
+        <text x="65" y="29" fill="#FFFFFF" font-size="25" font-weight="800">7</text>
+        <text x="65" y="48" fill="#B99BA3" font-size="11" font-weight="800" letter-spacing="1.1">CRITICAL</text>
+      </g>
+      <g transform="translate(243)">
+        <circle cx="28" cy="31" r="25" fill="#0D261C" stroke="#54EDA0" stroke-width="2"/>
+        <path d="m18 31 7 7 14-17" fill="none" stroke="#B8FFD7" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+        <text x="65" y="29" fill="#FFFFFF" font-size="25" font-weight="800">318</text>
+        <text x="65" y="48" fill="#91B4A2" font-size="11" font-weight="800" letter-spacing="1.1">UNITS</text>
+      </g>
+    </g>
+
+    <!-- Critical hotspot -->
+    <g transform="translate(1278 274)">
+      <circle r="93" fill="url(#criticalGlow)"/>
+      <circle r="60" fill="none" stroke="#FF4261" stroke-opacity=".24" stroke-width="1.5"/>
+      <circle r="42" fill="none" stroke="#FF4261" stroke-opacity=".38" stroke-width="1.5"/>
+      <circle r="23" fill="#35101B" stroke="#FF4B68" stroke-width="2.5" filter="url(#smallGlow)"/>
+      <path d="M0-11 10 9H-10L0-11Z" fill="#FF6A82"/>
+      <circle cy="14" r="2.5" fill="#FFE3E8"/>
+      <path d="M-86-28-122-54M66-45l53-31M63 48l54 34M-55 55l-50 43" stroke="#FF4B68" stroke-opacity=".62" stroke-width="1.5"/>
+    </g>
+
+    <!-- Mission and unit nodes -->
+    <g filter="url(#smallGlow)">
+      <g transform="translate(1016 225)">
+        <circle r="31" fill="#092736" stroke="#2EDDF7" stroke-width="2"/>
+        <circle r="10" fill="#D8FFFF" stroke="#2EDDF7" stroke-width="4"/>
+        <path d="M0-47v12M0 35v12M-47 0h12M35 0h12" stroke="#45E3F7" stroke-width="2.5" stroke-linecap="round"/>
+      </g>
+      <g transform="translate(1116 356)">
+        <circle r="38" fill="url(#unitGlow)"/>
+        <circle r="20" fill="#0B2A20" stroke="#56EEA2" stroke-width="2"/>
+        <path d="M-10-5h15l7 7v8h-4a6 6 0 0 1-12 0h-6a6 6 0 0 1-12 0h-4V0h6l4-5h6Z" fill="#5BF0A7"/>
+      </g>
+      <g transform="translate(1423 342)">
+        <circle r="39" fill="url(#unitGlow)"/>
+        <circle r="20" fill="#0C2A20" stroke="#58EDA1" stroke-width="2"/>
+        <path d="M-10 10V-8h20v18M-14 10h28M-5-8v-7h10v7M-5-2h3M2-2h3M-5 4h3M2 4h3" fill="none" stroke="#9FFFD0" stroke-width="2.6" stroke-linecap="round"/>
+      </g>
+      <g transform="translate(1070 292)">
+        <circle r="17" fill="#14203D" stroke="#9A86FF" stroke-width="1.8"/>
+        <path d="M-7 8V-5h14V8M-10 8h20M-3-5v-6h6v6" fill="none" stroke="#C3B6FF" stroke-width="2"/>
+      </g>
+      <g transform="translate(1361 198)">
+        <circle r="14" fill="#0B2732" stroke="#32DDF6"/>
+        <path d="M-6 7V-4h12V7M-9 7H9M-2-4v-5h4v5" fill="none" stroke="#7EEDFF" stroke-width="2"/>
+      </g>
+      <g transform="translate(1471 244)">
+        <circle r="8" fill="#FFB245" stroke="#FFE1A2" stroke-width="2"/>
+      </g>
+      <g transform="translate(1194 202)">
+        <circle r="7" fill="#5AF1A6" stroke="#C7FFE2" stroke-width="2"/>
+      </g>
+      <g transform="translate(998 334)">
+        <circle r="7" fill="#35D9FF" stroke="#C9F8FF" stroke-width="2"/>
+      </g>
+    </g>
+
+    <!-- Operational routes -->
+    <g fill="none" stroke-linecap="round">
+      <path d="M1016 225c63 17 91 70 100 131" stroke="#40E5B0" stroke-width="2.2" stroke-dasharray="6 8" opacity=".68"/>
+      <path d="M1116 356c54-36 95-57 162-82" stroke="#4FECA7" stroke-width="2.2" stroke-dasharray="6 8" opacity=".7"/>
+      <path d="M1278 274c52 34 89 53 145 68" stroke="#FF526E" stroke-width="2" stroke-dasharray="6 8" opacity=".68"/>
+      <path d="M1361 198c-30 24-52 40-83 76" stroke="#43DDF4" stroke-width="1.8" stroke-dasharray="5 7" opacity=".62"/>
+    </g>
+
+    <!-- Activity chart -->
+    <g transform="translate(914 392)">
+      <rect width="344" height="96" rx="17" fill="#071521" fill-opacity=".96" stroke="#39CDEB" stroke-opacity=".26"/>
+      <text x="17" y="25" fill="#EAF8FF" font-family="Segoe UI,Arial,sans-serif" font-size="12" font-weight="800" letter-spacing="1.1">OPERATIONAL ACTIVITY</text>
+      <text x="17" y="43" fill="#718FA3" font-family="Segoe UI,Arial,sans-serif" font-size="10" font-weight="700">LAST 24 HOURS</text>
+      <path d="M18 78H326M18 57H326" stroke="#497184" stroke-opacity=".24"/>
+      <path d="M18 78 49 70 77 64 105 67 134 52 164 61 194 42 224 35 255 43 284 27 309 30 326 20" fill="none" stroke="url(#line)" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"/>
+      <g fill="#E9FFFF">
+        <circle cx="77" cy="64" r="3"/><circle cx="164" cy="61" r="3"/><circle cx="224" cy="35" r="3"/><circle cx="284" cy="27" r="3"/><circle cx="326" cy="20" r="3"/>
+      </g>
+    </g>
+
+    <!-- Legend -->
+    <g transform="translate(1392 378)" font-family="Segoe UI,Arial,sans-serif">
+      <rect width="126" height="110" rx="16" fill="#071521" fill-opacity=".96" stroke="#39CDEB" stroke-opacity=".25"/>
+      <g transform="translate(14 20)" font-size="9.5" font-weight="700">
+        <circle cx="5" cy="0" r="4" fill="#39D9FF"/><text x="17" y="4" fill="#B7CAD8">MISSIONS</text>
+        <circle cx="5" cy="22" r="4" fill="#59F0A7"/><text x="17" y="26" fill="#B7CAD8">DEPLOYED UNITS</text>
+        <path d="M1 48V39h8v9M-1 48h12" fill="none" stroke="#A99AFF" stroke-width="1.5"/><text x="17" y="48" fill="#B7CAD8">BUILDINGS</text>
+        <path d="M5 59 10 69H0L5 59Z" fill="#FF5874"/><text x="17" y="69" fill="#B7CAD8">CRITICAL</text>
+        <circle cx="5" cy="87" r="4" fill="#FFB245"/><text x="17" y="91" fill="#B7CAD8">RESOURCES</text>
+      </g>
+    </g>
+
+    <g transform="translate(1467 155)">
+      <rect width="52" height="24" rx="12" fill="#092333" stroke="#3EDBF4" stroke-opacity=".5"/>
+      <circle cx="14" cy="12" r="5" fill="#5AF0A8" filter="url(#smallGlow)"/>
+      <text x="25" y="16" fill="#C9F9E0" font-family="Segoe UI,Arial,sans-serif" font-size="9" font-weight="800">SYNC</text>
     </g>
   </g>
 
+  <!-- Theme system rail -->
   <g transform="translate(58 545)">
     <text x="0" y="22" fill="#6C859A" font-family="Segoe UI,Arial,sans-serif" font-size="13" font-weight="800" letter-spacing="1.5">SEVEN COMPLETE INTERFACE SYSTEMS</text>
     <g transform="translate(0 38)" font-family="Segoe UI,Arial,sans-serif" font-size="12" font-weight="800">


### PR DESCRIPTION
## Objective

Replace the existing README operational hero with a more professional Map Command presentation while preserving the established left-side identity.

## Changes

- Corrects the main headline sizing so the complete text fits cleanly inside the left command panel.
- Rebuilds the right side as a detailed live operational command map rather than a sparse decorative diagram.
- Adds mission, critical-incident and fleet KPI telemetry.
- Adds a layered road network, river, district contours, operational routes and synchronisation state.
- Adds mission, deployed-unit, building, resource and critical-incident markers.
- Adds a compact operational activity chart and map legend.
- Retains all seven interface-system labels with balanced presentation.
- Keeps the existing `docs/media/readme-hero.svg` path, so current README references remain stable.

## Safety

- Documentation asset only.
- No userscript, distribution, setting, workflow, release or runtime change.
- No external media dependency.
- SVG remains self-contained and accessible with an updated title and description.