### PR TITLE
Fix false-failure storms in release-pipeline workflows

### DIFF
--- a/.github/fixtures/documentation-version-states.json
+++ b/.github/fixtures/documentation-version-states.json
@@ -1,0 +1,82 @@
+{
+  "schemaVersion": 1,
+  "cases": [
+    {
+      "name": "published release",
+      "sourceVersion": "4.13.4",
+      "currentVersion": "4.13.4",
+      "latestReleaseVersion": "4.13.4",
+      "githubRelease": "published",
+      "allowSourceTransition": false,
+      "changelogVersion": "4.13.4",
+      "expectedState": "published",
+      "expectedFailure": false
+    },
+    {
+      "name": "guarded source transition on pull request or main push",
+      "sourceVersion": "4.13.5",
+      "currentVersion": "4.13.4",
+      "latestReleaseVersion": "4.13.4",
+      "githubRelease": "published",
+      "allowSourceTransition": true,
+      "changelogVersion": "4.13.5",
+      "expectedState": "source-transition",
+      "expectedFailure": false
+    },
+    {
+      "name": "persistent source drift outside guarded transition",
+      "sourceVersion": "4.13.5",
+      "currentVersion": "4.13.4",
+      "latestReleaseVersion": "4.13.4",
+      "githubRelease": "published",
+      "allowSourceTransition": false,
+      "changelogVersion": "4.13.5",
+      "expectedState": "invalid",
+      "expectedFailure": true
+    },
+    {
+      "name": "generated release candidate",
+      "sourceVersion": "4.13.5",
+      "currentVersion": "4.13.5",
+      "latestReleaseVersion": "4.13.4",
+      "githubRelease": "not-published",
+      "allowSourceTransition": false,
+      "changelogVersion": "4.13.5",
+      "expectedState": "release-candidate",
+      "expectedFailure": false
+    },
+    {
+      "name": "candidate falsely marked published",
+      "sourceVersion": "4.13.5",
+      "currentVersion": "4.13.5",
+      "latestReleaseVersion": "4.13.4",
+      "githubRelease": "published",
+      "allowSourceTransition": false,
+      "changelogVersion": "4.13.5",
+      "expectedState": "invalid",
+      "expectedFailure": true
+    },
+    {
+      "name": "candidate missing changelog entry",
+      "sourceVersion": "4.13.5",
+      "currentVersion": "4.13.4",
+      "latestReleaseVersion": "4.13.4",
+      "githubRelease": "published",
+      "allowSourceTransition": true,
+      "changelogVersion": "4.13.4",
+      "expectedState": "invalid",
+      "expectedFailure": true
+    },
+    {
+      "name": "contradictory dashboard versions",
+      "sourceVersion": "4.13.5",
+      "currentVersion": "4.13.3",
+      "latestReleaseVersion": "4.13.4",
+      "githubRelease": "published",
+      "allowSourceTransition": true,
+      "changelogVersion": "4.13.5",
+      "expectedState": "invalid",
+      "expectedFailure": true
+    }
+  ]
+}

--- a/.github/scripts/check_documentation_drift.py
+++ b/.github/scripts/check_documentation_drift.py
@@ -27,6 +27,81 @@ def semantic_version(value: str) -> tuple[int, int, int]:
     return tuple(int(part) for part in match.groups())
 
 
+def changelog_contains_version(changelog: str, version: str) -> bool:
+    return (
+        re.search(
+            rf"^## \[{re.escape(version)}\](?:\s+-\s+\d{{4}}-\d{{2}}-\d{{2}})?\s*$",
+            changelog,
+            re.MULTILINE,
+        )
+        is not None
+    )
+
+
+def evaluate_version_state(
+    source_version: str,
+    dashboard: dict[str, Any],
+    changelog: str,
+    *,
+    allow_source_transition: bool = False,
+) -> tuple[str, list[str], list[str]]:
+    """Classify the published, candidate and guarded source-transition states."""
+    failures: list[str] = []
+    warnings: list[str] = []
+
+    current_version = str(dashboard.get("currentVersion", "")).strip()
+    latest_version = str(dashboard.get("latestRelease", {}).get("version", "")).strip()
+    github_release_state = str(dashboard.get("status", {}).get("githubRelease", "")).strip()
+
+    if not current_version or not latest_version:
+        failures.append(
+            "Version drift: release dashboard must record both currentVersion and latestRelease.version"
+        )
+        return "invalid", failures, warnings
+
+    try:
+        source_semver = semantic_version(source_version)
+        current_semver = semantic_version(current_version)
+        latest_semver = semantic_version(latest_version)
+    except ValueError as exc:
+        failures.append(str(exc))
+        return "invalid", failures, warnings
+
+    has_changelog = changelog_contains_version(changelog, source_version)
+
+    if source_version == current_version == latest_version:
+        return "published", failures, warnings
+
+    if (
+        source_version == current_version
+        and source_semver > latest_semver
+        and has_changelog
+        and github_release_state != "published"
+    ):
+        warnings.append(
+            f"Validated release candidate {source_version} is ahead of published release {latest_version}."
+        )
+        return "release-candidate", failures, warnings
+
+    if (
+        allow_source_transition
+        and source_semver > current_semver
+        and current_version == latest_version
+        and has_changelog
+    ):
+        warnings.append(
+            f"Validated guarded source transition {source_version} is ahead of dashboard version {current_version}."
+        )
+        return "source-transition", failures, warnings
+
+    failures.append(
+        "Version drift: "
+        f"userscript={source_version}, currentVersion={current_version}, "
+        f"latestRelease={latest_version}, githubRelease={github_release_state or 'unknown'}"
+    )
+    return "invalid", failures, warnings
+
+
 def audit(root: Path, *, allow_release_candidate: bool = False) -> dict[str, Any]:
     contract = load_json(root / ".github/documentation-contract.json")
     site = load_json(root / "docs/site-data.json")
@@ -37,31 +112,15 @@ def audit(root: Path, *, allow_release_candidate: bool = False) -> dict[str, Any
     failures: list[str] = []
     warnings: list[str] = []
     version = userscript_version(source)
-    dashboard_versions = {
-        str(dashboard.get("currentVersion", "")),
-        str(dashboard.get("latestRelease", {}).get("version", "")),
-    }
-    dashboard_versions.discard("")
-    if dashboard_versions != {version}:
-        candidate_is_valid = False
-        if allow_release_candidate and len(dashboard_versions) == 1:
-            published_version = next(iter(dashboard_versions))
-            try:
-                candidate_is_valid = (
-                    semantic_version(version) > semantic_version(published_version)
-                    and re.search(rf"^## \[{re.escape(version)}\](?:\s+-\s+\d{{4}}-\d{{2}}-\d{{2}})?\s*$", changelog, re.MULTILINE)
-                    is not None
-                )
-            except ValueError as exc:
-                failures.append(str(exc))
-        if candidate_is_valid:
-            warnings.append(
-                f"Validated pull-request candidate {version} is ahead of published dashboard version {published_version}."
-            )
-        elif not failures:
-            failures.append(
-                f"Version drift: userscript={version}, dashboard={sorted(dashboard_versions)}"
-            )
+
+    version_state, version_failures, version_warnings = evaluate_version_state(
+        version,
+        dashboard,
+        changelog,
+        allow_source_transition=allow_release_candidate,
+    )
+    failures.extend(version_failures)
+    warnings.extend(version_warnings)
 
     site_project = site.get("project", {})
     for key, expected in contract.get("project", {}).items():
@@ -132,9 +191,10 @@ def audit(root: Path, *, allow_release_candidate: bool = False) -> dict[str, Any
         warnings.append("Visual media roadmap is unusually small")
 
     return {
-        "schemaVersion": 1,
+        "schemaVersion": 2,
         "status": "failed" if failures else "passed",
         "userscriptVersion": version,
+        "versionState": version_state,
         "documentedThemes": themes,
         "documentedModes": modes,
         "documentedShortcuts": shortcuts,
@@ -152,6 +212,7 @@ def markdown(report: dict[str, Any]) -> str:
         f"{icon} **Status:** {report['status'].upper()}",
         "",
         f"- Toolkit version: **{report['userscriptVersion']}**",
+        f"- Version state: **{report['versionState']}**",
         f"- Features: **{report['featureCount']}**",
         f"- Themes: **{len(report['documentedThemes'])}**",
         f"- Modes: **{len(report['documentedModes'])}**",
@@ -173,7 +234,10 @@ def main() -> int:
     parser.add_argument(
         "--allow-release-candidate",
         action="store_true",
-        help="Allow one higher changelog-backed userscript version while the dashboard still records the published release.",
+        help=(
+            "Allow the brief changelog-backed source transition before the release dashboard "
+            "records the candidate version."
+        ),
     )
     args = parser.parse_args()
 

--- a/.github/scripts/reconcile_pages_incident.sh
+++ b/.github/scripts/reconcile_pages_incident.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+: "${HEALTH_EXIT:?HEALTH_EXIT is required}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+: "${GITHUB_RUN_ID:?GITHUB_RUN_ID is required}"
+: "${GITHUB_SERVER_URL:?GITHUB_SERVER_URL is required}"
+
+TITLE='[Automated] GitHub Pages production health incident'
+MARKER='<!-- missionchief-pages-production-health -->'
+SEARCH_QUERY='"GitHub Pages production health incident" in:title'
+ISSUE_JSON="$(gh issue list --state all --search "$SEARCH_QUERY" --json number,state,title --limit 20)"
+ISSUE_NUMBER="$(jq -r --arg title "$TITLE" '.[] | select(.title == $title) | .number' <<< "$ISSUE_JSON" | head -n 1)"
+ISSUE_STATE="$(jq -r --arg title "$TITLE" '.[] | select(.title == $title) | .state' <<< "$ISSUE_JSON" | head -n 1)"
+
+post_discord() {
+  local heading="$1"
+  local description="$2"
+  local color="$3"
+  [[ -n "${DISCORD_WEBHOOK:-}" ]] || return 0
+  jq -n \
+    --arg title "$heading" \
+    --arg description "$description" \
+    --arg url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+    --argjson color "$color" \
+    '{embeds:[{title:$title,description:$description,url:$url,color:$color,footer:{text:"MissionChief Map Command Toolkit · GitHub Pages monitor"}}]}' |
+    curl --fail --silent --show-error \
+      --header 'Content-Type: application/json' \
+      --data-binary @- \
+      "$DISCORD_WEBHOOK" >/dev/null
+}
+
+if [[ "$HEALTH_EXIT" != "0" ]]; then
+  {
+    echo "$MARKER"
+    echo
+    cat pages-production-health.md
+    echo
+    echo "Workflow: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+  } > /tmp/pages-incident.md
+
+  if [[ -z "$ISSUE_NUMBER" ]]; then
+    ISSUE_URL="$(gh issue create \
+      --title "$TITLE" \
+      --body-file /tmp/pages-incident.md \
+      --label 'bug' \
+      --label 'needs-triage' \
+      --label 'priority: high' \
+      --label 'area: release pipeline')"
+    post_discord '❌ GitHub Pages health incident' "The public Toolkit documentation site failed one or more live production checks. Incident: ${ISSUE_URL}" 15158332
+  elif [[ "$ISSUE_STATE" == "CLOSED" ]]; then
+    gh issue reopen "$ISSUE_NUMBER"
+    gh issue edit "$ISSUE_NUMBER" --body-file /tmp/pages-incident.md
+    gh issue comment "$ISSUE_NUMBER" --body "The production health incident has recurred. See the updated diagnostic body and workflow run."
+    post_discord '❌ GitHub Pages incident recurred' "The public Toolkit documentation site has failed live checks again. Incident #${ISSUE_NUMBER}." 15158332
+  else
+    gh issue edit "$ISSUE_NUMBER" --body-file /tmp/pages-incident.md
+    gh issue comment "$ISSUE_NUMBER" --body "Scheduled recheck still fails. Diagnostic state was refreshed by workflow run ${GITHUB_RUN_ID}."
+  fi
+  exit 1
+fi
+
+if [[ -n "$ISSUE_NUMBER" && "$ISSUE_STATE" == "OPEN" ]]; then
+  gh issue comment "$ISSUE_NUMBER" --body "✅ Live GitHub Pages checks recovered successfully in workflow run ${GITHUB_RUN_ID}."
+  gh issue close "$ISSUE_NUMBER" --reason completed
+  post_discord '✅ GitHub Pages recovered' "The public Toolkit documentation site has passed all live production checks. Incident #${ISSUE_NUMBER} was closed." 5763719
+fi

--- a/.github/scripts/test_documentation_version_states.py
+++ b/.github/scripts/test_documentation_version_states.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Fixture-backed tests for documentation release-state classification."""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CHECKER_PATH = ROOT / ".github" / "scripts" / "check_documentation_drift.py"
+FIXTURE_PATH = ROOT / ".github" / "fixtures" / "documentation-version-states.json"
+
+
+def load_checker():
+    spec = importlib.util.spec_from_file_location("documentation_drift_checker", CHECKER_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load {CHECKER_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def main() -> int:
+    checker = load_checker()
+    fixture = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+    failures: list[str] = []
+
+    for case in fixture["cases"]:
+        dashboard = {
+            "currentVersion": case["currentVersion"],
+            "latestRelease": {"version": case["latestReleaseVersion"]},
+            "status": {"githubRelease": case["githubRelease"]},
+        }
+        changelog = f"## [{case['changelogVersion']}] - 2026-07-16\n"
+        state, state_failures, _warnings = checker.evaluate_version_state(
+            case["sourceVersion"],
+            dashboard,
+            changelog,
+            allow_source_transition=bool(case["allowSourceTransition"]),
+        )
+        failed = bool(state_failures)
+        if state != case["expectedState"]:
+            failures.append(
+                f"{case['name']}: expected state {case['expectedState']!r}, found {state!r}"
+            )
+        if failed != bool(case["expectedFailure"]):
+            failures.append(
+                f"{case['name']}: expected failure={case['expectedFailure']}, found {failed}; "
+                f"details={state_failures}"
+            )
+
+    if failures:
+        print("Documentation version-state fixtures failed:")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+
+    print(f"Documentation version-state fixtures passed: {len(fixture['cases'])} cases.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/apply-development-package.yml
+++ b/.github/workflows/apply-development-package.yml
@@ -33,70 +33,115 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          read -r command branch package expected extra <<< "$COMMENT_BODY"
-          [[ "$command" == "/apply-development-package" ]] || { echo "::error::Invalid command."; exit 1; }
-          [[ -n "$branch" && -n "$package" && -n "$expected" && -z "${extra:-}" ]] || {
-            echo "::error::Use: /apply-development-package <branch> <package.py> <expected-head-sha>"
-            exit 1
+
+          reject() {
+            echo "accepted=false" >> "$GITHUB_OUTPUT"
+            echo "reason=$1" >> "$GITHUB_OUTPUT"
           }
-          [[ "$branch" =~ ^(feature|fix|chore)/[A-Za-z0-9._/-]+$ ]] || { echo "::error::Branch is outside the allowed development namespaces."; exit 1; }
-          [[ "$package" =~ ^\.github/development-packages/[A-Za-z0-9._/-]+\.py$ ]] || { echo "::error::Package path is outside .github/development-packages."; exit 1; }
-          [[ "$expected" =~ ^[0-9a-f]{40}$ ]] || { echo "::error::Expected head must be a full commit SHA."; exit 1; }
+
+          read -r command branch package expected extra <<< "$COMMENT_BODY"
+          if [[ "$command" != "/apply-development-package" ]]; then
+            reject "The command name is invalid."
+            exit 0
+          fi
+          if [[ -z "$branch" || -z "$package" || -z "$expected" || -n "${extra:-}" ]]; then
+            reject "Use: /apply-development-package <branch> <package.py> <expected-head-sha>"
+            exit 0
+          fi
+          if [[ ! "$branch" =~ ^(feature|fix|chore)/[A-Za-z0-9._/-]+$ ]]; then
+            reject "Branch is outside the allowed feature/, fix/ and chore/ namespaces."
+            exit 0
+          fi
+          if [[ ! "$package" =~ ^\.github/development-packages/[A-Za-z0-9._/-]+\.py$ ]]; then
+            reject "Package path is outside .github/development-packages."
+            exit 0
+          fi
+          if [[ ! "$expected" =~ ^[0-9a-f]{40}$ ]]; then
+            reject "Expected head must be a full 40-character lowercase commit SHA."
+            exit 0
+          fi
+
+          echo "accepted=true" >> "$GITHUB_OUTPUT"
           echo "branch=$branch" >> "$GITHUB_OUTPUT"
           echo "package=$package" >> "$GITHUB_OUTPUT"
           echo "expected=$expected" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "check-out-authorized-branch" > "$RUNNER_TEMP/development-package-stage"
+
+      - name: Record rejected command
+        if: steps.command.outputs.accepted != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REJECTION_REASON: ${{ steps.command.outputs.reason }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh issue comment "$ISSUE_NUMBER" \
+            --repo "$GITHUB_REPOSITORY" \
+            --body "Development package command rejected safely: ${REJECTION_REASON}\n\nNo branch was checked out, changed or pushed."
 
       - name: Check out authorized branch
+        if: steps.command.outputs.accepted == 'true'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ steps.command.outputs.branch }}
           fetch-depth: 0
 
       - name: Confirm exact authorized branch head
+        if: steps.command.outputs.accepted == 'true'
         shell: bash
         env:
           EXPECTED_HEAD: ${{ steps.command.outputs.expected }}
           PACKAGE_PATH: ${{ steps.command.outputs.package }}
         run: |
           set -euo pipefail
+          printf '%s\n' "confirm-authorized-head" > "$RUNNER_TEMP/development-package-stage"
           test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD"
           test -f "$PACKAGE_PATH"
           test ! -L "$PACKAGE_PATH"
 
       - name: Rebase package onto current main
+        if: steps.command.outputs.accepted == 'true'
         shell: bash
         run: |
           set -euo pipefail
+          printf '%s\n' "rebase-onto-current-main" > "$RUNNER_TEMP/development-package-stage"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git fetch origin main
           git rebase origin/main
 
       - name: Apply development package
+        if: steps.command.outputs.accepted == 'true'
         shell: bash
         env:
           PACKAGE_PATH: ${{ steps.command.outputs.package }}
         run: |
           set -euo pipefail
+          printf '%s\n' "apply-development-package" > "$RUNNER_TEMP/development-package-stage"
           python3 "$PACKAGE_PATH"
           rm -f "$PACKAGE_PATH"
           find .github/development-packages -type d -empty -delete 2>/dev/null || true
 
       - name: Validate canonical userscript
+        if: steps.command.outputs.accepted == 'true'
         shell: bash
         run: |
           set -euo pipefail
+          printf '%s\n' "validate-canonical-userscript" > "$RUNNER_TEMP/development-package-stage"
           python3 .github/scripts/validate_userscript.py
           node --check src/MissionChief_Map_Command_Toolkit.user.js
           cmp --silent dist/MissionChief_Map_Command_Toolkit.user.js dist/MissionChief_Map_Command_Toolkit.txt
 
       - name: Commit validated result
+        if: steps.command.outputs.accepted == 'true'
         id: commit
         shell: bash
         env:
           BRANCH: ${{ steps.command.outputs.branch }}
         run: |
           set -euo pipefail
+          printf '%s\n' "commit-and-push-validated-result" > "$RUNNER_TEMP/development-package-stage"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A
@@ -106,36 +151,88 @@ jobs:
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Open or update pull request
+        if: steps.command.outputs.accepted == 'true'
         id: pr
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.DEVELOPMENT_PR_TOKEN || github.token }}
           BRANCH: ${{ steps.command.outputs.branch }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         shell: bash
         run: |
           set -euo pipefail
-          PR_URL="$(gh pr list --head "$BRANCH" --base main --state open --json url -q '.[0].url // empty')"
+          printf '%s\n' "open-or-update-pull-request" > "$RUNNER_TEMP/development-package-stage"
+
+          PR_URL="$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --head "$BRANCH" \
+            --base main \
+            --state open \
+            --json url \
+            -q '.[0].url // empty')"
+
+          CREATED=false
           if [[ -z "$PR_URL" ]]; then
-            TITLE="$(gh issue view "$ISSUE_NUMBER" --json title -q '.title')"
-            PR_URL="$(gh pr create --head "$BRANCH" --base main --title "$TITLE" --body "Automated implementation for #${ISSUE_NUMBER}. The owner-authorized development package was rebased onto current main, applied, removed, and validated before this pull request was opened.\n\nCloses #${ISSUE_NUMBER}")"
+            TITLE="$(gh issue view "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --json title -q '.title')"
+            BODY_FILE="$(mktemp)"
+            printf '%s\n\n%s\n' \
+              "Automated implementation for #${ISSUE_NUMBER}. The owner-authorized development package was rebased onto current main, applied, removed, and validated before this pull request was opened." \
+              "Closes #${ISSUE_NUMBER}" \
+              > "$BODY_FILE"
+            if ! gh pr create \
+              --repo "$GITHUB_REPOSITORY" \
+              --head "$BRANCH" \
+              --base main \
+              --title "$TITLE" \
+              --body-file "$BODY_FILE" \
+              > /tmp/development-package-pr-url.txt \
+              2> /tmp/development-package-pr-error.txt; then
+              cat /tmp/development-package-pr-error.txt >&2
+              if grep -qi "not permitted to create or approve pull requests" /tmp/development-package-pr-error.txt; then
+                echo "::error::Automatic PR creation is disabled for GITHUB_TOKEN. Enable Settings > Actions > General > Workflow permissions > Allow GitHub Actions to create and approve pull requests, or configure a least-privilege DEVELOPMENT_PR_TOKEN secret."
+              else
+                echo "::error::The validated branch was pushed, but GitHub could not create its pull request."
+              fi
+              exit 1
+            fi
+            PR_URL="$(cat /tmp/development-package-pr-url.txt)"
+            CREATED=true
           fi
+
           echo "url=$PR_URL" >> "$GITHUB_OUTPUT"
+          echo "created=$CREATED" >> "$GITHUB_OUTPUT"
 
       - name: Record success
+        if: steps.command.outputs.accepted == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           RESULT_SHA: ${{ steps.commit.outputs.sha }}
           PR_URL: ${{ steps.pr.outputs.url }}
+          PR_CREATED: ${{ steps.pr.outputs.created }}
         shell: bash
         run: |
-          gh issue comment "$ISSUE_NUMBER" --body "Development package applied and validated automatically.\n\n- Result commit: \`${RESULT_SHA}\`\n- Pull request: ${PR_URL}\n- Package payload removed from the branch\n- Canonical validation, JavaScript syntax and distribution parity passed before push"
+          set -euo pipefail
+          printf '%s\n' "record-success" > "$RUNNER_TEMP/development-package-stage"
+          ACTION="updated"
+          [[ "$PR_CREATED" == "true" ]] && ACTION="opened"
+          gh issue comment "$ISSUE_NUMBER" \
+            --repo "$GITHUB_REPOSITORY" \
+            --body "Development package applied and validated automatically.\n\n- Result commit: \`${RESULT_SHA}\`\n- Pull request ${ACTION}: ${PR_URL}\n- Package payload removed from the branch\n- Canonical validation, JavaScript syntax and distribution parity passed before push"
 
-      - name: Record failure
-        if: failure()
+      - name: Record exact failure
+        if: failure() && steps.command.outputs.accepted == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
+          RESULT_SHA: ${{ steps.commit.outputs.sha }}
         shell: bash
         run: |
-          gh issue comment "$ISSUE_NUMBER" --body "The owner-authorized development package stopped at a guarded validation step. No failed gate was bypassed. Diagnostics: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          set -euo pipefail
+          STAGE="$(cat "$RUNNER_TEMP/development-package-stage" 2>/dev/null || echo unknown)"
+          RESULT_NOTE=""
+          if [[ -n "${RESULT_SHA:-}" ]]; then
+            RESULT_NOTE="\n- Validated branch commit already pushed: \`${RESULT_SHA}\`"
+          fi
+          gh issue comment "$ISSUE_NUMBER" \
+            --repo "$GITHUB_REPOSITORY" \
+            --body "The owner-authorized development package stopped during **${STAGE}**. No failed gate was bypassed.${RESULT_NOTE}\n- Diagnostics: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"

--- a/.github/workflows/documentation-drift-check.yml
+++ b/.github/workflows/documentation-drift-check.yml
@@ -6,7 +6,9 @@ on:
   pull_request:
     paths:
       - ".github/documentation-contract.json"
+      - ".github/fixtures/documentation-version-states.json"
       - ".github/scripts/check_documentation_drift.py"
+      - ".github/scripts/test_documentation_version_states.py"
       - ".github/workflows/documentation-drift-check.yml"
       - ".github/release-settings.json"
       - "docs/site-data.json"
@@ -19,7 +21,9 @@ on:
       - main
     paths:
       - ".github/documentation-contract.json"
+      - ".github/fixtures/documentation-version-states.json"
       - ".github/scripts/check_documentation_drift.py"
+      - ".github/scripts/test_documentation_version_states.py"
       - ".github/workflows/documentation-drift-check.yml"
       - ".github/release-settings.json"
       - "docs/site-data.json"
@@ -50,9 +54,17 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Run documentation state fixtures
+        run: |
+          set -euo pipefail
+          python3 -m py_compile \
+            .github/scripts/check_documentation_drift.py \
+            .github/scripts/test_documentation_version_states.py
+          python3 .github/scripts/test_documentation_version_states.py
+
       - name: Run documentation contract audit
         env:
-          ALLOW_RELEASE_CANDIDATE: ${{ github.event_name == 'pull_request' && '1' || '0' }}
+          ALLOW_RELEASE_CANDIDATE: ${{ (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && '1' || '0' }}
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/pages-production-monitor.yml
+++ b/.github/workflows/pages-production-monitor.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - ".github/pages-monitor-policy.json"
       - ".github/scripts/check_pages_live.py"
+      - ".github/scripts/reconcile_pages_incident.sh"
       - ".github/workflows/pages-production-monitor.yml"
       - "status/release-dashboard.json"
   workflow_run:
@@ -37,6 +38,13 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || 'main' }}
           persist-credentials: false
+
+      - name: Validate monitor scripts
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m py_compile .github/scripts/check_pages_live.py
+          bash -n .github/scripts/reconcile_pages_incident.sh
 
       - name: Check live GitHub Pages deployment
         id: health
@@ -70,63 +78,4 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_COMMITS_WEBHOOK }}
           HEALTH_EXIT: ${{ steps.health.outputs.exit_code }}
         shell: bash
-        run: |
-          set -euo pipefail
-          TITLE='[Automated] GitHub Pages production health incident'
-          MARKER='<!-- missionchief-pages-production-health -->'
-          ISSUE_JSON="$(gh issue list --state all --search '"'"'GitHub Pages production health incident'"'"' in:title' --json number,state,title --limit 20)"
-          ISSUE_NUMBER="$(jq -r --arg title "$TITLE" '.[] | select(.title == $title) | .number' <<< "$ISSUE_JSON" | head -n 1)"
-          ISSUE_STATE="$(jq -r --arg title "$TITLE" '.[] | select(.title == $title) | .state' <<< "$ISSUE_JSON" | head -n 1)"
-
-          post_discord() {
-            local heading="$1"
-            local description="$2"
-            local color="$3"
-            [[ -n "${DISCORD_WEBHOOK:-}" ]] || return 0
-            jq -n \
-              --arg title "$heading" \
-              --arg description "$description" \
-              --arg url "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
-              --argjson color "$color" \
-              '{embeds:[{title:$title,description:$description,url:$url,color:$color,footer:{text:"MissionChief Map Command Toolkit · GitHub Pages monitor"}}]}' |
-              curl --fail --silent --show-error \
-                --header 'Content-Type: application/json' \
-                --data-binary @- \
-                "$DISCORD_WEBHOOK" >/dev/null
-          }
-
-          if [[ "$HEALTH_EXIT" != "0" ]]; then
-            {
-              echo "$MARKER"
-              echo
-              cat pages-production-health.md
-              echo
-              echo "Workflow: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-            } > /tmp/pages-incident.md
-
-            if [[ -z "$ISSUE_NUMBER" ]]; then
-              ISSUE_URL="$(gh issue create \
-                --title "$TITLE" \
-                --body-file /tmp/pages-incident.md \
-                --label 'bug' \
-                --label 'needs-triage' \
-                --label 'priority: high' \
-                --label 'area: release pipeline')"
-              post_discord '❌ GitHub Pages health incident' "The public Toolkit documentation site failed one or more live production checks. Incident: ${ISSUE_URL}" 15158332
-            elif [[ "$ISSUE_STATE" == "CLOSED" ]]; then
-              gh issue reopen "$ISSUE_NUMBER"
-              gh issue edit "$ISSUE_NUMBER" --body-file /tmp/pages-incident.md
-              gh issue comment "$ISSUE_NUMBER" --body "The production health incident has recurred. See the updated diagnostic body and workflow run."
-              post_discord '❌ GitHub Pages incident recurred' "The public Toolkit documentation site has failed live checks again. Incident #${ISSUE_NUMBER}." 15158332
-            else
-              gh issue edit "$ISSUE_NUMBER" --body-file /tmp/pages-incident.md
-              gh issue comment "$ISSUE_NUMBER" --body "Scheduled recheck still fails. Diagnostic state was refreshed by workflow run ${GITHUB_RUN_ID}."
-            fi
-            exit 1
-          fi
-
-          if [[ -n "$ISSUE_NUMBER" && "$ISSUE_STATE" == "OPEN" ]]; then
-            gh issue comment "$ISSUE_NUMBER" --body "✅ Live GitHub Pages checks recovered successfully in workflow run ${GITHUB_RUN_ID}."
-            gh issue close "$ISSUE_NUMBER" --reason completed
-            post_discord '✅ GitHub Pages recovered' "The public Toolkit documentation site has passed all live production checks. Incident #${ISSUE_NUMBER} was closed." 5763719
-          fi
+        run: bash .github/scripts/reconcile_pages_incident.sh


### PR DESCRIPTION
## Objective

Resolve critical Issue #80 by stopping structurally broken and expected transitional states from generating misleading GitHub Actions failures.

## Changes

### GitHub Pages production monitor

- Moves incident reconciliation into a dedicated, syntax-testable Bash script.
- Fixes the malformed issue-search quoting that caused every production reconciliation run to fail.
- Adds `bash -n` and Python compilation checks before live monitoring.
- Preserves issue creation, recurrence handling, recovery closure and Discord deduplication.

### Documentation drift

- Replaces the two-version equality assumption with explicit states:
  - verified published release;
  - guarded source transition;
  - generated release candidate.
- Allows the brief source-ahead transition only on pull requests and direct `main` pushes.
- Keeps scheduled/manual checks strict so persistent drift still fails.
- Adds seven fixture-backed release-state cases covering valid and contradictory states.

### Reviewed development packages

- Converts malformed or unauthorized commands into safe, green command rejections with an explanatory issue comment.
- Keeps branch namespace, package path and exact-SHA authorization strict.
- Tracks the exact operational stage so genuine failures are reported accurately.
- Detects and explains repository-level PR-creation restrictions instead of mislabelling them as validation failures.
- Supports an optional least-privilege `DEVELOPMENT_PR_TOKEN`; otherwise it continues to use `github.token`.

## Local verification

- All modified workflow YAML parsed successfully.
- Every changed Bash `run:` block passed `bash -n` after GitHub-expression substitution.
- Pages reconciler passed healthy and incident-path mock tests.
- Documentation Python scripts compiled successfully.
- All seven documentation version-state fixtures passed.
- Development-package command parser passed valid, invalid-namespace and extra-argument cases.

## Safety

- No userscript or distribution changes.
- No release or dashboard mutation.
- No workflow permission expansion.
- No authorization, validation or release safeguard weakened.

Closes #80