### PR TITLE
Deploy GitHub Pages after verified Toolkit releases

### DIFF
--- a/.github/scripts/test_pages_release_deploy_contract.py
+++ b/.github/scripts/test_pages_release_deploy_contract.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Static contract for verified release-driven GitHub Pages deployment."""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "github-pages.yml"
+
+
+def main() -> int:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    required = [
+        "  release:\n    types:\n      - published",
+        "Wait for verified release dashboard",
+        "github.event.release.tag_name",
+        "EXPECTED_TAG#v",
+        "git fetch --no-tags --depth=1 origin main",
+        "git reset --hard origin/main",
+        "latestRelease.version // empty",
+        "status.githubRelease // empty",
+        '[[ "$DASHBOARD_VERSION" == "$EXPECTED_VERSION" && "$RELEASE_STATE" == "published" ]]',
+        ".github/scripts/test_pages_release_deploy_contract.py",
+    ]
+    missing = [fragment for fragment in required if fragment not in text]
+    assert not missing, f"Pages release deployment contract fragments missing: {missing}"
+
+    wait_index = text.index("Wait for verified release dashboard")
+    build_index = text.index("Build deployment site")
+    assert wait_index < build_index, "Verified release wait must run before the deployment build"
+
+    print("Pages release deployment contract passed: published release waits for verified dashboard state before build.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths:
       - ".github/scripts/build_pages_site.py"
+      - ".github/scripts/test_pages_release_deploy_contract.py"
       - ".github/workflows/github-pages.yml"
       - ".github/release-settings.json"
       - "docs/site-data.json"
@@ -20,6 +21,7 @@ on:
       - main
     paths:
       - ".github/scripts/build_pages_site.py"
+      - ".github/scripts/test_pages_release_deploy_contract.py"
       - ".github/workflows/github-pages.yml"
       - ".github/release-settings.json"
       - "docs/site-data.json"
@@ -29,6 +31,9 @@ on:
       - "status/release-dashboard.json"
       - "CHANGELOG.md"
       - "README.md"
+  release:
+    types:
+      - published
   workflow_dispatch:
 
 permissions:
@@ -47,10 +52,15 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ github.event_name == 'release' && 'main' || github.sha }}
+          persist-credentials: false
 
       - name: Validate source syntax
         run: |
           python3 -m py_compile .github/scripts/build_pages_site.py
+          python3 -m py_compile .github/scripts/test_pages_release_deploy_contract.py
+          python3 .github/scripts/test_pages_release_deploy_contract.py
           node --check docs/site-assets/site.js
           python3 -m json.tool docs/site-data.json > /dev/null
 
@@ -90,7 +100,7 @@ jobs:
     if: github.event_name != 'pull_request'
     needs: validate
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     permissions:
       contents: read
@@ -104,6 +114,33 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ github.event_name == 'release' && 'main' || github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Wait for verified release dashboard
+        if: github.event_name == 'release'
+        env:
+          EXPECTED_TAG: ${{ github.event.release.tag_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          EXPECTED_VERSION="${EXPECTED_TAG#v}"
+          for ATTEMPT in $(seq 1 40); do
+            git fetch --no-tags --depth=1 origin main
+            git reset --hard origin/main
+            DASHBOARD_VERSION="$(jq -r '.latestRelease.version // empty' status/release-dashboard.json)"
+            RELEASE_STATE="$(jq -r '.status.githubRelease // empty' status/release-dashboard.json)"
+            if [[ "$DASHBOARD_VERSION" == "$EXPECTED_VERSION" && "$RELEASE_STATE" == "published" ]]; then
+              echo "Verified release dashboard reached ${EXPECTED_VERSION} on attempt ${ATTEMPT}."
+              exit 0
+            fi
+            echo "Waiting for verified release ${EXPECTED_VERSION}; dashboard=${DASHBOARD_VERSION:-missing}, state=${RELEASE_STATE:-missing}."
+            sleep 15
+          done
+          echo "::error::Release dashboard did not verify ${EXPECTED_VERSION} within 10 minutes."
+          exit 1
 
       - name: Configure GitHub Pages
         id: pages


### PR DESCRIPTION
## Root cause

The release pipeline finalises `status/release-dashboard.json` with a bot-authored commit. GitHub intentionally prevents that `GITHUB_TOKEN` push from recursively starting another workflow, so the Pages deployment remained on the previous verified release.

## Fix

- Trigger the Pages workflow when a GitHub Release is published.
- Wait for `latestRelease.version` and `status.githubRelease` on `main` to confirm the same verified release before deployment.
- Refresh the checkout from `main` before building, ensuring the final reconciled dashboard is included.
- Add and run a static workflow contract.
- Increase the deployment timeout to cover the bounded verification wait.

Merging this workflow change also triggers an immediate Pages deployment for the already verified 4.13.5 release. Issue #86 remains open until the production monitor confirms recovery and closes it through the normal Discord-aware reconciliation path.