### PR TITLE
Exclude Pages previews from production incident reconciliation

### DIFF
--- a/.github/scripts/test_pages_monitor_reconciliation_contract.py
+++ b/.github/scripts/test_pages_monitor_reconciliation_contract.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Protect production incident reconciliation from pull-request preview runs."""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "pages-production-monitor.yml"
+
+
+def main() -> int:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    required = [
+        "github.event_name != 'pull_request'",
+        "github.event_name != 'workflow_run' || github.event.workflow_run.event != 'pull_request'",
+        ".github/scripts/test_pages_monitor_reconciliation_contract.py",
+        "python3 .github/scripts/test_pages_monitor_reconciliation_contract.py",
+    ]
+    missing = [fragment for fragment in required if fragment not in text]
+    assert not missing, f"Pages incident reconciliation contract fragments missing: {missing}"
+    assert "if: always() && github.event_name != 'pull_request'\n" not in text, (
+        "Legacy reconciliation condition still permits workflow_run events from pull-request previews"
+    )
+    print("Pages incident reconciliation contract passed: PR previews cannot mutate the production incident.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/pages-production-monitor.yml
+++ b/.github/workflows/pages-production-monitor.yml
@@ -9,6 +9,7 @@ on:
       - ".github/fixtures/pages-monitor-version-contract.json"
       - ".github/scripts/check_pages_live.py"
       - ".github/scripts/reconcile_pages_incident.sh"
+      - ".github/scripts/test_pages_monitor_reconciliation_contract.py"
       - ".github/scripts/test_pages_monitor_version_contract.py"
       - ".github/workflows/pages-production-monitor.yml"
       - "status/release-dashboard.json"
@@ -20,6 +21,7 @@ on:
       - ".github/fixtures/pages-monitor-version-contract.json"
       - ".github/scripts/check_pages_live.py"
       - ".github/scripts/reconcile_pages_incident.sh"
+      - ".github/scripts/test_pages_monitor_reconciliation_contract.py"
       - ".github/scripts/test_pages_monitor_version_contract.py"
       - ".github/workflows/pages-production-monitor.yml"
   workflow_run:
@@ -56,7 +58,9 @@ jobs:
         run: |
           set -euo pipefail
           python3 -m py_compile .github/scripts/check_pages_live.py
+          python3 -m py_compile .github/scripts/test_pages_monitor_reconciliation_contract.py
           python3 -m py_compile .github/scripts/test_pages_monitor_version_contract.py
+          python3 .github/scripts/test_pages_monitor_reconciliation_contract.py
           python3 .github/scripts/test_pages_monitor_version_contract.py
           bash -n .github/scripts/reconcile_pages_incident.sh
 
@@ -86,7 +90,10 @@ jobs:
           retention-days: 30
 
       - name: Reconcile persistent incident
-        if: always() && github.event_name != 'pull_request'
+        if: >-
+          always() &&
+          github.event_name != 'pull_request' &&
+          (github.event_name != 'workflow_run' || github.event.workflow_run.event != 'pull_request')
         env:
           GH_TOKEN: ${{ github.token }}
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_COMMITS_WEBHOOK }}


### PR DESCRIPTION
Pull-request Pages validations emit `workflow_run` completion events. The monitor previously treated those as production completions because it excluded only direct `pull_request` events, allowing preview checks to refresh Issue #86 before any production deployment occurred.

This change:
- skips incident reconciliation when the completed Pages workflow originated from a pull request;
- preserves reconciliation for main deployments, scheduled checks, monitor pushes and manual production runs;
- adds a static regression contract and executes it with the monitor tests.

No Toolkit runtime or documentation content changes.