### PR TITLE
Optimise routine userscript delivery for faster safe releases

### DIFF
--- a/.github/scripts/run_userscript_preflight.sh
+++ b/.github/scripts/run_userscript_preflight.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+MODE="${1:---all}"
+if [[ "$MODE" != "--all" && "$MODE" != "--contracts" ]]; then
+  echo "Usage: $0 [--all|--contracts]" >&2
+  exit 2
+fi
+
+SOURCE="src/MissionChief_Map_Command_Toolkit.user.js"
+DIST_JS="dist/MissionChief_Map_Command_Toolkit.user.js"
+DIST_TXT="dist/MissionChief_Map_Command_Toolkit.txt"
+
+if [[ "$MODE" == "--all" ]]; then
+  echo "[preflight] Validate canonical userscript and generated distribution"
+  python3 .github/scripts/validate_userscript.py
+fi
+
+echo "[preflight] Verify JavaScript syntax"
+node --check "$SOURCE"
+
+echo "[preflight] Verify distribution parity"
+cmp --silent "$DIST_JS" "$DIST_TXT"
+
+CONTRACTS=(
+  .github/scripts/test_financial_ledger_contract.py
+  .github/scripts/test_mission_marker_ingestion_contract.py
+  .github/scripts/test_settings_ui_contract.py
+  .github/scripts/test_desktop_panel_layout_contract.py
+  .github/scripts/test_mission_value_contract.py
+)
+
+for contract in "${CONTRACTS[@]}"; do
+  [[ -f "$contract" ]] || { echo "Missing contract: $contract" >&2; exit 1; }
+  echo "[preflight] Run $(basename "$contract")"
+  python3 "$contract"
+done
+
+echo "[preflight] Complete"

--- a/.github/workflows/full-userscript-audit.yml
+++ b/.github/workflows/full-userscript-audit.yml
@@ -18,6 +18,7 @@ on:
       - ".github/scripts/refine_full_userscript_audit.py"
       - ".github/scripts/summarise_eslint_audit.py"
       - ".github/scripts/extract_userscript_audit_evidence.py"
+      - ".github/scripts/run_userscript_preflight.sh"
       - ".github/scripts/test_financial_ledger_contract.py"
       - ".github/scripts/test_mission_marker_ingestion_contract.py"
       - ".github/scripts/test_settings_ui_contract.py"
@@ -34,35 +35,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  audit:
-    name: Audit complete canonical userscript
+  contracts:
+    name: Contract and syntax lane
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 10
 
     steps:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
-          fetch-depth: 0
           persist-credentials: false
 
-      - name: Verify JavaScript syntax
-        run: node --check src/MissionChief_Map_Command_Toolkit.user.js
+      - name: Run deterministic contract preflight
+        run: bash .github/scripts/run_userscript_preflight.sh --contracts
 
-      - name: Run financial ledger contract fixtures
-        run: python3 .github/scripts/test_financial_ledger_contract.py
+  static-audit:
+    name: Static-analysis lane
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
 
-      - name: Run mission marker ingestion contract fixtures
-        run: python3 .github/scripts/test_mission_marker_ingestion_contract.py
-
-      - name: Run settings migration and UI routing contract fixtures
-        run: python3 .github/scripts/test_settings_ui_contract.py
-
-      - name: Run Desktop panel layout contract fixtures
-        run: python3 .github/scripts/test_desktop_panel_layout_contract.py
-
-      - name: Run Mission Value contract fixtures
-        run: python3 .github/scripts/test_mission_value_contract.py
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Run full static audit
         id: full_audit
@@ -92,6 +88,42 @@ jobs:
           echo "exit_code=$STATUS" >> "$GITHUB_OUTPUT"
           exit 0
 
+      - name: Publish static audit summary
+        if: always()
+        run: cat full-userscript-audit.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload static audit evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: missionchief-toolkit-static-audit
+          path: |
+            full-userscript-audit-raw.json
+            full-userscript-audit-raw.md
+            full-userscript-audit.json
+            full-userscript-audit.md
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Stop on definite static-audit failure
+        if: >-
+          steps.full_audit.outputs.exit_code != '0' ||
+          steps.refined_audit.outputs.exit_code != '0'
+        run: |
+          echo "One or more definite static-audit gates failed. Review the workflow summary and evidence artifact."
+          exit 1
+
+  eslint-audit:
+    name: ESLint lane
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
       - name: Restore ESLint package cache
         id: eslint-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -100,10 +132,7 @@ jobs:
           key: toolkit-eslint-${{ runner.os }}-9.32.0
 
       - name: Install exact ESLint audit engine
-        shell: bash
-        run: |
-          set -euo pipefail
-          npm install --no-save --ignore-scripts --no-audit --no-fund eslint@9.32.0
+        run: npm install --no-save --ignore-scripts --no-audit --no-fund eslint@9.32.0
 
       - name: Save ESLint package cache
         if: steps.eslint-cache.outputs.cache-hit != 'true'
@@ -134,33 +163,22 @@ jobs:
           exit 0
 
       - name: Extract exact source evidence
-        shell: bash
         run: |
-          set -euo pipefail
           python3 .github/scripts/extract_userscript_audit_evidence.py \
             --source src/MissionChief_Map_Command_Toolkit.user.js \
             --eslint eslint-userscript-audit.json \
             --output userscript-audit-evidence.md
 
-      - name: Publish complete audit summary
+      - name: Publish ESLint audit summary
         if: always()
-        shell: bash
-        run: |
-          set -euo pipefail
-          cat full-userscript-audit.md >> "$GITHUB_STEP_SUMMARY"
-          printf '\n---\n\n' >> "$GITHUB_STEP_SUMMARY"
-          cat eslint-userscript-audit.md >> "$GITHUB_STEP_SUMMARY"
+        run: cat eslint-userscript-audit.md >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Upload complete audit evidence
+      - name: Upload ESLint audit evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: missionchief-toolkit-full-userscript-audit
+          name: missionchief-toolkit-eslint-audit
           path: |
-            full-userscript-audit-raw.json
-            full-userscript-audit-raw.md
-            full-userscript-audit.json
-            full-userscript-audit.md
             eslint-userscript-raw.json
             eslint-userscript-audit.json
             eslint-userscript-audit.md
@@ -168,11 +186,32 @@ jobs:
           if-no-files-found: error
           retention-days: 90
 
-      - name: Stop on definite audit failure
-        if: >-
-          steps.full_audit.outputs.exit_code != '0' ||
-          steps.refined_audit.outputs.exit_code != '0' ||
-          steps.eslint.outputs.summary_exit_code != '0'
+      - name: Stop on definite ESLint failure
+        if: steps.eslint.outputs.summary_exit_code != '0'
         run: |
-          echo "One or more definite deep-audit gates failed. Review the workflow summary and evidence artifact."
+          echo "The definite ESLint summary gate failed. Review the workflow summary and evidence artifact."
           exit 1
+
+  audit:
+    name: Audit complete canonical userscript
+    if: always()
+    needs:
+      - contracts
+      - static-audit
+      - eslint-audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Aggregate parallel audit lanes
+        env:
+          CONTRACT_RESULT: ${{ needs.contracts.result }}
+          STATIC_RESULT: ${{ needs.static-audit.result }}
+          ESLINT_RESULT: ${{ needs.eslint-audit.result }}
+        run: |
+          set -euo pipefail
+          printf 'Contract lane: %s\nStatic lane: %s\nESLint lane: %s\n' \
+            "$CONTRACT_RESULT" "$STATIC_RESULT" "$ESLINT_RESULT"
+          [[ "$CONTRACT_RESULT" == "success" ]]
+          [[ "$STATIC_RESULT" == "success" ]]
+          [[ "$ESLINT_RESULT" == "success" ]]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,9 +18,31 @@ The MissionChief Map Command Toolkit is maintained through reviewed, validated c
 - Keep public asset paths stable or update the asset-health policy in the same change.
 - Update user-facing documentation and changelog data when behaviour changes.
 
+## Routine delivery path
+
+Contained userscript changes should use the fastest safe route:
+
+1. Create one owner-authored `feature/`, `fix/` or `chore/` branch from current `main`.
+2. Complete the source, generated distribution, changelog and focused contract in that branch.
+3. Run the deterministic repository preflight:
+
+   ```bash
+   bash .github/scripts/run_userscript_preflight.sh --all
+   ```
+
+4. Open one pull request.
+5. Allow the targeted validation matrix and parallel Full Userscript Audit lanes to complete.
+6. Merge the exact reviewed head and use the permanent guarded release command when a public version is required.
+
+Do not create diagnostic pull requests or test-only commits when the required code and fixtures can be prepared and verified before the pull request is opened.
+
+## Reviewed development packages
+
+The owner-authorised development-package workflow remains available for large generated transformations, exact-source rewrites and changes that are safer to apply inside the repository runner. It is not the default route for small, contained edits.
+
 ## Validation
 
-Pull requests may run userscript validation, code-integrity auditing, performance-regression checks, asset-health checks and documentation-site validation. Do not bypass a failed check without identifying and correcting the underlying cause.
+Pull requests may run userscript validation, code-integrity auditing, performance-regression checks, asset-health checks and documentation-site validation. The Full Userscript Audit executes contract, static-analysis and ESLint lanes concurrently, then reports through one aggregate required check. Do not bypass a failed check without identifying and correcting the underlying cause.
 
 ## Releases
 


### PR DESCRIPTION
## What changed

- Added one deterministic userscript preflight command for routine changes.
- Split the Full Userscript Audit into three concurrent lanes: contracts/syntax, static analysis, and ESLint.
- Preserved the existing required check name through a final aggregate gate that fails if any lane fails.
- Kept superseded PR audit runs cancellable.
- Documented the direct owner-authored branch and PR route as the default for contained changes.
- Retained reviewed development packages for large generated transformations only.

## Safety

No validation, integrity, performance, release-readiness, recovery or publication safeguard is removed. This changes execution order and developer workflow only.

## Expected result

Routine userscript pull requests should spend less wall-clock time in the deep audit and avoid diagnostic/package/retrigger commits. This PR itself is the controlled proof of the optimised path.

No Toolkit version or public release is required.