### PR TITLE
Make GitHub Pages release deployment deterministic

### DIFF
--- a/.github/scripts/test_pages_monitor_reconciliation_contract.py
+++ b/.github/scripts/test_pages_monitor_reconciliation_contract.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Protect production incident reconciliation from pull-request preview runs."""
+"""Protect production incident reconciliation from previews and propagation races."""
 from __future__ import annotations
 
 from pathlib import Path
@@ -12,6 +12,13 @@ WORKFLOW = ROOT / ".github" / "workflows" / "pages-production-monitor.yml"
 def main() -> int:
     text = WORKFLOW.read_text(encoding="utf-8")
     required = [
+        "github.event_name != 'workflow_run' ||",
+        "github.event.workflow_run.event != 'pull_request'",
+        "github.event.workflow_run.conclusion == 'success'",
+        "MAX_ATTEMPTS:",
+        "github.event_name == 'workflow_run' || github.event_name == 'push'",
+        'for ATTEMPT in $(seq 1 "$MAX_ATTEMPTS")',
+        'sleep "$RETRY_SECONDS"',
         "github.event_name != 'pull_request'",
         "github.event_name != 'workflow_run' || github.event.workflow_run.event != 'pull_request'",
         ".github/scripts/test_pages_monitor_reconciliation_contract.py",
@@ -22,7 +29,15 @@ def main() -> int:
     assert "if: always() && github.event_name != 'pull_request'\n" not in text, (
         "Legacy reconciliation condition still permits workflow_run events from pull-request previews"
     )
-    print("Pages incident reconciliation contract passed: PR previews cannot mutate the production incident.")
+
+    health_index = text.index("Check live GitHub Pages deployment")
+    reconcile_index = text.index("Reconcile persistent incident")
+    assert health_index < reconcile_index, "Propagation-aware health retries must finish before incident reconciliation"
+
+    print(
+        "Pages monitor contract passed: preview/cancelled runs are ignored and successful deployments "
+        "receive a bounded propagation window before incident reconciliation."
+    )
     return 0
 
 

--- a/.github/scripts/test_pages_release_deploy_contract.py
+++ b/.github/scripts/test_pages_release_deploy_contract.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Static contract for verified release-driven GitHub Pages deployment."""
+"""Static contract for deterministic verified GitHub Pages deployment."""
 from __future__ import annotations
 
 from pathlib import Path
@@ -13,24 +13,39 @@ def main() -> int:
     text = WORKFLOW.read_text(encoding="utf-8")
     required = [
         "  release:\n    types:\n      - published",
-        "Wait for verified release dashboard",
+        "format('toolkit-pages-pr-{0}', github.event.pull_request.number)",
+        "'toolkit-pages-production'",
+        "cancel-in-progress: true",
+        "Resolve verified production source",
         "github.event.release.tag_name",
         "EXPECTED_TAG#v",
         "git fetch --no-tags --depth=1 origin main",
         "git reset --hard origin/main",
         "latestRelease.version // empty",
         "status.githubRelease // empty",
-        '[[ "$DASHBOARD_VERSION" == "$EXPECTED_VERSION" && "$RELEASE_STATE" == "published" ]]',
+        "status.greasyForkSync // empty",
+        '[[ -n "$EXPECTED_VERSION" && "$DASHBOARD_VERSION" == "$EXPECTED_VERSION" && "$RELEASE_STATE" == "published" && "$GREASY_FORK_STATE" == "verified" ]]',
+        "source_sha=$SOURCE_SHA",
+        'grep -Fq "${{ steps.production.outputs.release_version }}" _site/index.html',
         ".github/scripts/test_pages_release_deploy_contract.py",
     ]
     missing = [fragment for fragment in required if fragment not in text]
-    assert not missing, f"Pages release deployment contract fragments missing: {missing}"
+    assert not missing, f"Pages production deployment contract fragments missing: {missing}"
+    assert "group: toolkit-pages-${{" not in text, (
+        "Legacy event-specific production concurrency group still permits release/push deployment races"
+    )
 
-    wait_index = text.index("Wait for verified release dashboard")
+    resolve_index = text.index("Resolve verified production source")
     build_index = text.index("Build deployment site")
-    assert wait_index < build_index, "Verified release wait must run before the deployment build"
+    deploy_index = text.index("Deploy GitHub Pages")
+    assert resolve_index < build_index < deploy_index, (
+        "Verified production source must be resolved before building and deploying Pages"
+    )
 
-    print("Pages release deployment contract passed: published release waits for verified dashboard state before build.")
+    print(
+        "Pages deployment contract passed: all production events share one concurrency group "
+        "and build from verified current main state."
+    )
     return 0
 
 

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -40,8 +40,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: toolkit-pages-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.event_name == 'pull_request' && format('toolkit-pages-pr-{0}', github.event.pull_request.number) || 'toolkit-pages-production' }}
+  cancel-in-progress: true
 
 jobs:
   validate:
@@ -112,17 +112,17 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
-      - name: Check out repository
+      - name: Check out current production source
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
-          ref: ${{ github.event_name == 'release' && 'main' || github.sha }}
+          ref: main
           fetch-depth: 1
           persist-credentials: false
 
-      - name: Wait for verified release dashboard
-        if: github.event_name == 'release'
+      - name: Resolve verified production source
+        id: production
         env:
-          EXPECTED_TAG: ${{ github.event.release.tag_name }}
+          EXPECTED_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -132,14 +132,21 @@ jobs:
             git reset --hard origin/main
             DASHBOARD_VERSION="$(jq -r '.latestRelease.version // empty' status/release-dashboard.json)"
             RELEASE_STATE="$(jq -r '.status.githubRelease // empty' status/release-dashboard.json)"
-            if [[ "$DASHBOARD_VERSION" == "$EXPECTED_VERSION" && "$RELEASE_STATE" == "published" ]]; then
-              echo "Verified release dashboard reached ${EXPECTED_VERSION} on attempt ${ATTEMPT}."
+            GREASY_FORK_STATE="$(jq -r '.status.greasyForkSync // empty' status/release-dashboard.json)"
+            if [[ -z "$EXPECTED_VERSION" ]]; then
+              EXPECTED_VERSION="$DASHBOARD_VERSION"
+            fi
+            if [[ -n "$EXPECTED_VERSION" && "$DASHBOARD_VERSION" == "$EXPECTED_VERSION" && "$RELEASE_STATE" == "published" && "$GREASY_FORK_STATE" == "verified" ]]; then
+              SOURCE_SHA="$(git rev-parse HEAD)"
+              echo "release_version=$EXPECTED_VERSION" >> "$GITHUB_OUTPUT"
+              echo "source_sha=$SOURCE_SHA" >> "$GITHUB_OUTPUT"
+              echo "Deploying verified Toolkit ${EXPECTED_VERSION} from ${SOURCE_SHA}."
               exit 0
             fi
-            echo "Waiting for verified release ${EXPECTED_VERSION}; dashboard=${DASHBOARD_VERSION:-missing}, state=${RELEASE_STATE:-missing}."
+            echo "Waiting for verified production state ${EXPECTED_VERSION:-unknown}; dashboard=${DASHBOARD_VERSION:-missing}, GitHub=${RELEASE_STATE:-missing}, Greasy Fork=${GREASY_FORK_STATE:-missing}."
             sleep 15
           done
-          echo "::error::Release dashboard did not verify ${EXPECTED_VERSION} within 10 minutes."
+          echo "::error::Verified production state ${EXPECTED_VERSION:-unknown} was not available within 10 minutes."
           exit 1
 
       - name: Configure GitHub Pages
@@ -156,6 +163,9 @@ jobs:
           python3 .github/scripts/build_pages_site.py \
             --output _site \
             --base-path "$BASE_PATH"
+          grep -Fq "${{ steps.production.outputs.release_version }}" _site/index.html
+          echo "Pages source: ${{ steps.production.outputs.source_sha }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "Pages release: ${{ steps.production.outputs.release_version }}" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0

--- a/.github/workflows/pages-production-monitor.yml
+++ b/.github/workflows/pages-production-monitor.yml
@@ -43,6 +43,9 @@ concurrency:
 
 jobs:
   monitor:
+    if: >-
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.event != 'pull_request' && github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -66,11 +69,25 @@ jobs:
 
       - name: Check live GitHub Pages deployment
         id: health
+        env:
+          MAX_ATTEMPTS: ${{ (github.event_name == 'workflow_run' || github.event_name == 'push') && '16' || '1' }}
+          RETRY_SECONDS: "15"
         shell: bash
         run: |
           set +e
-          python3 .github/scripts/check_pages_live.py
-          STATUS=$?
+          STATUS=1
+          for ATTEMPT in $(seq 1 "$MAX_ATTEMPTS"); do
+            python3 .github/scripts/check_pages_live.py
+            STATUS=$?
+            if [[ "$STATUS" -eq 0 ]]; then
+              echo "Live Pages matched the verified release on attempt ${ATTEMPT}."
+              break
+            fi
+            if [[ "$ATTEMPT" -lt "$MAX_ATTEMPTS" ]]; then
+              echo "Pages propagation not complete on attempt ${ATTEMPT}; retrying in ${RETRY_SECONDS}s."
+              sleep "$RETRY_SECONDS"
+            fi
+          done
           echo "exit_code=$STATUS" >> "$GITHUB_OUTPUT"
           exit 0
 


### PR DESCRIPTION
Fixes the recurring Pages deployment race behind Issue #86.

- serialises all production Pages deployments in one concurrency group;
- rebuilds from current verified `main` state;
- requires published GitHub Release and verified Greasy Fork state;
- verifies the homepage contains the selected release version;
- ignores preview/cancelled workflow-run events;
- gives successful deployments a bounded propagation window before incident reconciliation.

Workflow and contract changes only. Issue #86 remains open until live monitoring confirms recovery.