### PR TITLE
Reconcile Pages health on release dashboard updates

### DIFF
--- a/.github/scripts/test_pages_monitor_version_contract.py
+++ b/.github/scripts/test_pages_monitor_version_contract.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import re
 import tempfile
 from pathlib import Path
 
@@ -11,6 +12,8 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 CHECKER_PATH = ROOT / ".github" / "scripts" / "check_pages_live.py"
 FIXTURE_PATH = ROOT / ".github" / "fixtures" / "pages-monitor-version-contract.json"
+WORKFLOW_PATH = ROOT / ".github" / "workflows" / "pages-production-monitor.yml"
+RELEASE_DASHBOARD_PATH = '      - "status/release-dashboard.json"'
 
 
 def load_checker():
@@ -20,6 +23,34 @@ def load_checker():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def event_block(workflow: str, event_name: str) -> str:
+    match = re.search(
+        rf"(?ms)^  {re.escape(event_name)}:\n(?P<body>.*?)(?=^  [A-Za-z_][A-Za-z0-9_-]*:|\Z)",
+        workflow,
+    )
+    if match is None:
+        raise AssertionError(f"Pages monitor workflow is missing the {event_name!r} trigger")
+    return match.group("body")
+
+
+def assert_workflow_trigger_contract() -> None:
+    workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+    push = event_block(workflow, "push")
+    pull_request = event_block(workflow, "pull_request")
+    workflow_run = event_block(workflow, "workflow_run")
+
+    assert RELEASE_DASHBOARD_PATH in push, (
+        "A verified release dashboard update must trigger the production monitor directly; "
+        "otherwise an existing incident can remain frozen on the previous expected version."
+    )
+    assert RELEASE_DASHBOARD_PATH in pull_request, (
+        "Pull requests that change the release dashboard must validate the monitor contract."
+    )
+    assert "GitHub Pages Documentation" in workflow_run, (
+        "The production monitor must also reconcile after the corresponding Pages deployment."
+    )
 
 
 def run_case(checker, item: dict) -> None:
@@ -62,13 +93,14 @@ def run_case(checker, item: dict) -> None:
 
 
 def main() -> int:
+    assert_workflow_trigger_contract()
     checker = load_checker()
     fixture = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
     for item in fixture["cases"]:
         run_case(checker, item)
     print(
         "Pages monitor version contract passed: "
-        f"{len(fixture['cases'])} published/candidate transition cases."
+        f"dashboard push trigger plus {len(fixture['cases'])} published/candidate transition cases."
     )
     return 0
 

--- a/.github/workflows/pages-production-monitor.yml
+++ b/.github/workflows/pages-production-monitor.yml
@@ -24,6 +24,7 @@ on:
       - ".github/scripts/test_pages_monitor_reconciliation_contract.py"
       - ".github/scripts/test_pages_monitor_version_contract.py"
       - ".github/workflows/pages-production-monitor.yml"
+      - "status/release-dashboard.json"
   workflow_run:
     workflows:
       - GitHub Pages Documentation


### PR DESCRIPTION
Adds the verified release dashboard to the production monitor's main-push triggers and protects that path with the existing version contract. No Toolkit runtime or release files change. Refs #86.