### PR TITLE
Add verified stable update-manifest pipeline for Issue #153

### DIFF
--- a/.github/actions-security-policy.json
+++ b/.github/actions-security-policy.json
@@ -17,6 +17,7 @@
     ".github/workflows/owner-release-command.yml": ["actions", "issues"],
     ".github/workflows/pages-production-monitor.yml": ["issues"],
     ".github/workflows/prepare-release-rollback.yml": ["contents", "issues", "pull-requests"],
+    ".github/workflows/publish-update-manifest.yml": ["contents"],
     ".github/workflows/reconcile-release-announcement-state.yml": ["contents"],
     ".github/workflows/release-recovery.yml": ["contents"],
     ".github/workflows/release-toolkit-dry-run.yml": ["contents"],

--- a/.github/workflows/publish-update-manifest.yml
+++ b/.github/workflows/publish-update-manifest.yml
@@ -1,0 +1,122 @@
+name: Publish Toolkit Update Manifest
+
+on:
+  workflow_run:
+    workflows:
+      - Release Toolkit
+    types:
+      - completed
+
+permissions:
+  contents: write
+
+concurrency:
+  group: toolkit-update-manifest
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out reconciled main
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Build manifest from verified release ledger
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          from __future__ import annotations
+
+          import json
+          import re
+          from pathlib import Path
+          from urllib.parse import urlparse
+
+          dashboard_path = Path('status/release-dashboard.json')
+          settings_path = Path('.github/release-settings.json')
+          manifest_path = Path('status/update-manifest.json')
+
+          dashboard = json.loads(dashboard_path.read_text(encoding='utf-8'))
+          settings = json.loads(settings_path.read_text(encoding='utf-8'))
+          latest = dashboard.get('latestRelease') or {}
+          status = dashboard.get('status') or {}
+
+          required_status = {
+              'validation': 'passed',
+              'githubRelease': 'published',
+              'greasyForkSync': 'verified',
+              'backup': 'private-repository-verified',
+              'discordRelease': 'posted',
+              'assetAudit': 'passed',
+              'releaseReadiness': 'passed',
+          }
+          for key, expected in required_status.items():
+              actual = status.get(key)
+              if actual != expected:
+                  raise SystemExit(f'Refusing manifest publication: {key}={actual!r}, expected {expected!r}.')
+
+          version = str(latest.get('version') or '').strip()
+          if not re.fullmatch(r'\d+\.\d+\.\d+', version):
+              raise SystemExit(f'Refusing manifest publication: invalid stable version {version!r}.')
+          if str(dashboard.get('currentVersion') or '') != version:
+              raise SystemExit('Refusing manifest publication: dashboard currentVersion is not the verified latest release.')
+          if latest.get('greasyForkVerified') is not True:
+              raise SystemExit('Refusing manifest publication: Greasy Fork is not verified.')
+          if latest.get('discordPosted') is not True:
+              raise SystemExit('Refusing manifest publication: Discord release is not recorded.')
+          if not str(latest.get('privateBackupCommit') or '').strip():
+              raise SystemExit('Refusing manifest publication: private backup commit is absent.')
+
+          release_url = str(latest.get('githubRelease') or '').strip()
+          release_parts = urlparse(release_url)
+          expected_path = f'/Conroy1988/missionchief-toolkit-assets/releases/tag/v{version}'
+          if release_parts.scheme != 'https' or release_parts.netloc != 'github.com' or release_parts.path != expected_path:
+              raise SystemExit('Refusing manifest publication: GitHub release URL is not canonical.')
+
+          update_url = str((settings.get('greasyFork') or {}).get('installUrl') or '').strip()
+          update_parts = urlparse(update_url)
+          if update_parts.scheme != 'https' or update_parts.netloc != 'update.greasyfork.org' or not update_parts.path.startswith('/scripts/586018/'):
+              raise SystemExit('Refusing manifest publication: Greasy Fork update URL is not canonical.')
+
+          published_at = str(latest.get('completedAt') or '').strip()
+          if not published_at:
+              raise SystemExit('Refusing manifest publication: verified completion time is absent.')
+
+          manifest = {
+              'schemaVersion': 1,
+              'channel': 'stable',
+              'version': version,
+              'releaseNotesUrl': release_url,
+              'updateUrl': update_url,
+              'publishedAt': published_at,
+              'sha256': str(latest.get('sha256') or '').strip(),
+          }
+          manifest_path.write_text(json.dumps(manifest, indent=2) + '\n', encoding='utf-8')
+          print(f'Prepared stable update manifest for Toolkit v{version}')
+          PY
+
+      - name: Commit verified stable manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- status/update-manifest.json; then
+            echo "Stable update manifest already matches the verified release."
+            exit 0
+          fi
+
+          VERSION="$(jq -r '.version' status/update-manifest.json)"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add status/update-manifest.json
+          git commit -m "Publish Toolkit ${VERSION} update manifest"
+          git pull --rebase origin main
+          git push origin HEAD:main

--- a/status/update-manifest.json
+++ b/status/update-manifest.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": 1,
+  "channel": "stable",
+  "version": "4.19.2",
+  "releaseNotesUrl": "https://github.com/Conroy1988/missionchief-toolkit-assets/releases/tag/v4.19.2",
+  "updateUrl": "https://update.greasyfork.org/scripts/586018/MissionChief%20Map%20Command%20Toolkit.user.js",
+  "publishedAt": "2026-07-19T13:08:02Z",
+  "sha256": "c43433fd6df8080cd951a3164b7f2523abb17201e3f2434c9cf18eabcd26c7df"
+}


### PR DESCRIPTION
Part 1 of Issue #153, rebuilt from the current `main` head.

Adds a repository-owned stable update manifest and a dedicated post-release workflow that republishes it only after the permanent `Release Toolkit` workflow completes successfully and the reconciled release dashboard proves GitHub Release, Greasy Fork, private backup, Discord, validation, asset audit and release readiness all passed.

The initial manifest is seeded from the verified v4.19.2 release ledger. This PR does not yet add the userscript map control and does not close #153.