### PR TITLE
Fix verified update-manifest dispatch after Toolkit releases

### DIFF
--- a/.github/scripts/test_version_status_contract.py
+++ b/.github/scripts/test_version_status_contract.py
@@ -10,6 +10,7 @@ ROOT = Path(__file__).resolve().parents[2]
 SOURCE = ROOT / "src" / "MissionChief_Map_Command_Toolkit.user.js"
 RUNTIME = ROOT / ".github" / "scripts" / "test_version_status_runtime.js"
 WORKFLOW = ROOT / ".github" / "workflows" / "publish-update-manifest.yml"
+RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release-toolkit.yml"
 MANIFEST = ROOT / "status" / "update-manifest.json"
 DASHBOARD = ROOT / "status" / "release-dashboard.json"
 
@@ -23,6 +24,7 @@ def semver(value: str) -> tuple[int, int, int]:
 def main() -> int:
     source = SOURCE.read_text(encoding="utf-8")
     workflow = WORKFLOW.read_text(encoding="utf-8")
+    release_workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
     manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
     dashboard = json.loads(DASHBOARD.read_text(encoding="utf-8"))
     start = source.index("    // Issue #153: stable live Toolkit version-status control.")
@@ -66,7 +68,9 @@ def main() -> int:
 
     for marker in [
         "workflow_run:",
+        "workflow_dispatch:",
         "- Release Toolkit",
+        "github.event_name == 'workflow_dispatch'",
         "github.event.workflow_run.conclusion == 'success'",
         "github.event.workflow_run.head_branch == 'main'",
         "Build manifest from verified release ledger",
@@ -79,10 +83,23 @@ def main() -> int:
     ]:
         assert marker in workflow, f"verified manifest workflow marker missing: {marker}"
     trigger_index = workflow.index("workflow_run:")
+    dispatch_index = workflow.index("workflow_dispatch:")
     build_index = workflow.index("Build manifest from verified release ledger")
     push_index = workflow.index("git push origin HEAD:main")
-    assert trigger_index < build_index < push_index, "manifest publication must follow successful release reconciliation"
+    assert trigger_index < dispatch_index < build_index < push_index, "manifest workflow triggers must precede verified publication"
 
+    for marker in [
+        "- name: Publish verified update manifest",
+        "gh workflow run publish-update-manifest.yml --ref main",
+        "gh run list --workflow publish-update-manifest.yml --event workflow_dispatch --branch main",
+        "gh run watch \"$RUN_ID\" --exit-status",
+        "MANIFEST_RUN_ID: ${{ steps.update_manifest.outputs.run_id }}",
+    ]:
+        assert marker in release_workflow, f"release workflow manifest dispatch marker missing: {marker}"
+    dashboard_index = release_workflow.index("- name: Record successful release in dashboard")
+    publish_index = release_workflow.index("- name: Publish verified update manifest")
+    pages_index = release_workflow.index("- name: Deploy verified documentation site")
+    assert dashboard_index < publish_index < pages_index, "manifest must publish after dashboard reconciliation and before release completion"
 
     result = subprocess.run(["node", str(RUNTIME)], cwd=ROOT)
     assert result.returncode == 0, "version status runtime fixtures failed"

--- a/.github/workflows/publish-update-manifest.yml
+++ b/.github/workflows/publish-update-manifest.yml
@@ -6,6 +6,7 @@ on:
       - Release Toolkit
     types:
       - completed
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -17,8 +18,9 @@ concurrency:
 jobs:
   publish:
     if: >-
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.head_branch == 'main'
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'main')
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/release-toolkit.yml
+++ b/.github/workflows/release-toolkit.yml
@@ -217,6 +217,28 @@ jobs:
           git pull --rebase origin main
           git push origin HEAD:main
 
+      - name: Publish verified update manifest
+        id: update_manifest
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ inputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          STARTED_AT="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+          gh workflow run publish-update-manifest.yml --ref main
+
+          RUN_ID=""
+          for attempt in $(seq 1 60); do
+            RUN_ID="$(gh run list --workflow publish-update-manifest.yml --event workflow_dispatch --branch main --limit 30 --json databaseId,createdAt -q "map(select(.createdAt >= \"${STARTED_AT}\")) | sort_by(.createdAt) | reverse | .[0].databaseId // empty")"
+            [[ -n "$RUN_ID" ]] && break
+            sleep 2
+          done
+          [[ -n "$RUN_ID" ]] || { echo "::error::The dispatched update-manifest run was not found."; exit 1; }
+          echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
+          echo "Waiting for update-manifest run ${RUN_ID} for Toolkit ${RELEASE_VERSION}."
+          gh run watch "$RUN_ID" --exit-status
+
       - name: Deploy verified documentation site
         id: pages_deploy
         env:
@@ -243,6 +265,7 @@ jobs:
         env:
           RELEASE_VERSION: ${{ inputs.version }}
           BACKUP_COMMIT: ${{ steps.private_backup.outputs.backup_commit }}
+          MANIFEST_RUN_ID: ${{ steps.update_manifest.outputs.run_id }}
           PAGES_RUN_ID: ${{ steps.pages_deploy.outputs.run_id }}
         shell: bash
         run: |
@@ -259,5 +282,6 @@ jobs:
             echo "- ✅ Private migration backup committed: ${BACKUP_COMMIT}"
             echo "- ✅ Discord release announcement posted"
             echo "- ✅ Release dashboard and generated control panel updated"
+            echo "- ✅ Stable update manifest published: ${MANIFEST_RUN_ID}"
             echo "- ✅ GitHub Pages deployment completed: ${PAGES_RUN_ID}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/validate-userscript.yml
+++ b/.github/workflows/validate-userscript.yml
@@ -7,8 +7,12 @@ on:
       - "CHANGELOG.md"
       - ".github/scripts/validate_userscript.py"
       - ".github/scripts/reconcile_validation_dashboard.py"
+      - ".github/scripts/test_version_status_contract.py"
+      - ".github/workflows/publish-update-manifest.yml"
+      - ".github/workflows/release-toolkit.yml"
       - ".github/workflows/validate-userscript.yml"
       - "status/source-baseline.json"
+      - "status/update-manifest.json"
   push:
     branches:
       - main
@@ -17,8 +21,12 @@ on:
       - "CHANGELOG.md"
       - ".github/scripts/validate_userscript.py"
       - ".github/scripts/reconcile_validation_dashboard.py"
+      - ".github/scripts/test_version_status_contract.py"
+      - ".github/workflows/publish-update-manifest.yml"
+      - ".github/workflows/release-toolkit.yml"
       - ".github/workflows/validate-userscript.yml"
       - "status/source-baseline.json"
+      - "status/update-manifest.json"
   workflow_dispatch:
 
 permissions:

--- a/status/update-manifest.json
+++ b/status/update-manifest.json
@@ -1,9 +1,9 @@
 {
   "schemaVersion": 1,
   "channel": "stable",
-  "version": "4.19.2",
-  "releaseNotesUrl": "https://github.com/Conroy1988/missionchief-toolkit-assets/releases/tag/v4.19.2",
+  "version": "4.20.0",
+  "releaseNotesUrl": "https://github.com/Conroy1988/missionchief-toolkit-assets/releases/tag/v4.20.0",
   "updateUrl": "https://update.greasyfork.org/scripts/586018/MissionChief%20Map%20Command%20Toolkit.user.js",
-  "publishedAt": "2026-07-19T13:08:02Z",
-  "sha256": "c43433fd6df8080cd951a3164b7f2523abb17201e3f2434c9cf18eabcd26c7df"
+  "publishedAt": "2026-07-19T14:43:35Z",
+  "sha256": "a6513e94e7ef526446785d543a329b55d34e1f1761c9608f017050830286546f"
 }


### PR DESCRIPTION
Closes #198.

The original `workflow_run` trigger created zero runs after the verified v4.20.0 production workflow, leaving the stable update manifest on v4.19.2.

This correction:

- retains `workflow_run` as a fallback;
- adds explicit `workflow_dispatch` support;
- dispatches and watches the manifest workflow from `Release Toolkit` immediately after the verified dashboard is committed;
- fails the production workflow if the manifest run cannot be found or does not succeed;
- reconciles the current manifest to the already verified v4.20.0 release;
- extends the version-status contract to require the explicit dispatch-and-watch path.

Verified release evidence is recorded in #198.