### PR TITLE
Redesign Discord release announcements

### DIFF
--- a/.github/scripts/build_discord_release_payload.py
+++ b/.github/scripts/build_discord_release_payload.py
@@ -19,15 +19,28 @@ SECTION_ICONS = {
     "removed": "🗑️",
 }
 
-MAX_SECTIONS = 3
-MAX_ITEMS = 6
-MAX_ITEM_LENGTH = 220
-MAX_BRIEF_LENGTH = 1000
+SECTION_PRIORITY = {
+    "security": 0,
+    "fixed": 1,
+    "added": 2,
+    "changed": 3,
+    "performance": 4,
+    "removed": 5,
+    "distribution": 6,
+    "baseline": 7,
+}
+
+MAX_SECTIONS = 2
+MAX_ITEMS = 4
+MAX_ITEM_LENGTH = 165
+MAX_BRIEF_LENGTH = 760
 
 
 def clean_text(value: str) -> str:
     value = re.sub(r"`([^`]+)`", r"\1", value)
+    value = re.sub(r"!\[[^\]]*\]\([^)]+\)", "", value)
     value = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", value)
+    value = re.sub(r"<[^>]+>", " ", value)
     value = re.sub(r"[*_~]+", "", value)
     value = re.sub(r"\s+", " ", value).strip()
     return value
@@ -41,10 +54,10 @@ def shorten(value: str, limit: int) -> str:
 
 
 def parse_changelog(path: Path) -> str:
-    sections: list[tuple[str, list[str]]] = []
+    sections: list[tuple[str, list[str], int]] = []
     current_name = "Release"
     current_items: list[str] = []
-    total_items = 0
+    source_order = 0
 
     for raw_line in path.read_text(encoding="utf-8").splitlines():
         line = raw_line.strip()
@@ -56,44 +69,62 @@ def parse_changelog(path: Path) -> str:
         heading = re.match(r"^#{3,6}\s+(.+?)\s*$", line)
         if heading:
             if current_items:
-                sections.append((current_name, current_items))
+                sections.append((current_name, current_items, source_order))
+                source_order += 1
             current_name = clean_text(heading.group(1)) or "Release"
             current_items = []
             continue
 
         bullet = re.match(r"^(?:[-*•]|(?:\d+\.))\s+(.+?)\s*$", line)
         if bullet:
-            total_items += 1
             current_items.append(shorten(bullet.group(1), MAX_ITEM_LENGTH))
             continue
 
         if current_items:
-            current_items[-1] = shorten(f"{current_items[-1]} {line}", MAX_ITEM_LENGTH)
+            current_items[-1] = shorten(
+                f"{current_items[-1]} {line}",
+                MAX_ITEM_LENGTH,
+            )
 
     if current_items:
-        sections.append((current_name, current_items))
+        sections.append((current_name, current_items, source_order))
 
     if not sections:
-        fallback = shorten(path.read_text(encoding="utf-8"), 800)
-        return fallback or "Release notes are available from the linked release page."
+        fallback = shorten(path.read_text(encoding="utf-8"), 520)
+        return fallback or "Open the release notes for the complete change list."
+
+    total_items = sum(len(items) for _, items, _ in sections)
+    ranked = sorted(
+        sections,
+        key=lambda entry: (
+            SECTION_PRIORITY.get(entry[0].casefold(), 99),
+            entry[2],
+        ),
+    )
 
     rendered: list[str] = []
     used_items = 0
-    for name, items in sections[:MAX_SECTIONS]:
-        if used_items >= MAX_ITEMS:
+    used_sections = 0
+
+    for name, items, _ in ranked:
+        if used_sections >= MAX_SECTIONS or used_items >= MAX_ITEMS:
             break
+
+        available = MAX_ITEMS - used_items
+        selected_items = items[:available]
+        if not selected_items:
+            continue
+
         icon = SECTION_ICONS.get(name.casefold(), "◆")
-        rendered.append(f"**{icon} {name.upper()}**")
-        for item in items:
-            if used_items >= MAX_ITEMS:
-                break
-            rendered.append(f"▸ {item}")
-            used_items += 1
+        rendered.append(f"**{icon} {name.title()}**")
+        rendered.extend(f"• {item}" for item in selected_items)
+        used_items += len(selected_items)
+        used_sections += 1
 
     omitted = max(0, total_items - used_items)
     if omitted:
         suffix = "s" if omitted != 1 else ""
-        rendered.append(f"*+ {omitted} additional change{suffix} in the full release notes.*")
+        rendered.append(f"*{omitted} more change{suffix} in the full release notes.*")
 
     brief = "\n".join(rendered)
     if len(brief) > MAX_BRIEF_LENGTH:
@@ -101,69 +132,87 @@ def parse_changelog(path: Path) -> str:
     return brief
 
 
-def short_hash(value: str) -> str:
+def short_hash(value: str, head: int = 8, tail: int = 6) -> str:
     value = value.strip()
-    if len(value) <= 20:
+    if len(value) <= head + tail + 1:
         return value
-    return f"{value[:10]}…{value[-8:]}"
+    return f"{value[:head]}…{value[-tail:]}"
 
 
 def utc_timestamp() -> str:
-    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace(
+        "+00:00",
+        "Z",
+    )
 
 
 def build_primary(args: argparse.Namespace, brief: str) -> dict:
+    integrity = (
+        f"SHA-256 `{short_hash(args.sha256)}`\n"
+        f"Backup `{args.backup_commit[:10]}`"
+    )
+
     return {
         "username": "MissionChief Toolkit Releases",
         "allowed_mentions": {"parse": []},
-        "embeds": [{
-            "author": {"name": "MISSION CONTROL // RELEASE OPERATIONS"},
-            "title": f"🚨 TOOLKIT DEPLOYMENT COMPLETE // v{args.version}",
-            "description": (
-                "**STATUS: LIVE**\n"
-                "The latest command package has cleared every release gate and is now active on Greasy Fork."
-            ),
-            "url": args.release_url,
-            "color": 0x00AEEF,
-            "fields": [
-                {
-                    "name": "🚀 DEPLOYMENT",
-                    "value": f"**v{args.version}**\nPublic release live",
-                    "inline": True,
+        "embeds": [
+            {
+                "author": {
+                    "name": "MissionChief Map Command Toolkit",
+                    "url": args.release_url,
                 },
-                {
-                    "name": "🛡️ VERIFICATION",
-                    "value": "GitHub ✅\nGreasy Fork ✅",
-                    "inline": True,
+                "title": f"✅ Toolkit v{args.version} is live",
+                "description": (
+                    "The verified update is available now on Greasy Fork.\n"
+                    "**Update to receive the latest fixes and improvements.**"
+                ),
+                "url": args.release_url,
+                "color": 0x2ECC71,
+                "fields": [
+                    {
+                        "name": "Release",
+                        "value": (
+                            f"**v{args.version}**\n"
+                            f"[Public release]({args.release_url})"
+                        ),
+                        "inline": True,
+                    },
+                    {
+                        "name": "Availability",
+                        "value": "Greasy Fork ✅\nInstall source ✅",
+                        "inline": True,
+                    },
+                    {
+                        "name": "Verification",
+                        "value": "GitHub ✅\nPrivate backup ✅",
+                        "inline": True,
+                    },
+                    {
+                        "name": "What changed",
+                        "value": brief,
+                        "inline": False,
+                    },
+                    {
+                        "name": "Release integrity",
+                        "value": integrity,
+                        "inline": False,
+                    },
+                    {
+                        "name": "Update now",
+                        "value": (
+                            f"**[⬇️ Install / Update]({args.install_url})**"
+                            f"  •  [Release notes]({args.release_url})"
+                            f"  •  [Greasy Fork page]({args.script_url})"
+                        ),
+                        "inline": False,
+                    },
+                ],
+                "footer": {
+                    "text": "Verified deployment • MissionChief Toolkit",
                 },
-                {
-                    "name": "💾 RECOVERY",
-                    "value": f"Private archive ✅\n`{args.backup_commit[:10]}`",
-                    "inline": True,
-                },
-                {
-                    "name": "⚙️ MISSION BRIEF",
-                    "value": brief,
-                    "inline": False,
-                },
-                {
-                    "name": "🔐 BUILD SIGNATURE",
-                    "value": f"`{short_hash(args.sha256)}`",
-                    "inline": False,
-                },
-                {
-                    "name": "🔗 COMMAND LINKS",
-                    "value": (
-                        f"[⬇️ Install / Update]({args.install_url})"
-                        f"  •  [📋 Full Release]({args.release_url})"
-                        f"  •  [🛠️ Greasy Fork]({args.script_url})"
-                    ),
-                    "inline": False,
-                },
-            ],
-            "footer": {"text": "MISSIONCHIEF MAP COMMAND TOOLKIT • VERIFIED DEPLOYMENT"},
-            "timestamp": utc_timestamp(),
-        }],
+                "timestamp": utc_timestamp(),
+            }
+        ],
     }
 
 
@@ -171,52 +220,60 @@ def build_fallback(args: argparse.Namespace, brief: str) -> dict:
     history_url = args.history_url or f"{args.script_url.rstrip('/')}/versions"
     previous = args.previous_version or "unknown"
     previous_label = f"v{previous}" if previous != "unknown" else "Unknown"
+
     return {
         "username": "MissionChief Toolkit Releases",
         "allowed_mentions": {"parse": []},
-        "embeds": [{
-            "author": {"name": "MISSION CONTROL // RELEASE SIGNAL"},
-            "title": f"📡 TOOLKIT RELEASE SIGNAL ACQUIRED // v{args.version}",
-            "description": (
-                "**STATUS: LIVE ON GREASY FORK**\n"
-                "The fallback monitor detected a public version that had not yet been announced."
-            ),
-            "url": args.script_url,
-            "color": 0xF0A500,
-            "fields": [
-                {
-                    "name": "⏮️ PREVIOUS",
-                    "value": f"`{previous_label}`",
-                    "inline": True,
+        "embeds": [
+            {
+                "author": {
+                    "name": "MissionChief Map Command Toolkit",
+                    "url": args.script_url,
                 },
-                {
-                    "name": "🚀 NOW LIVE",
-                    "value": f"**v{args.version}**",
-                    "inline": True,
+                "title": f"📡 Toolkit v{args.version} detected on Greasy Fork",
+                "description": (
+                    "The public version changed before the standard release "
+                    "announcement completed. The update is available now."
+                ),
+                "url": args.script_url,
+                "color": 0xF39C12,
+                "fields": [
+                    {
+                        "name": "Version change",
+                        "value": f"`{previous_label}` → **v{args.version}**",
+                        "inline": True,
+                    },
+                    {
+                        "name": "Source",
+                        "value": "Greasy Fork ✅",
+                        "inline": True,
+                    },
+                    {
+                        "name": "Status",
+                        "value": "Fallback notice",
+                        "inline": True,
+                    },
+                    {
+                        "name": "What changed",
+                        "value": brief,
+                        "inline": False,
+                    },
+                    {
+                        "name": "Update now",
+                        "value": (
+                            f"**[⬇️ Install / Update]({args.install_url})**"
+                            f"  •  [Version history]({history_url})"
+                            f"  •  [Greasy Fork page]({args.script_url})"
+                        ),
+                        "inline": False,
+                    },
+                ],
+                "footer": {
+                    "text": "Fallback release signal • MissionChief Toolkit",
                 },
-                {
-                    "name": "📡 SOURCE",
-                    "value": "Greasy Fork ✅",
-                    "inline": True,
-                },
-                {
-                    "name": "⚙️ MISSION BRIEF",
-                    "value": brief,
-                    "inline": False,
-                },
-                {
-                    "name": "🔗 COMMAND LINKS",
-                    "value": (
-                        f"[⬇️ Install / Update]({args.install_url})"
-                        f"  •  [📜 Version History]({history_url})"
-                        f"  •  [🛠️ Greasy Fork]({args.script_url})"
-                    ),
-                    "inline": False,
-                },
-            ],
-            "footer": {"text": "MISSIONCHIEF MAP COMMAND TOOLKIT • FALLBACK RELEASE SIGNAL"},
-            "timestamp": utc_timestamp(),
-        }],
+                "timestamp": utc_timestamp(),
+            }
+        ],
     }
 
 
@@ -225,18 +282,45 @@ def validate_payload(payload: dict) -> None:
     if len(encoded.encode("utf-8")) > 20_000:
         raise SystemExit("Discord payload is unexpectedly large.")
 
-    embed = payload["embeds"][0]
+    embeds = payload.get("embeds", [])
+    if len(embeds) != 1:
+        raise SystemExit("Expected exactly one Discord embed.")
+
+    embed = embeds[0]
     if len(embed.get("title", "")) > 256:
         raise SystemExit("Discord embed title exceeds 256 characters.")
+    if len(embed.get("description", "")) > 4096:
+        raise SystemExit("Discord embed description exceeds 4096 characters.")
+    if len(embed.get("fields", [])) > 25:
+        raise SystemExit("Discord embed contains more than 25 fields.")
+
+    total_characters = (
+        len(embed.get("title", ""))
+        + len(embed.get("description", ""))
+        + len(embed.get("author", {}).get("name", ""))
+        + len(embed.get("footer", {}).get("text", ""))
+    )
 
     for field in embed.get("fields", []):
-        if len(field["name"]) > 256 or len(field["value"]) > 1024:
-            raise SystemExit(f"Discord embed field exceeds limits: {field['name']}")
+        name = field.get("name", "")
+        value = field.get("value", "")
+        if len(name) > 256 or len(value) > 1024:
+            raise SystemExit(f"Discord embed field exceeds limits: {name}")
+        total_characters += len(name) + len(value)
+
+    if total_characters > 6000:
+        raise SystemExit("Discord embed exceeds the 6000-character total limit.")
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Build a styled Discord Toolkit release embed.")
-    parser.add_argument("--mode", choices=("primary", "fallback"), required=True)
+    parser = argparse.ArgumentParser(
+        description="Build a styled Discord Toolkit release embed.",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=("primary", "fallback"),
+        required=True,
+    )
     parser.add_argument("--version", required=True)
     parser.add_argument("--changelog", type=Path, required=True)
     parser.add_argument("--output", type=Path, required=True)
@@ -254,19 +338,30 @@ def main() -> int:
 
     if args.mode == "primary":
         missing = [
-            name for name, value in (
+            name
+            for name, value in (
                 ("release URL", args.release_url),
                 ("SHA-256", args.sha256),
                 ("backup commit", args.backup_commit),
-            ) if not value
+            )
+            if not value
         ]
         if missing:
-            raise SystemExit("Missing primary release values: " + ", ".join(missing))
+            raise SystemExit(
+                "Missing primary release values: " + ", ".join(missing),
+            )
 
     brief = parse_changelog(args.changelog)
-    payload = build_primary(args, brief) if args.mode == "primary" else build_fallback(args, brief)
+    if args.mode == "primary":
+        payload = build_primary(args, brief)
+    else:
+        payload = build_fallback(args, brief)
+
     validate_payload(payload)
-    args.output.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    args.output.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
     print(f"Built {args.mode} Discord release payload: {args.output}")
     return 0
 

--- a/.github/scripts/test_discord_release_payload.py
+++ b/.github/scripts/test_discord_release_payload.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).with_name("build_discord_release_payload.py")
+SPEC = importlib.util.spec_from_file_location("discord_release_payload", SCRIPT_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError("Unable to load Discord release payload builder.")
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class DiscordReleasePayloadTests(unittest.TestCase):
+    def make_changelog(self, content: str) -> Path:
+        directory = Path(tempfile.mkdtemp())
+        changelog = directory / "CHANGELOG.md"
+        changelog.write_text(content, encoding="utf-8")
+        self.addCleanup(lambda: changelog.unlink(missing_ok=True))
+        self.addCleanup(lambda: directory.rmdir())
+        return changelog
+
+    @staticmethod
+    def make_args() -> argparse.Namespace:
+        return argparse.Namespace(
+            version="4.20.22",
+            release_url="https://github.com/example/toolkit/releases/tag/v4.20.22",
+            script_url="https://greasyfork.org/scripts/123-toolkit",
+            install_url="https://greasyfork.org/scripts/123-toolkit/code/toolkit.user.js",
+            history_url="https://greasyfork.org/scripts/123-toolkit/versions",
+            previous_version="4.20.21",
+            sha256="57b89188ab780a36dc1234567890abcdefabcdefabcdefabcdefabcdefabcd",
+            backup_commit="6e81faa47f1234567890abcdef1234567890abcd",
+        )
+
+    def test_changelog_prioritises_user_facing_sections_and_limits_items(self) -> None:
+        changelog = self.make_changelog(
+            """# Toolkit v4.20.22
+### Distribution
+- Rebuilt public assets.
+### Fixed
+- Fixed firefighter capacity reconciliation.
+- Fixed Police Sergeant responding counts.
+- Fixed Police Inspector selected counts.
+- Fixed Railway Police responding counts.
+- Fixed BASU capability resolution.
+### Added
+- Added another feature.
+"""
+        )
+
+        brief = MODULE.parse_changelog(changelog)
+
+        self.assertTrue(brief.startswith("**🛠️ Fixed**"))
+        self.assertEqual(brief.count("\n• "), 4)
+        self.assertIn("2 more changes", brief)
+        self.assertNotIn("Rebuilt public assets", brief)
+        self.assertLessEqual(len(brief), MODULE.MAX_BRIEF_LENGTH)
+
+    def test_primary_payload_is_compact_and_valid(self) -> None:
+        args = self.make_args()
+        payload = MODULE.build_primary(args, "**🛠️ Fixed**\n• Corrected Matrix counts.")
+
+        MODULE.validate_payload(payload)
+        embed = payload["embeds"][0]
+
+        self.assertEqual(embed["title"], "✅ Toolkit v4.20.22 is live")
+        self.assertEqual(len(embed["fields"]), 6)
+        self.assertEqual(embed["fields"][3]["name"], "What changed")
+        self.assertIn("Install / Update", embed["fields"][-1]["value"])
+        self.assertNotIn("MISSION CONTROL", str(payload))
+
+    def test_fallback_payload_remains_visually_distinct(self) -> None:
+        args = self.make_args()
+        payload = MODULE.build_fallback(args, "**🛠️ Fixed**\n• Corrected Matrix counts.")
+
+        MODULE.validate_payload(payload)
+        embed = payload["embeds"][0]
+
+        self.assertIn("detected on Greasy Fork", embed["title"])
+        self.assertEqual(embed["color"], 0xF39C12)
+        self.assertIn("v4.20.21", embed["fields"][0]["value"])
+        self.assertIn("v4.20.22", embed["fields"][0]["value"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_discord_release_payload.py
+++ b/.github/scripts/test_discord_release_payload.py
@@ -21,8 +21,8 @@ class DiscordReleasePayloadTests(unittest.TestCase):
         directory = Path(tempfile.mkdtemp())
         changelog = directory / "CHANGELOG.md"
         changelog.write_text(content, encoding="utf-8")
-        self.addCleanup(lambda: changelog.unlink(missing_ok=True))
         self.addCleanup(lambda: directory.rmdir())
+        self.addCleanup(lambda: changelog.unlink(missing_ok=True))
         return changelog
 
     @staticmethod
@@ -58,7 +58,7 @@ class DiscordReleasePayloadTests(unittest.TestCase):
 
         self.assertTrue(brief.startswith("**🛠️ Fixed**"))
         self.assertEqual(brief.count("\n• "), 4)
-        self.assertIn("2 more changes", brief)
+        self.assertIn("3 more changes", brief)
         self.assertNotIn("Rebuilt public assets", brief)
         self.assertLessEqual(len(brief), MODULE.MAX_BRIEF_LENGTH)
 


### PR DESCRIPTION
## Summary

Redesigns the verified Toolkit release notification so the Discord card is easier to scan and gives the update action proper visual priority.

### Changes

- Replaces the dense all-caps command-centre presentation with a cleaner `Toolkit vX is live` release card.
- Reduces the changelog preview from six long entries to four shorter, priority-ranked user-facing changes.
- Prioritises Security, Fixed, Added, Changed and Performance sections over distribution/internal release notes.
- Uses three compact top-level fields for release, availability and verification.
- Compresses the SHA-256 and private-backup identifiers into one integrity field.
- Makes **Install / Update** the primary call to action.
- Keeps release notes and the Greasy Fork page immediately accessible.
- Redesigns the fallback Greasy Fork monitor card to match while remaining visually distinct.
- Expands Discord validation to enforce the one-embed contract and the 6,000-character aggregate embed limit.
- Adds focused contract tests for changelog prioritisation, primary releases and fallback releases.

### Release impact

Repository automation only. No public Toolkit userscript release is required.