### PR TITLE
Rebuild Discord release announcements as epic deployment transmissions

### DIFF
--- a/.github/scripts/build_discord_release_payload.py
+++ b/.github/scripts/build_discord_release_payload.py
@@ -32,8 +32,8 @@ SECTION_PRIORITY = {
 
 MAX_SECTIONS = 2
 MAX_ITEMS = 4
-MAX_ITEM_LENGTH = 165
-MAX_BRIEF_LENGTH = 760
+MAX_ITEM_LENGTH = 150
+MAX_BRIEF_LENGTH = 820
 
 
 def clean_text(value: str) -> str:
@@ -116,15 +116,16 @@ def parse_changelog(path: Path) -> str:
             continue
 
         icon = SECTION_ICONS.get(name.casefold(), "◆")
-        rendered.append(f"**{icon} {name.title()}**")
-        rendered.extend(f"• {item}" for item in selected_items)
-        used_items += len(selected_items)
+        rendered.append(f"**{icon} {name.upper()}**")
+        for item in selected_items:
+            used_items += 1
+            rendered.append(f"> **{used_items:02d}**  {item}")
         used_sections += 1
 
     omitted = max(0, total_items - used_items)
     if omitted:
         suffix = "s" if omitted != 1 else ""
-        rendered.append(f"*{omitted} more change{suffix} in the full release notes.*")
+        rendered.append(f"*+{omitted} additional change{suffix} in the full release notes.*")
 
     brief = "\n".join(rendered)
     if len(brief) > MAX_BRIEF_LENGTH:
@@ -147,133 +148,144 @@ def utc_timestamp() -> str:
 
 
 def build_primary(args: argparse.Namespace, brief: str) -> dict:
-    integrity = (
-        f"SHA-256 `{short_hash(args.sha256)}`\n"
-        f"Backup `{args.backup_commit[:10]}`"
-    )
+    hero = {
+        "author": {
+            "name": "MISSIONCHIEF // MAP COMMAND TOOLKIT",
+            "url": args.release_url,
+        },
+        "title": f"🚨 DEPLOYMENT CONFIRMED // v{args.version}",
+        "description": (
+            "**THE NEW BUILD IS LIVE**\n"
+            "Greasy Fork has published and verified the latest Toolkit package.\n\n"
+            f"**[⬇️  INSTALL / UPDATE TO v{args.version}]({args.install_url})**\n\n"
+            "`LIVE`  `VERIFIED`  `RECOVERABLE`"
+        ),
+        "url": args.release_url,
+        "color": 0xE11D48,
+        "fields": [
+            {
+                "name": "PUBLIC CHANNEL",
+                "value": "Greasy Fork\n**SYNCED** ✅",
+                "inline": True,
+            },
+            {
+                "name": "RELEASE GATE",
+                "value": "GitHub + backup\n**PASSED** ✅",
+                "inline": True,
+            },
+            {
+                "name": "BUILD ID",
+                "value": f"`{short_hash(args.sha256, 10, 8)}`",
+                "inline": True,
+            },
+        ],
+        "footer": {
+            "text": "Verified public deployment • MissionChief Toolkit",
+        },
+        "timestamp": utc_timestamp(),
+    }
+
+    intelligence = {
+        "title": "⚡ RELEASE INTELLIGENCE",
+        "description": brief,
+        "url": args.release_url,
+        "color": 0x00AEEF,
+        "fields": [
+            {
+                "name": "MISSION LINKS",
+                "value": (
+                    f"[Full release]({args.release_url})"
+                    f"  •  [Greasy Fork]({args.script_url})"
+                    f"  •  **[Install now]({args.install_url})**"
+                ),
+                "inline": False,
+            },
+            {
+                "name": "RECOVERY MARKER",
+                "value": f"Private archive `{args.backup_commit[:10]}`",
+                "inline": False,
+            },
+        ],
+        "footer": {
+            "text": "Release brief • User-facing changes only",
+        },
+    }
 
     return {
         "username": "MissionChief Toolkit Releases",
         "allowed_mentions": {"parse": []},
-        "embeds": [
-            {
-                "author": {
-                    "name": "MissionChief Map Command Toolkit",
-                    "url": args.release_url,
-                },
-                "title": f"✅ Toolkit v{args.version} is live",
-                "description": (
-                    "The verified update is available now on Greasy Fork.\n"
-                    "**Update to receive the latest fixes and improvements.**"
-                ),
-                "url": args.release_url,
-                "color": 0x2ECC71,
-                "fields": [
-                    {
-                        "name": "Release",
-                        "value": (
-                            f"**v{args.version}**\n"
-                            f"[Public release]({args.release_url})"
-                        ),
-                        "inline": True,
-                    },
-                    {
-                        "name": "Availability",
-                        "value": "Greasy Fork ✅\nInstall source ✅",
-                        "inline": True,
-                    },
-                    {
-                        "name": "Verification",
-                        "value": "GitHub ✅\nPrivate backup ✅",
-                        "inline": True,
-                    },
-                    {
-                        "name": "What changed",
-                        "value": brief,
-                        "inline": False,
-                    },
-                    {
-                        "name": "Release integrity",
-                        "value": integrity,
-                        "inline": False,
-                    },
-                    {
-                        "name": "Update now",
-                        "value": (
-                            f"**[⬇️ Install / Update]({args.install_url})**"
-                            f"  •  [Release notes]({args.release_url})"
-                            f"  •  [Greasy Fork page]({args.script_url})"
-                        ),
-                        "inline": False,
-                    },
-                ],
-                "footer": {
-                    "text": "Verified deployment • MissionChief Toolkit",
-                },
-                "timestamp": utc_timestamp(),
-            }
-        ],
+        "embeds": [hero, intelligence],
     }
 
 
 def build_fallback(args: argparse.Namespace, brief: str) -> dict:
-    history_url = args.history_url or f"{args.script_url.rstrip('/')}/versions"
+    history_url = args.history_url or f"{Args.script_url.rstrip('/')}/versions"
     previous = args.previous_version or "unknown"
     previous_label = f"v{previous}" if previous != "unknown" else "Unknown"
+
+    hero = {
+        "author": {
+            "name": "MISSIONCHIEF // RELEASE WATCH",
+            "url": args.script_url,
+        },
+        "title": f"📡 PUBLIC VERSION DETECTED // v{args.version}",
+        "description": (
+            "**FALLBACK RELEASE SIGNAL**\n"
+            "Greasy Fork published a new public version before the normal release "
+            "announcement completed.\n\n"
+            f"**[⬇️  INSTALL / UPDATE TO v{args.version}]({args.install_url})**\n\n"
+            f"`{previous_label}`  →  `v{args.version}`"
+        ),
+        "url": args.script_url,
+        "color": 0xF59E0B,
+        "fields": [
+            {
+                "name": "SOURCE",
+                "value": "Greasy Fork\n**LIVE** ✅",
+                "inline": True,
+            },
+            {
+                "name": "SIGNAL",
+                "value": "Fallback monitor\n**CONFIRMED**",
+                "inline": True,
+            },
+            {
+                "name": "VERSION",
+                "value": f"**v{args.version}**",
+                "inline": True,
+            },
+        ],
+        "footer": {
+            "text": "Fallback release signal • MissionChief Toolkit",
+        },
+        "timestamp": utc_timestamp(),
+    }
+
+    intelligence = {
+        "title": "⚡ RELEASE INTELLIGENCE",
+        "description": brief,
+        "url": history_url,
+        "color": 0xD97706,
+        "fields": [
+            {
+                "name": "MISSION LINKS",
+                "value": (
+                    f"[Version history]({history_url})"
+                    f"  •  [Greasy Fork]({args.script_url})"
+                    f"  •  **[Install now]({args.install_url})**"
+                ),
+                "inline": False,
+            },
+        ],
+        "footer": {
+            "text": "Fallback brief • Standard release verification may still be running",
+        },
+    }
 
     return {
         "username": "MissionChief Toolkit Releases",
         "allowed_mentions": {"parse": []},
-        "embeds": [
-            {
-                "author": {
-                    "name": "MissionChief Map Command Toolkit",
-                    "url": args.script_url,
-                },
-                "title": f"📡 Toolkit v{args.version} detected on Greasy Fork",
-                "description": (
-                    "The public version changed before the standard release "
-                    "announcement completed. The update is available now."
-                ),
-                "url": args.script_url,
-                "color": 0xF39C12,
-                "fields": [
-                    {
-                        "name": "Version change",
-                        "value": f"`{previous_label}` → **v{args.version}**",
-                        "inline": True,
-                    },
-                    {
-                        "name": "Source",
-                        "value": "Greasy Fork ✅",
-                        "inline": True,
-                    },
-                    {
-                        "name": "Status",
-                        "value": "Fallback notice",
-                        "inline": True,
-                    },
-                    {
-                        "name": "What changed",
-                        "value": brief,
-                        "inline": False,
-                    },
-                    {
-                        "name": "Update now",
-                        "value": (
-                            f"**[⬇️ Install / Update]({args.install_url})**"
-                            f"  •  [Version history]({history_url})"
-                            f"  •  [Greasy Fork page]({args.script_url})"
-                        ),
-                        "inline": False,
-                    },
-                ],
-                "footer": {
-                    "text": "Fallback release signal • MissionChief Toolkit",
-                },
-                "timestamp": utc_timestamp(),
-            }
-        ],
+        "embeds": [hero, intelligence],
     }
 
 
@@ -283,33 +295,34 @@ def validate_payload(payload: dict) -> None:
         raise SystemExit("Discord payload is unexpectedly large.")
 
     embeds = payload.get("embeds", [])
-    if len(embeds) != 1:
-        raise SystemExit("Expected exactly one Discord embed.")
+    if len(embeds) != 2:
+        raise SystemExit("Expected exactly two Discord embeds.")
 
-    embed = embeds[0]
-    if len(embed.get("title", "")) > 256:
-        raise SystemExit("Discord embed title exceeds 256 characters.")
-    if len(embed.get("description", "")) > 4096:
-        raise SystemExit("Discord embed description exceeds 4096 characters.")
-    if len(embed.get("fields", [])) > 25:
-        raise SystemExit("Discord embed contains more than 25 fields.")
+    total_characters = 0
+    for index, embed in enumerate(embeds, 1):
+        if len(embed.get("title", "")) > 256:
+            raise SystemExit(f"Discord embed {index} title exceeds 256 characters.")
+        if len(embed.get("description", "")) > 4096:
+            raise SystemExit(f"Discord embed {index} description exceeds 4096 characters.")
+        if len(embed.get("fields", [])) > 25:
+            raise SystemExit(f"Discord embed {index} contains more than 25 fields.")
 
-    total_characters = (
-        len(embed.get("title", ""))
-        + len(embed.get("description", ""))
-        + len(embed.get("author", {}).get("name", ""))
-        + len(embed.get("footer", {}).get("text", ""))
-    )
+        total_characters += (
+            len(embed.get("title", ""))
+            + len(embed.get("description", ""))
+            + len(embed.get("author", {}).get("name", ""))
+            + len(embed.get("footer", {}).get("text", ""))
+        )
 
-    for field in embed.get("fields", []):
-        name = field.get("name", "")
-        value = field.get("value", "")
-        if len(name) > 256 or len(value) > 1024:
-            raise SystemExit(f"Discord embed field exceeds limits: {name}")
-        total_characters += len(name) + len(value)
+        for field in embed.get("fields", []):
+            name = field.get("name", "")
+            value = field.get("value", "")
+            if len(name) > 256 or len(value) > 1024:
+                raise SystemExit(f"Discord embed field exceeds limits: {name}")
+            total_characters += len(name) + len(value)
 
     if total_characters > 6000:
-        raise SystemExit("Discord embed exceeds the 6000-character total limit.")
+        raise SystemExit("Discord embeds exceed the 6000-character total limit.")
 
 
 def main() -> int:

--- a/.github/scripts/test_discord_release_payload.py
+++ b/.github/scripts/test_discord_release_payload.py
@@ -9,9 +9,9 @@ import unittest
 from pathlib import Path
 
 SCRIPT_PATH = Path(__file__).with_name("build_discord_release_payload.py")
-SPEC = importlib.util.spec_from_file_location("discord_release_payload", SCRIPT_PATH)
+SPEC = importlib.util.spec_from_file_location('discord_release_payload', SCRIPT_PATH)
 if SPEC is None or SPEC.loader is None:
-    raise RuntimeError("Unable to load Discord release payload builder.")
+    raise RuntimeError('Unable to load Discord release payload builder.')
 MODULE = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(MODULE)
 
@@ -19,8 +19,8 @@ SPEC.loader.exec_module(MODULE)
 class DiscordReleasePayloadTests(unittest.TestCase):
     def make_changelog(self, content: str) -> Path:
         directory = Path(tempfile.mkdtemp())
-        changelog = directory / "CHANGELOG.md"
-        changelog.write_text(content, encoding="utf-8")
+        changelog = directory / 'CHANGELOG.md'
+        changelog.write_text(content, encoding='utf-8')
         self.addCleanup(lambda: directory.rmdir())
         self.addCleanup(lambda: changelog.unlink(missing_ok=True))
         return changelog
@@ -28,19 +28,19 @@ class DiscordReleasePayloadTests(unittest.TestCase):
     @staticmethod
     def make_args() -> argparse.Namespace:
         return argparse.Namespace(
-            version="4.20.22",
-            release_url="https://github.com/example/toolkit/releases/tag/v4.20.22",
-            script_url="https://greasyfork.org/scripts/123-toolkit",
-            install_url="https://greasyfork.org/scripts/123-toolkit/code/toolkit.user.js",
-            history_url="https://greasyfork.org/scripts/123-toolkit/versions",
-            previous_version="4.20.21",
-            sha256="57b89188ab780a36dc1234567890abcdefabcdefabcdefabcdefabcdefabcd",
-            backup_commit="6e81faa47f1234567890abcdef1234567890abcd",
+            version='4.20.22',
+            release_url='https://github.com/example/toolkit/releases/tag/v4.20.22',
+            script_url='https://greasyfork.org/scripts/123-toolkit',
+            install_url='https://greasyfork.org/scripts/123-toolkit/code/toolkit.user.js',
+            history_url='https://greasyfork.org/scripts/123-toolkit/versions',
+            previous_version='4.20.21',
+            sha256='57b89188ab780a36dc1234567890abcdefabcdefabcdefabcdefabcdefabcd',
+            backup_commit='6e81faa47f1234567890abcdef1234567890abcd',
         )
 
     def test_changelog_prioritises_user_facing_sections_and_limits_items(self) -> None:
         changelog = self.make_changelog(
-            """# Toolkit v4.20.22
+            '''# Toolkit v4.20.22
 ### Distribution
 - Rebuilt public assets.
 ### Fixed
@@ -51,42 +51,46 @@ class DiscordReleasePayloadTests(unittest.TestCase):
 - Fixed BASU capability resolution.
 ### Added
 - Added another feature.
-"""
+'''
         )
 
         brief = MODULE.parse_changelog(changelog)
 
-        self.assertTrue(brief.startswith("**🛠️ Fixed**"))
-        self.assertEqual(brief.count("\n• "), 4)
-        self.assertIn("3 more changes", brief)
-        self.assertNotIn("Rebuilt public assets", brief)
+        self.assertTrue(brief.startswith('**🛠️ FIXED**'))
+        self.assertEqual(brief.count('\n> **'), 4)
+        self.assertIn('+3 additional changes', brief)
+        self.assertNotIn('Rebuilt public assets', brief)
         self.assertLessEqual(len(brief), MODULE.MAX_BRIEF_LENGTH)
 
-    def test_primary_payload_is_compact_and_valid(self) -> None:
+    def test_primary_payload_uses_two_embed_release_hierarchy(self) -> None:
         args = self.make_args()
-        payload = MODULE.build_primary(args, "**🛠️ Fixed**\n• Corrected Matrix counts.")
+        payload = MODULE.build_primary(args, '**🛠️ FIXED**\n> **01**  Corrected Matrix counts.')
 
         MODULE.validate_payload(payload)
-        embed = payload["embeds"][0]
+        self.assertEqual(len(payload['embeds']), 2)
+        hero, intelligence = payload['embeds']
 
-        self.assertEqual(embed["title"], "✅ Toolkit v4.20.22 is live")
-        self.assertEqual(len(embed["fields"]), 6)
-        self.assertEqual(embed["fields"][3]["name"], "What changed")
-        self.assertIn("Install / Update", embed["fields"][-1]["value"])
-        self.assertNotIn("MISSION CONTROL", str(payload))
+        self.assertEqual(hero['title'], '🚨 DEPLOYMENT CONFIRMED // v4.20.22')
+        self.assertIn('INSTALL / UPDATE TO v4.20.22', hero['description'])
+        self.assertEqual(len(hero['fields']), 3)
+        self.assertEqual(intelligence['title'], '⚡ RELEASE INTELLIGENCE')
+        self.assertIn('Corrected Matrix counts', intelligence['description'])
+        self.assertIn('Install now', intelligence['fields'][0]['value'])
 
     def test_fallback_payload_remains_visually_distinct(self) -> None:
         args = self.make_args()
-        payload = MODULE.build_fallback(args, "**🛠️ Fixed**\n• Corrected Matrix counts.")
+        payload = MODULE.build_fallback(args, '**🛠️ FIXED**\n> **01**  Corrected Matrix counts.')
 
         MODULE.validate_payload(payload)
-        embed = payload["embeds"][0]
+        self.assertEqual(len(payload['embeds']), 2)
+        hero, intelligence = payload['embeds']
 
-        self.assertIn("detected on Greasy Fork", embed["title"])
-        self.assertEqual(embed["color"], 0xF39C12)
-        self.assertIn("v4.20.21", embed["fields"][0]["value"])
-        self.assertIn("v4.20.22", embed["fields"][0]["value"])
+        self.assertIn('PUBLIC VERSION DETECTED', hero['title'])
+        self.assertEqual(hero['color'], 0xF59E0B)
+        self.assertIn('v4.20.21', hero['description'])
+        self.assertIn('v4.20.22', hero['description'])
+        self.assertEqual(intelligence['color'], 0xD97706)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     unittest.main()

--- a/.github/workflows/discord-release-preview.yml
+++ b/.github/workflows/discord-release-preview.yml
@@ -68,8 +68,8 @@ jobs:
           - Ensured responding Police Sergeants, Police Inspectors and Railway Police Officers reduce outstanding demand.
 
           ### Changed
-          - Simplified Discord release announcements with a clearer update action and concise change summary.
-          - Prioritised user-facing changes over internal deployment metadata.
+          - Rebuilt Discord release anouncements as a two-card deployment transmission.
+          - Prioritised the update action and user-facing release intelligence.
           EOF
 
           python3 .github/scripts/build_discord_release_payload.py \
@@ -85,27 +85,41 @@ jobs:
 
           python3 - <<'PY'
           import json
+          import re
           from pathlib import Path
 
           path = Path("discord-release-preview.json")
           payload = json.loads(path.read_text(encoding="utf-8"))
-          embed = payload["embeds"][0]
-          version = embed["fields"][0]["value"].splitlines()[0].strip("*")
+          hero, intelligence = payload["embeds"]
+          match = re.search(r"v([^\s]+)$", hero["title"])
+          version = f"v{match.group(1)}" if match else "current version"
 
-          embed["title"] = f"🧪 TEST — {version} release announcement preview"
-          embed["description"] = (
-              "**No release was published and Greasy Fork was not changed.**\n"
-              "This is a live webhook test of the redesigned release card."
+          hero["title"] = f"🧪 TRANSMISSION TEST // {version}"
+          hero["description"] = (
+              "**LIVE DESIGN PREVIEW **\n"
+              "This message is testing the release channel presentation only.\n\n"
+              "**No release was created. Greasy Fork, was not changed.**\n\n"
+              "`WEBHOOK LIVE`  `SAFETY LOCKED`  `TEST ONLY`"
           )
-          embed["color"] = 0x5865F2
-          embed["fields"][0]["name"] = "Previewed release"
-          embed["fields"][1]["name"] = "Live systems"
-          embed["fields"][1]["value"] = "Greasy Fork unchanged\nInstall source unchanged"
-          embed["fields"][2]["name"] = "Preview checks"
-          embed["fields"][2]["value"] = "Payload contract ✅\nWebhook delivery test"
-          embed["fields"][4]["name"] = "Preview integrity"
-          embed["fields"][5]["name"] = "Current links"
-          embed["footer"]["text"] = "TEST ONLY • Discord release embed preview"
+          hero["color"] = 0x7C3AED
+          hero["fields"][0] = {
+              "name": "TEST TARGET",
+              "value": "Release webhook\n**CONNECTED** ✅",
+              "inline": True,
+          }
+          hero["fields"][1] = {
+              "name": "SAFETY LOCK",
+              "value": "No publish\n**CONFIRMED** ✅",
+              "inline": True,
+          }
+          hero["fields"][2]["name"] = "PREVIEW ID"
+          hero["footer"]["text"] = "TEST ONLY • No production state changed"
+
+          intelligence["title"] = "⚡ PREVIEW // RELEASE INTELLIGENCE"
+          intelligence["color"] = 0x5865F2
+          intelligence["fields"][0]["name"] = "CURRENT LIVE'LINKS"
+          intelligence["fields"][1]["name"] = "PREVIEW MARKER"
+          intelligence["footer"]["text"] = "Design preview • Release brief simulation"
 
           path.write_text(
               json.dumps(payload, ensure_ascii=False, indent=2) + "\n",


### PR DESCRIPTION
## Summary

Replaces the field-heavy release card with a two-stage Discord announcement designed around a deployment hero and a concise release-intelligence brief.

### New structure

1. **Deployment hero**
   - High-impact `DEPLOYMENT CONFIRMED // vX` headline.
   - Install / Update link is the primary focal point.
   - Three compact status markers only: public channel, release gate and build ID.
   - Red verified-deployment accent.

2. **Release intelligence**
   - Separate cyan card for user-facing changes.
   - Numbered quote-style change entries rather than a dense field list.
   - Direct release, Greasy Fork and install links.
   - Private recovery marker retained without dominating the announcement.

### Additional changes

- Matching two-card fallback release signal in amber.
- Preview workflow updated to test both cards safely against the live release webhook.
- Payload validation now enforces exactly two embeds and Discord's shared 6,000-character embed limit.
- Contract tests updated for the new hierarchy and changelog formatting.

### Safety

- No Toolkit userscript code changes.
- No public release required.
- Does not interfere with active draft PR #313.