### PR TITLE
Restore release details and command links to Discord announcements

### DIFF
--- a/.github/development-packages/.discord-release-info-links-validation-marker
+++ b/.github/development-packages/.discord-release-info-links-validation-marker
@@ -1,1 +1,0 @@
-Discord release info-links branch validation marker.

--- a/.github/development-packages/.discord-release-info-links-validation-marker
+++ b/.github/development-packages/.discord-release-info-links-validation-marker
@@ -1,0 +1,1 @@
+Discord release info-links branch validation marker.

--- a/.github/scripts/build_discord_release_payload.py
+++ b/.github/scripts/build_discord_release_payload.py
@@ -17,6 +17,9 @@ SECTION_ICONS = {
     "distribution": "📡",
     "baseline": "🧱",
     "removed": "🗑️",
+    "validation": "🧪",
+    "engineering": "⚙️",
+    "audit": "🔎",
 }
 
 SECTION_PRIORITY = {
@@ -26,14 +29,17 @@ SECTION_PRIORITY = {
     "changed": 3,
     "performance": 4,
     "removed": 5,
-    "distribution": 6,
-    "baseline": 7,
+    "validation": 6,
+    "audit": 7,
+    "engineering": 8,
+    "distribution": 9,
+    "baseline": 10,
 }
 
 MAX_SECTIONS = 2
-MAX_ITEMS = 4
+MAX_ITEMS = 3
 MAX_ITEM_LENGTH = 150
-MAX_BRIEF_LENGTH = 820
+MAX_BRIEF_LENGTH = 680
 
 
 def clean_text(value: str) -> str:
@@ -116,7 +122,7 @@ def parse_changelog(path: Path) -> str:
             continue
 
         icon = SECTION_ICONS.get(name.casefold(), "◆")
-        rendered.append(f"**{icon} {name.upper()}**")
+        rendered.append(f"**{icon} {name.title()}**")
         for item in selected_items:
             used_items += 1
             rendered.append(f"> **{used_items:02d}**  {item}")
@@ -147,22 +153,44 @@ def utc_timestamp() -> str:
     )
 
 
+def command_links(install_url: str, release_url: str, script_url: str) -> str:
+    return (
+        f"**[⬇️ Install / Update]({install_url})**"
+        f"  •  [📋 Release notes]({release_url})"
+        f"  •  [🛠️ Greasy Fork]({script_url})"
+    )
+
+
 def build_primary(args: argparse.Namespace, brief: str) -> dict:
-    hero = {
+    embed = {
         "author": {
             "name": "MISSIONCHIEF // MAP COMMAND TOOLKIT",
             "url": args.release_url,
         },
-        "title": f"🚨 DEPLOYMENT CONFIRMED // v{args.version}",
+        "title": f"🚨 TOOLKIT v{args.version} // DEPLOYMENT LIVE",
         "description": (
-            "**THE NEW BUILD IS LIVE**\n"
-            "Greasy Fork has published and verified the latest Toolkit package.\n\n"
-            f"**[⬇️  INSTALL / UPDATE TO v{args.version}]({args.install_url})**\n\n"
+            "**VERIFIED PUBLIC RELEASE**\n"
+            "The latest command package has cleared every release gate and is "
+            "available now on Greasy Fork.\n\n"
             "`LIVE`  `VERIFIED`  `RECOVERABLE`"
         ),
         "url": args.release_url,
         "color": 0xE11D48,
         "fields": [
+            {
+                "name": "⚡ MISSION BRIEF",
+                "value": brief,
+                "inline": False,
+            },
+            {
+                "name": "🔗 COMMAND LINKS",
+                "value": command_links(
+                    args.install_url,
+                    args.release_url,
+                    args.script_url,
+                ),
+                "inline": False,
+            },
             {
                 "name": "PUBLIC CHANNEL",
                 "value": "Greasy Fork\n**SYNCED** ✅",
@@ -180,65 +208,55 @@ def build_primary(args: argparse.Namespace, brief: str) -> dict:
             },
         ],
         "footer": {
-            "text": "Verified public deployment • MissionChief Toolkit",
+            "text": (
+                "Verified deployment • "
+                f"Recovery {args.backup_commit[:10]} • MissionChief Toolkit"
+            ),
         },
         "timestamp": utc_timestamp(),
-    }
-
-    intelligence = {
-        "title": "⚡ RELEASE INTELLIGENCE",
-        "description": brief,
-        "url": args.release_url,
-        "color": 0x00AEEF,
-        "fields": [
-            {
-                "name": "MISSION LINKS",
-                "value": (
-                    f"[Full release]({args.release_url})"
-                    f"  •  [Greasy Fork]({args.script_url})"
-                    f"  •  **[Install now]({args.install_url})**"
-                ),
-                "inline": False,
-            },
-            {
-                "name": "RECOVERY MARKER",
-                "value": f"Private archive `{args.backup_commit[:10]}`",
-                "inline": False,
-            },
-        ],
-        "footer": {
-            "text": "Release brief • User-facing changes only",
-        },
     }
 
     return {
         "username": "MissionChief Toolkit Releases",
         "allowed_mentions": {"parse": []},
-        "embeds": [hero, intelligence],
+        "embeds": [embed],
     }
 
 
 def build_fallback(args: argparse.Namespace, brief: str) -> dict:
-    history_url = args.history_url or f"{Args.script_url.rstrip('/')}/versions"
+    history_url = args.history_url or f"{args.script_url.rstrip('/')}/versions"
     previous = args.previous_version or "unknown"
     previous_label = f"v{previous}" if previous != "unknown" else "Unknown"
 
-    hero = {
+    embed = {
         "author": {
             "name": "MISSIONCHIEF // RELEASE WATCH",
             "url": args.script_url,
         },
-        "title": f"📡 PUBLIC VERSION DETECTED // v{args.version}",
+        "title": f"📡 TOOLKIT v{args.version} // PUBLIC VERSION DETECTED",
         "description": (
             "**FALLBACK RELEASE SIGNAL**\n"
             "Greasy Fork published a new public version before the normal release "
             "announcement completed.\n\n"
-            f"**[⬇️  INSTALL / UPDATE TO v{args.version}]({args.install_url})**\n\n"
             f"`{previous_label}`  →  `v{args.version}`"
         ),
         "url": args.script_url,
         "color": 0xF59E0B,
         "fields": [
+            {
+                "name": "⚡ MISSION BRIEF",
+                "value": brief,
+                "inline": False,
+            },
+            {
+                "name": "🔗 COMMAND LINKS",
+                "value": command_links(
+                    args.install_url,
+                    history_url,
+                    args.script_url,
+                ).replace("Release notes", "Version history"),
+                "inline": False,
+            },
             {
                 "name": "SOURCE",
                 "value": "Greasy Fork\n**LIVE** ✅",
@@ -256,36 +274,15 @@ def build_fallback(args: argparse.Namespace, brief: str) -> dict:
             },
         ],
         "footer": {
-            "text": "Fallback release signal • MissionChief Toolkit",
+            "text": "Fallback release signal • Verification may still be running",
         },
         "timestamp": utc_timestamp(),
-    }
-
-    intelligence = {
-        "title": "⚡ RELEASE INTELLIGENCE",
-        "description": brief,
-        "url": history_url,
-        "color": 0xD97706,
-        "fields": [
-            {
-                "name": "MISSION LINKS",
-                "value": (
-                    f"[Version history]({history_url})"
-                    f"  •  [Greasy Fork]({args.script_url})"
-                    f"  •  **[Install now]({args.install_url})**"
-                ),
-                "inline": False,
-            },
-        ],
-        "footer": {
-            "text": "Fallback brief • Standard release verification may still be running",
-        },
     }
 
     return {
         "username": "MissionChief Toolkit Releases",
         "allowed_mentions": {"parse": []},
-        "embeds": [hero, intelligence],
+        "embeds": [embed],
     }
 
 
@@ -295,34 +292,33 @@ def validate_payload(payload: dict) -> None:
         raise SystemExit("Discord payload is unexpectedly large.")
 
     embeds = payload.get("embeds", [])
-    if len(embeds) != 2:
-        raise SystemExit("Expected exactly two Discord embeds.")
+    if len(embeds) != 1:
+        raise SystemExit("Expected exactly one Discord embed.")
 
-    total_characters = 0
-    for index, embed in enumerate(embeds, 1):
-        if len(embed.get("title", "")) > 256:
-            raise SystemExit(f"Discord embed {index} title exceeds 256 characters.")
-        if len(embed.get("description", "")) > 4096:
-            raise SystemExit(f"Discord embed {index} description exceeds 4096 characters.")
-        if len(embed.get("fields", [])) > 25:
-            raise SystemExit(f"Discord embed {index} contains more than 25 fields.")
+    embed = embeds[0]
+    if len(embed.get("title", "")) > 256:
+        raise SystemExit("Discord embed title exceeds 256 characters.")
+    if len(embed.get("description", "")) > 4096:
+        raise SystemExit("Discord embed description exceeds 4096 characters.")
+    if len(embed.get("fields", [])) > 25:
+        raise SystemExit("Discord embed contains more than 25 fields.")
 
-        total_characters += (
-            len(embed.get("title", ""))
-            + len(embed.get("description", ""))
-            + len(embed.get("author", {}).get("name", ""))
-            + len(embed.get("footer", {}).get("text", ""))
-        )
+    total_characters = (
+        len(embed.get("title", ""))
+        + len(embed.get("description", ""))
+        + len(embed.get("author", {}).get("name", ""))
+        + len(embed.get("footer", {}).get("text", ""))
+    )
 
-        for field in embed.get("fields", []):
-            name = field.get("name", "")
-            value = field.get("value", "")
-            if len(name) > 256 or len(value) > 1024:
-                raise SystemExit(f"Discord embed field exceeds limits: {name}")
-            total_characters += len(name) + len(value)
+    for field in embed.get("fields", []):
+        name = field.get("name", "")
+        value = field.get("value", "")
+        if len(name) > 256 or len(value) > 1024:
+            raise SystemExit(f"Discord embed field exceeds limits: {name}")
+        total_characters += len(name) + len(value)
 
     if total_characters > 6000:
-        raise SystemExit("Discord embeds exceed the 6000-character total limit.")
+        raise SystemExit("Discord embed exceeds the 6000-character total limit.")
 
 
 def main() -> int:

--- a/.github/scripts/test_discord_release_payload.py
+++ b/.github/scripts/test_discord_release_payload.py
@@ -9,9 +9,9 @@ import unittest
 from pathlib import Path
 
 SCRIPT_PATH = Path(__file__).with_name("build_discord_release_payload.py")
-SPEC = importlib.util.spec_from_file_location('discord_release_payload', SCRIPT_PATH)
+SPEC = importlib.util.spec_from_file_location("discord_release_payload", SCRIPT_PATH)
 if SPEC is None or SPEC.loader is None:
-    raise RuntimeError('Unable to load Discord release payload builder.')
+    raise RuntimeError("Unable to load Discord release payload builder.")
 MODULE = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(MODULE)
 
@@ -19,8 +19,8 @@ SPEC.loader.exec_module(MODULE)
 class DiscordReleasePayloadTests(unittest.TestCase):
     def make_changelog(self, content: str) -> Path:
         directory = Path(tempfile.mkdtemp())
-        changelog = directory / 'CHANGELOG.md'
-        changelog.write_text(content, encoding='utf-8')
+        changelog = directory / "CHANGELOG.md"
+        changelog.write_text(content, encoding="utf-8")
         self.addCleanup(lambda: directory.rmdir())
         self.addCleanup(lambda: changelog.unlink(missing_ok=True))
         return changelog
@@ -28,69 +28,75 @@ class DiscordReleasePayloadTests(unittest.TestCase):
     @staticmethod
     def make_args() -> argparse.Namespace:
         return argparse.Namespace(
-            version='4.20.22',
-            release_url='https://github.com/example/toolkit/releases/tag/v4.20.22',
-            script_url='https://greasyfork.org/scripts/123-toolkit',
-            install_url='https://greasyfork.org/scripts/123-toolkit/code/toolkit.user.js',
-            history_url='https://greasyfork.org/scripts/123-toolkit/versions',
-            previous_version='4.20.21',
-            sha256='57b89188ab780a36dc1234567890abcdefabcdefabcdefabcdefabcdefabcd',
-            backup_commit='6e81faa47f1234567890abcdef1234567890abcd',
+            version="4.20.23",
+            release_url="https://github.com/example/toolkit/releases/tag/v4.20.23",
+            script_url="https://greasyfork.org/scripts/123-toolkit",
+            install_url="https://greasyfork.org/scripts/123-toolkit/code/toolkit.user.js",
+            history_url="https://greasyfork.org/scripts/123-toolkit/versions",
+            previous_version="4.20.22",
+            sha256="57b89188ab780a36dc1234567890abcdefabcdefabcdefabcdefabcdefabcd",
+            backup_commit="6e81faa47f1234567890abcdef1234567890abcd",
         )
 
     def test_changelog_prioritises_user_facing_sections_and_limits_items(self) -> None:
         changelog = self.make_changelog(
-            '''# Toolkit v4.20.22
+            """# Toolkit v4.20.23
 ### Distribution
 - Rebuilt public assets.
 ### Fixed
-- Fixed firefighter capacity reconciliation.
-- Fixed Police Sergeant responding counts.
-- Fixed Police Inspector selected counts.
-- Fixed Railway Police responding counts.
-- Fixed BASU capability resolution.
+- Counted confirmed patient releases exactly once.
+- Recognised global MissionChief release confirmations.
+- Preserved successful totals after cleanup failures.
+- Kept every sweep counter in sync.
+### Validation
+- Added deterministic regression coverage.
 ### Added
 - Added another feature.
-'''
+"""
         )
 
         brief = MODULE.parse_changelog(changelog)
 
-        self.assertTrue(brief.startswith('**🛠️ FIXED**'))
-        self.assertEqual(brief.count('\n> **'), 4)
-        self.assertIn('+3 additional changes', brief)
-        self.assertNotIn('Rebuilt public assets', brief)
+        self.assertTrue(brief.startswith("**🛠️ Fixed**"))
+        self.assertEqual(brief.count("\n> **"), 3)
+        self.assertIn("4 additional changes", brief)
+        self.assertNotIn("Rebuilt public assets", brief)
         self.assertLessEqual(len(brief), MODULE.MAX_BRIEF_LENGTH)
 
-    def test_primary_payload_uses_two_embed_release_hierarchy(self) -> None:
+    def test_primary_payload_puts_summary_and_links_in_the_only_embed(self) -> None:
         args = self.make_args()
-        payload = MODULE.build_primary(args, '**🛠️ FIXED**\n> **01**  Corrected Matrix counts.')
+        brief = "**🛠️ Fixed**\n> **01**  Corrected Transport Sweep counts."
+        payload = MODULE.build_primary(args, brief)
 
         MODULE.validate_payload(payload)
-        self.assertEqual(len(payload['embeds']), 2)
-        hero, intelligence = payload['embeds']
+        self.assertEqual(len(payload["embeds"]), 1)
 
-        self.assertEqual(hero['title'], '🚨 DEPLOYMENT CONFIRMED // v4.20.22')
-        self.assertIn('INSTALL / UPDATE TO v4.20.22', hero['description'])
-        self.assertEqual(len(hero['fields']), 3)
-        self.assertEqual(intelligence['title'], '⚡ RELEASE INTELLIGENCE')
-        self.assertIn('Corrected Matrix counts', intelligence['description'])
-        self.assertIn('Install now', intelligence['fields'][0]['value'])
+        embed = payload["embeds"][0]
+        self.assertEqual(embed["title"], "🚨 TOOLKIT v4.20.23 // DEPLOYMENT LIVE")
+        self.assertEqual(embed["fields"][0]["name"], "⚡ MISSION BRIEF")
+        self.assertEqual(embed["fields"][0]["value"], brief)
+        self.assertEqual(embed["fields"][1]["name"], "🔗 COMMAND LINKS")
+        self.assertIn("Install / Update", embed["fields"][1]["value"])
+        self.assertIn("Release notes", embed["fields"][1]["value"])
+        self.assertIn("Greasy Fork", embed["fields"][1]["value"])
+        self.assertEqual(len(embed["fields"]), 5)
 
-    def test_fallback_payload_remains_visually_distinct(self) -> None:
+    def test_fallback_payload_retains_summary_links_and_distinct_state(self) -> None:
         args = self.make_args()
-        payload = MODULE.build_fallback(args, '**🛠️ FIXED**\n> **01**  Corrected Matrix counts.')
+        brief = "**🛠️ Fixed**\n> **01**  Corrected Matrix counts."
+        payload = MODULE.build_fallback(args, brief)
 
         MODULE.validate_payload(payload)
-        self.assertEqual(len(payload['embeds']), 2)
-        hero, intelligence = payload['embeds']
+        embed = payload["embeds"][0]
 
-        self.assertIn('PUBLIC VERSION DETECTED', hero['title'])
-        self.assertEqual(hero['color'], 0xF59E0B)
-        self.assertIn('v4.20.21', hero['description'])
-        self.assertIn('v4.20.22', hero['description'])
-        self.assertEqual(intelligence['color'], 0xD97706)
+        self.assertIn("PUBLIC VERSION DETECTED", embed["title"])
+        self.assertEqual(embed["color"], 0xF59E0B)
+        self.assertEqual(embed["fields"][0]["value"], brief)
+        self.assertIn("Version history", embed["fields"][1]["value"])
+        self.assertIn("Install / Update", embed["fields"][1]["value"])
+        self.assertIn("v4.20.22", embed["description"])
+        self.assertIn("v4.20.23", embed["description"])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/.github/workflows/discord-release-preview.yml
+++ b/.github/workflows/discord-release-preview.yml
@@ -60,17 +60,23 @@ jobs:
           [[ -n "$HASH" ]] || HASH="${GITHUB_SHA}${GITHUB_SHA}"
           [[ -n "$BACKUP_COMMIT" ]] || BACKUP_COMMIT="$GITHUB_SHA"
 
-          cat > release-preview-changelog.md <<'EOF'
-          # Toolkit release preview
+          awk -v version="$VERSION" '
+            $0 ~ "^## \\[" version "\\]" {
+              capture = 1
+              next
+            }
+            capture && /^## \[/ {
+              exit
+            }
+            capture {
+              print
+            }
+          ' CHANGELOG.md > release-preview-changelog.md
 
-          ### Fixed
-          - Corrected firefighter, specialist personnel and BASU reconciliation in the Mission Requirements Matrix.
-          - Ensured responding Police Sergeants, Police Inspectors and Railway Police Officers reduce outstanding demand.
-
-          ### Changed
-          - Rebuilt Discord release anouncements as a two-card deployment transmission.
-          - Prioritised the update action and user-facing release intelligence.
-          EOF
+          [[ -s release-preview-changelog.md ]] || {
+            echo "::error::Unable to extract release notes for v${VERSION}."
+            exit 1
+          }
 
           python3 .github/scripts/build_discord_release_payload.py \
             --mode primary \
@@ -90,36 +96,31 @@ jobs:
 
           path = Path("discord-release-preview.json")
           payload = json.loads(path.read_text(encoding="utf-8"))
-          hero, intelligence = payload["embeds"]
-          match = re.search(r"v([^\s]+)$", hero["title"])
+          embed = payload["embeds"][0]
+          match = re.search(r"v([^\s]+)", embed["title"])
           version = f"v{match.group(1)}" if match else "current version"
+          original_description = embed["description"]
 
-          hero["title"] = f"🧪 TRANSMISSION TEST // {version}"
-          hero["description"] = (
-              "**LIVE DESIGN PREVIEW **\n"
-              "This message is testing the release channel presentation only.\n\n"
-              "**No release was created. Greasy Fork, was not changed.**\n\n"
-              "`WEBHOOK LIVE`  `SAFETY LOCKED`  `TEST ONLY`"
+          embed["title"] = f"🧪 TEST // TOOLKIT {version} RELEASE CARD"
+          embed["description"] = (
+              "**LIVE DESIGN PREVIEW — NO RELEASE ACTION TAKEN**\n"
+              "This is a rendering test only. Greasy Fork and the published "
+              "version are unchanged.\n\n"
+              + original_description
           )
-          hero["color"] = 0x7C3AED
-          hero["fields"][0] = {
+          embed["color"] = 0x7C3AED
+          embed["fields"][2] = {
               "name": "TEST TARGET",
               "value": "Release webhook\n**CONNECTED** ✅",
               "inline": True,
           }
-          hero["fields"][1] = {
+          embed["fields"][3] = {
               "name": "SAFETY LOCK",
               "value": "No publish\n**CONFIRMED** ✅",
               "inline": True,
           }
-          hero["fields"][2]["name"] = "PREVIEW ID"
-          hero["footer"]["text"] = "TEST ONLY • No production state changed"
-
-          intelligence["title"] = "⚡ PREVIEW // RELEASE INTELLIGENCE"
-          intelligence["color"] = 0x5865F2
-          intelligence["fields"][0]["name"] = "CURRENT LIVE'LINKS"
-          intelligence["fields"][1]["name"] = "PREVIEW MARKER"
-          intelligence["footer"]["text"] = "Design preview • Release brief simulation"
+          embed["fields"][4]["name"] = "PREVIEW ID"
+          embed["footer"]["text"] = "TEST ONLY • No production state changed"
 
           path.write_text(
               json.dumps(payload, ensure_ascii=False, indent=2) + "\n",


### PR DESCRIPTION
## Summary

Fixes the usability regression in the redesigned Discord release announcement.

### Problem

The two-card design placed the actual changelog and clickable links in a secondary embed that was not reliably visible. The preview workflow also replaced the main description with test-only text, leaving the visible card with no useful release information.

### Correction

- Returns to one guaranteed-visible release embed.
- Places the real release summary in a prominent **Mission Brief** section.
- Restores direct **Install / Update**, **Release notes**, and **Greasy Fork** links.
- Retains the stronger deployment styling and three compact status fields.
- Makes the preview extract the actual current version section from `CHANGELOG.md`.
- Keeps the Mission Brief and command links visible in test previews.
- Fixes the fallback history URL typo while preserving its amber state.
- Updates contract tests to require information and links in the sole embed.

### Release impact

Workflow and notification tooling only. No userscript release is required.