### PR TITLE
Record v4.20.24 performance evidence and observer ownership

### DIFF
--- a/.github/fixtures/observer-ownership-v4.20.24.json
+++ b/.github/fixtures/observer-ownership-v4.20.24.json
@@ -1,0 +1,212 @@
+{
+  "schemaVersion": 1,
+  "baseline": {
+    "version": "4.20.24",
+    "sourceSha256": "4bd9a9f3708292a6a48523f2f4d69b105e5957395fb10bcbeec671a4d8a4029c",
+    "mutationObservers": 12,
+    "resizeObservers": 4,
+    "observerConstructions": 16,
+    "observeRegistrations": 19,
+    "broadSubtreeRegistrations": 10,
+    "explicitDocumentBodySubtreeRegistrations": 3
+  },
+  "observers": [
+    {
+      "key": "installAllianceBuildingsContextWatcherEarly|MutationObserver|observer",
+      "subsystem": "Alliance Buildings early suppression",
+      "installation": "Installed once before normal runtime when the Alliance Buildings map preference is disabled.",
+      "scheduling": "Filters added/removed element nodes, then coalesces work through queueMicrotask.",
+      "ownership": "page-process-lifetime",
+      "teardown": "Browser document lifetime; not registered in the replaceable Toolkit runtime.",
+      "duplicateGuard": "allianceBuildingsContextWatcherInstalled",
+      "documentReplacement": "Tracks SPA navigation with popstate, hashchange, pageshow and load; observes documentElement.",
+      "coverage": ["docs/issue-251-alliance-observer-performance-contract.md"],
+      "status": "accepted-process-lifetime"
+    },
+    {
+      "key": "observeDesktopPanelWorkspace|ResizeObserver|desktopPanelResizeObserver",
+      "subsystem": "Desktop panel workspace",
+      "installation": "Created lazily only in desktop layout when ResizeObserver exists.",
+      "scheduling": "Re-applies panel sizing and schedules position after resize.",
+      "ownership": "runtime",
+      "teardown": "runtime.destroy disconnects; stopDesktopPanelWorkspaceObservation unobserves current elements.",
+      "duplicateGuard": "desktopPanelResizeObserver singleton plus desktopPanelObservedElements set",
+      "documentReplacement": "Observed elements are refreshed and stale elements unobserved.",
+      "coverage": [".github/scripts/test_desktop_panel_layout_contract.py"],
+      "status": "owned"
+    },
+    {
+      "key": "observeTabletMapArea|ResizeObserver|tabletDockResizeObserver",
+      "subsystem": "Tablet map area",
+      "installation": "Created lazily for tablet layout when ResizeObserver exists.",
+      "scheduling": "Schedules tablet layout refresh.",
+      "ownership": "runtime",
+      "teardown": "runtime.destroy disconnects; tablet observation reset disconnects/unobserves.",
+      "duplicateGuard": "tabletDockResizeObserver singleton and observed-element identity",
+      "documentReplacement": "Map element changes cause observation refresh.",
+      "coverage": [".github/scripts/test_settings_ui_contract.py"],
+      "status": "owned"
+    },
+    {
+      "key": "observeCustomVehicleBadgeDocument|MutationObserver|observer",
+      "subsystem": "Custom vehicle badges",
+      "installation": "One observer per discovered document/frame context.",
+      "scheduling": "Filters relevant mutations and debounces a badge scan with runtimeSetTimeout.",
+      "ownership": "runtime",
+      "teardown": "runtime.destroy disconnects all tracked observers.",
+      "duplicateGuard": "customVehicleBadgeObservedDocuments WeakSet",
+      "documentReplacement": "Discovers frames and registers load listeners; new documents get their own observer.",
+      "coverage": ["canonical validation", "full userscript audit"],
+      "status": "owned"
+    },
+    {
+      "key": "ensureMajorIncidentFeed|ResizeObserver|majorIncidentFeedResizeObserver",
+      "subsystem": "Major Incident Feed",
+      "installation": "Created only outside Economy Mode when feed identity changes.",
+      "scheduling": "Schedules feed motion/layout or recovery.",
+      "ownership": "runtime-and-subsystem",
+      "teardown": "resetMajorIncidentFeedObserver disconnects; runtime.destroy is final owner.",
+      "duplicateGuard": "majorIncidentFeedObservedElement identity",
+      "documentReplacement": "Disconnected and recreated when feed/header is replaced.",
+      "coverage": ["canonical validation", "full userscript audit"],
+      "status": "owned"
+    },
+    {
+      "key": "observeMissionValueHost|ResizeObserver|record.resizeObserver",
+      "subsystem": "Mission Value host sizing",
+      "installation": "One record per connected toolbar spacer.",
+      "scheduling": "Schedules mission-value scan after resize.",
+      "ownership": "runtime-and-record",
+      "teardown": "pruneMissionValueHostObservers disconnects stale records; runtime.destroy is final owner.",
+      "duplicateGuard": "missionValueHostObservers Map keyed by spacer",
+      "documentReplacement": "Disconnected when spacer/toolbar is no longer connected.",
+      "coverage": [".github/scripts/test_mission_value_contract.py"],
+      "status": "owned"
+    },
+    {
+      "key": "observeMissionValueHost|MutationObserver|record.mutationObserver",
+      "subsystem": "Mission Value toolbar content",
+      "installation": "Paired with the host ResizeObserver for each toolbar spacer.",
+      "scheduling": "Schedules mission-value scan after direct toolbar child changes.",
+      "ownership": "runtime-and-record",
+      "teardown": "pruneMissionValueHostObservers disconnects stale records; runtime.destroy is final owner.",
+      "duplicateGuard": "missionValueHostObservers Map keyed by spacer",
+      "documentReplacement": "Disconnected when spacer/toolbar is replaced.",
+      "coverage": [".github/scripts/test_mission_value_contract.py"],
+      "status": "owned"
+    },
+    {
+      "key": "observeMissionValueDocument|MutationObserver|observer",
+      "subsystem": "Mission Value document discovery",
+      "installation": "One observer per discovered document context.",
+      "scheduling": "Filters mission-window/frame activity and schedules a 50 ms scan.",
+      "ownership": "runtime",
+      "teardown": "runtime.destroy disconnects.",
+      "duplicateGuard": "missionValueObservedDocuments WeakSet",
+      "documentReplacement": "Frame loads schedule rescans; new document contexts receive separate observers.",
+      "coverage": [".github/scripts/test_mission_value_contract.py"],
+      "status": "owned"
+    },
+    {
+      "key": "missionRequirementsEnsureRecord|MutationObserver|record.observer",
+      "subsystem": "Mission Requirements live record",
+      "installation": "One observer per mission requirements root record.",
+      "scheduling": "Filters requirement-relevant mutations and schedules record reconciliation.",
+      "ownership": "runtime-and-record",
+      "teardown": "record cleanup disconnects; runtime.destroy is final owner.",
+      "duplicateGuard": "missionRequirementsRecords record identity",
+      "documentReplacement": "Record is discarded when its root disconnects.",
+      "coverage": [".github/scripts/test_mission_requirements_runtime.js", ".github/scripts/test_mission_requirements_contract.py"],
+      "status": "owned"
+    },
+    {
+      "key": "observeMissionRequirementsDocument|MutationObserver|observer",
+      "subsystem": "Mission Requirements document discovery",
+      "installation": "One observer per discovered document context.",
+      "scheduling": "Filters mission/patient/vehicle activity and schedules scan plus record updates.",
+      "ownership": "runtime",
+      "teardown": "runtime.destroy disconnects.",
+      "duplicateGuard": "missionRequirementsObservedDocuments WeakSet",
+      "documentReplacement": "Frame loads and document discovery create observers for replacement contexts.",
+      "coverage": [".github/scripts/test_mission_requirements_runtime.js", ".github/scripts/test_mission_requirements_contract.py"],
+      "status": "owned"
+    },
+    {
+      "key": "observeCreditValue|MutationObserver|creditsValueObserver",
+      "subsystem": "Credits total",
+      "installation": "Attached to the current .credits-value element.",
+      "scheduling": "Processes the updated text synchronously.",
+      "ownership": "runtime-and-element",
+      "teardown": "Explicitly disconnects and untracks before replacing; runtime.destroy is final owner.",
+      "duplicateGuard": "observedCreditsElement identity plus creditsValueObserver",
+      "documentReplacement": "Rebinds when the credits element identity changes.",
+      "coverage": [".github/scripts/test_financial_ledger_contract.py"],
+      "status": "owned"
+    },
+    {
+      "key": "installAllianceBuildingsPageOptimisation|MutationObserver|pageObserver",
+      "subsystem": "Alliance Buildings page rendering",
+      "installation": "Installed only in Alliance Buildings context or while map suppression is enabled.",
+      "scheduling": "Child-list filter then zero-delay coalesced render.",
+      "ownership": "runtime",
+      "teardown": "runtime.destroy disconnects.",
+      "duplicateGuard": "install path returns early from normal boot for the page context",
+      "documentReplacement": "Body subtree observation covers in-page replacement.",
+      "coverage": ["docs/issue-251-alliance-observer-performance-contract.md"],
+      "status": "owned"
+    },
+    {
+      "key": "observeAutoLoadAllVehiclesRoot|MutationObserver|observer",
+      "subsystem": "Auto-load mission root visibility",
+      "installation": "One observer for the current non-body mission root.",
+      "scheduling": "Schedules bounded scan or resets disconnected/hidden root.",
+      "ownership": "runtime-and-subsystem",
+      "teardown": "disconnectAutoLoadAllVehiclesRootObserver and runtime.destroy.",
+      "duplicateGuard": "Always disconnects previous root observer before binding.",
+      "documentReplacement": "Root disconnection resets mission state.",
+      "coverage": [".github/scripts/test_transport_sweep_lssm_contract.py"],
+      "status": "owned"
+    },
+    {
+      "key": "observeAutoLoadAllVehiclesLink|MutationObserver|observer",
+      "subsystem": "Auto-load native link state",
+      "installation": "One observer for the current native load-all link.",
+      "scheduling": "Releases/reschedules when identity, visibility or signature changes.",
+      "ownership": "runtime-and-subsystem",
+      "teardown": "disconnectAutoLoadAllVehiclesLinkObserver and runtime.destroy.",
+      "duplicateGuard": "Always disconnects previous link observer before binding.",
+      "documentReplacement": "Disconnected/rebound when link identity changes.",
+      "coverage": [".github/scripts/test_transport_sweep_lssm_contract.py"],
+      "status": "owned"
+    },
+    {
+      "key": "installAutoLoadAllVehicles|MutationObserver|observer",
+      "subsystem": "Auto-load document discovery",
+      "installation": "Singleton body observer only while feature is enabled.",
+      "scheduling": "Filters relevant child-list changes and debounces a bounded scan.",
+      "ownership": "runtime-and-subsystem",
+      "teardown": "stopAutoLoadAllVehicles untracks/disconnects; runtime.destroy is final owner.",
+      "duplicateGuard": "autoLoadAllVehiclesObserver singleton",
+      "documentReplacement": "Detects mission-root/native-link replacement and resets stale identities.",
+      "coverage": [".github/scripts/test_transport_sweep_lssm_contract.py"],
+      "status": "owned"
+    },
+    {
+      "key": "boot|MutationObserver|observer",
+      "subsystem": "Main map and mission lifecycle",
+      "installation": "Constructed once by guarded boot and connected after core UI readiness.",
+      "scheduling": "Filters Toolkit-owned mutations, classifies mission/layout/UI removal and debounces runtime work.",
+      "ownership": "runtime",
+      "teardown": "runtime.destroy disconnects; connectMainMutationObserver disconnects before re-targeting.",
+      "duplicateGuard": "bootStarted plus replaceable runtime singleton",
+      "documentReplacement": "Re-targets map and mission roots; body fallback is replaced when stable roots appear.",
+      "coverage": [".github/scripts/test_boot_lifecycle_contract.py"],
+      "status": "owned",
+      "manualRegistrations": [
+        {"line": 31001, "target": "document.body", "options": "{ childList: true, subtree: true }", "broad": true, "explicitDocumentBody": true, "condition": "fallback when no stable map or mission root exists"},
+        {"line": 31005, "target": "root", "options": "{ childList: true, subtree: true }", "broad": true, "explicitDocumentBody": false, "condition": "each connected stable map/mission root"},
+        {"line": 31006, "target": "document.body", "options": "{ childList: true, subtree: false }", "broad": false, "explicitDocumentBody": false, "condition": "top-level replacement detection while stable roots are observed"}
+      ]
+    }
+  ]
+}

--- a/.github/scripts/build_observer_ownership_inventory.py
+++ b/.github/scripts/build_observer_ownership_inventory.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Build the reviewed observer ownership inventory from AST evidence and manual lifecycle annotations."""
+from __future__ import annotations
+import argparse, hashlib, json
+from pathlib import Path
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def main() -> int:
+    ap=argparse.ArgumentParser()
+    ap.add_argument('--source', default='src/MissionChief_Map_Command_Toolkit.user.js')
+    ap.add_argument('--deep-json', default='docs/audits/deep-performance-audit-v4.20.24.json')
+    ap.add_argument('--fixture', default='.github/fixtures/observer-ownership-v4.20.24.json')
+    ap.add_argument('--json-output', default='docs/audits/observer-ownership-v4.20.24.json')
+    ap.add_argument('--markdown-output', default='docs/audits/observer-ownership-v4.20.24.md')
+    args=ap.parse_args()
+    source=Path(args.source); deep=json.loads(Path(args.deep_json).read_text()); fixture=json.loads(Path(args.fixture).read_text())
+    baseline=fixture['baseline']
+    actual_sha=sha256(source)
+    if actual_sha != baseline['sourceSha256']:
+        raise SystemExit(f"source SHA mismatch: {actual_sha} != {baseline['sourceSha256']}")
+    constructions=deep['observerConstructions']; annotations={x['key']:x for x in fixture['observers']}
+    rows=[]
+    for item in constructions:
+        key=f"{item['function']}|{item['constructor']}|{item['variable']}"
+        if key not in annotations: raise SystemExit(f'missing manual annotation: {key}')
+        ann=annotations[key]
+        regs=list(item.get('registrations') or [])
+        regs.extend(ann.get('manualRegistrations') or [])
+        row={
+            'key':key,'subsystem':ann['subsystem'],'constructor':item['constructor'],'variable':item['variable'],
+            'constructionLine':item['line'],'installation':ann['installation'],'registrations':regs,
+            'scheduling':ann['scheduling'],'ownership':ann['ownership'],'teardown':ann['teardown'],
+            'duplicateGuard':ann['duplicateGuard'],'documentReplacement':ann['documentReplacement'],
+            'coverage':ann['coverage'],'status':ann['status']
+        }
+        rows.append(row)
+    if len(rows) != baseline['observerConstructions']: raise SystemExit('observer construction count mismatch')
+    mutation=sum(r['constructor']=='MutationObserver' for r in rows); resize=sum(r['constructor']=='ResizeObserver' for r in rows)
+    registrations=sum(len(r['registrations']) for r in rows)
+    broad=sum(bool(x.get('subtree') or x.get('broad')) for r in rows for x in r['registrations'])
+    explicit=sum(bool(x.get('explicitDocumentBody')) or (x.get('target')=='document.body' and bool(x.get('subtree'))) for r in rows for x in r['registrations'])
+    metrics={'mutationObservers':mutation,'resizeObservers':resize,'observerConstructions':len(rows),'observeRegistrations':registrations,'broadSubtreeRegistrations':broad,'explicitDocumentBodySubtreeRegistrations':explicit}
+    for key,val in metrics.items():
+        if val != baseline[key]: raise SystemExit(f'{key} mismatch: {val} != {baseline[key]}')
+    unowned=[r['key'] for r in rows if not r['duplicateGuard'] or not r['teardown'] or r['status'] not in {'owned','accepted-process-lifetime'}]
+    if unowned: raise SystemExit(f'unowned observer rows: {unowned}')
+    result={'schemaVersion':1,'tool':'build_observer_ownership_inventory.py','baseline':baseline,'metrics':metrics,'unresolvedAstObserveCallsResolvedManually':len(deep.get('unresolvedObserveCalls',[])),'observers':rows,'conclusion':{
+      'allConstructionsAccountedFor':True,'allRegistrationsAccountedFor':True,'allLongLivedObserversOwned':True,
+      'processLifetimeExceptions':['installAllianceBuildingsContextWatcherEarly|MutationObserver|observer'],
+      'runtimeChangeRecommended':False,
+      'nextEvidence':'Use the external browser profiler for authenticated Desktop, Tablet and iOS scenarios before narrowing any broad observer.'}}
+    Path(args.json_output).write_text(json.dumps(result,indent=2)+"\n")
+    lines=['# Observer ownership inventory — Toolkit v4.20.24','',
+      '> Measurement-only evidence. No observer scope, callback, timing or runtime behaviour is changed by this inventory.','',
+      '## Result','',
+      f"- MutationObserver constructions: **{mutation}**",f"- ResizeObserver constructions: **{resize}**",f"- Observe registrations: **{registrations}**",f"- Broad `subtree: true` registrations: **{broad}**",f"- Explicit document/body subtree registrations: **{explicit}**",'- Long-lived observers with a documented owner and duplicate guard: **16 / 16**','- AST-unresolved main-observer registrations manually reconciled: **3 / 3**','',
+      'The early Alliance Buildings observer is the sole deliberate page-process-lifetime exception. It is protected by `allianceBuildingsContextWatcherInstalled`; all other observers are owned by the replaceable Toolkit runtime, with several also having subsystem-specific disconnect paths.','',
+      '## Inventory','',
+      '| Subsystem | Type | Line | Registrations | Ownership | Duplicate guard | Teardown |','|---|---:|---:|---:|---|---|---|']
+    for r in rows:
+        lines.append(f"| {r['subsystem']} | {r['constructor']} | {r['constructionLine']} | {len(r['registrations'])} | {r['ownership']} | {r['duplicateGuard']} | {r['teardown']} |")
+    lines += ['','## Review conclusion','',
+      '- No observer is currently orphaned.','- The three previously unresolved `.observe()` calls belong to the runtime-tracked main MutationObserver created in `boot()`.','- Raw observer count is not an optimisation target. Different ownership and timing semantics must remain separate.','- No production observer change is justified from static ownership evidence alone.','- Issue #256 can be closed as an inventory/audit task; any later narrowing must use one observer subsystem per PR and equivalent live browser evidence.','']
+    Path(args.markdown_output).write_text('\n'.join(lines))
+    print(json.dumps(metrics))
+    return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/.github/scripts/collect_controlled_browser_evidence.py
+++ b/.github/scripts/collect_controlled_browser_evidence.py
@@ -96,7 +96,7 @@ def main()->int:
     Path(args.json_output).write_text(json.dumps(result,indent=2)+"\n")
     md=['# Controlled browser evidence — Toolkit v4.20.24','',
       '> Controlled synthetic Chromium evidence. It verifies repeatable micro-contracts, but it is **not** authenticated MissionChief runtime evidence and does not justify CSS modularisation by itself.','',
-      '## Baseline','',f"- Source SHA-256: `{source_sha}`",f"- Main embedded CSS: **{len(css.encode()):,} bytes**, approximately **{css_rule_estimate:,}** rule blocks",f"- Guarded root attributes: **{len(attrs)}**,'',
+      '## Baseline','',f"- Source SHA-256: `{source_sha}`",f"- Main embedded CSS: **{len(css.encode()):,} bytes**, approximately **{css_rule_estimate:,}** rule blocks",f"- Guarded root attributes: **{len(attrs)}**",'',
       '## Results','', '| Scenario | Viewport | CSS insertion median* | Forced style/layout median* | Initial writes | Unchanged repeat | Changed value | Tamper repair |','|---|---:|---:|---:|---:|---:|---:|---:|']
     for x in scenarios:
         c=x['rootAttributeContract']; v=x['viewport']; md.append(f"| {x['label']} | {v['width']}×{v['height']} | {x['styleInsertMedianMs']:.4f} ms | {x['forcedStyleLayoutMedianMs']:.4f} ms | {c['initialWrites']} | {c['unchangedWrites']} | {c['changedWrites']} | {c['repairedWrites']} |")

--- a/.github/scripts/collect_controlled_browser_evidence.py
+++ b/.github/scripts/collect_controlled_browser_evidence.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Collect controlled Chromium microbenchmarks for Toolkit CSS and guarded root writes.
+
+This is deliberately not a substitute for authenticated MissionChief live scenarios.
+"""
+from __future__ import annotations
+import argparse, hashlib, html, json, re, shutil, statistics, subprocess, tempfile
+from pathlib import Path
+
+VIEWPORTS=[('desktop',1440,900),('tablet',1024,768),('ios',390,844)]
+
+def extract_main_css(source: str) -> str:
+    start=source.index('function installMainStyles()')
+    marker=source.index('addStyle(`',start)+len('addStyle(`')
+    i=marker; escaped=False
+    while i < len(source):
+        ch=source[i]
+        if escaped: escaped=False
+        elif ch=='\\': escaped=True
+        elif ch=='`': return source[marker:i]
+        i+=1
+    raise ValueError('installMainStyles template terminator not found')
+
+def extract_root_attributes(source: str) -> list[str]:
+    start=source.index('function applyRootAttributes()')
+    end=source.index('\n    function getStrongMarkerSignal',start)
+    names=re.findall(r"setAttributeIfChanged\(root, '([^']+)'",source[start:end])
+    if len(names)!=22 or len(set(names))!=22: raise ValueError(f'expected 22 unique root attributes, got {len(names)}')
+    return names
+
+def median(values): return round(statistics.median(values),4)
+
+def html_document(css: str, attrs: list[str], label: str) -> str:
+    payload=json.dumps(css); attrs_json=json.dumps(attrs)
+    return f'''<!doctype html><html><head><meta charset="utf-8"><title>MCMS controlled evidence</title></head><body>
+<div id="map_outer"><div id="map" class="leaflet-container"><div class="leaflet-pane leaflet-marker-pane"></div></div></div>
+<div id="missions" class="missions-panel mission-list"></div><div id="mc-map-command-panel" class="mcms-panel mcms-open"></div>
+<pre id="result">pending</pre><script>
+const CSS={payload}; const ATTRS={attrs_json}; const LABEL={json.dumps(label)};
+for(let i=0;i<120;i++){{const n=document.createElement('div');n.className=`mcms-card mcms-row mcms-setting-row mcms-mission-row mcms-${{i%9}}`;n.textContent='Evidence '+i;document.body.appendChild(n);}}
+const longTasks=[]; const shifts=[];
+try{{new PerformanceObserver(l=>longTasks.push(...l.getEntries().map(e=>e.duration))).observe({{type:'longtask',buffered:true}})}}catch(e){{}}
+try{{new PerformanceObserver(l=>shifts.push(...l.getEntries().filter(e=>!e.hadRecentInput).map(e=>e.value))).observe({{type:'layout-shift',buffered:true}})}}catch(e){{}}
+const inserts=[],layouts=[];
+for(let i=0;i<3;i++){{
+ const style=document.createElement('style');style.id='mc-map-command-style-'+i;style.textContent=CSS+`\n/* controlled-run:${{i}} */`;
+ let t=performance.now();document.head.appendChild(style);inserts.push(performance.now()-t);
+ t=performance.now();const nodes=document.querySelectorAll('.mcms-card,.leaflet-container,#mc-map-command-panel');let checksum=0;for(let j=0;j<nodes.length;j+=5){{const cs=getComputedStyle(nodes[j]);checksum+=nodes[j].offsetHeight+cs.display.length;}}layouts.push(performance.now()-t);style.remove();
+}}
+const root=document.documentElement;let writes=0;const nativeSet=root.setAttribute.bind(root);root.setAttribute=(n,v)=>{{writes++;nativeSet(n,v)}};
+function setAttributeIfChanged(el,n,v){{v=String(v);if(el.getAttribute(n)===v)return false;el.setAttribute(n,v);return true}}
+const values=Object.fromEntries(ATTRS.map((n,i)=>[n,`${{LABEL}}-${{i}}`]));
+function apply(){{for(const n of ATTRS)setAttributeIfChanged(root,n,values[n])}}
+apply();const initialWrites=writes;writes=0;apply();const unchangedWrites=writes;writes=0;values[ATTRS[ATTRS.length-1]]+='-changed';apply();const changedWrites=writes;writes=0;root.removeAttribute(ATTRS[0]);apply();const repairedWrites=writes;
+setTimeout(()=>{{document.getElementById('result').textContent=JSON.stringify({{
+ label:LABEL, cssBytes:new TextEncoder().encode(CSS).length, cssRuleEstimate:(CSS.match(/{{/g)||[]).length,
+ styleInsertSamplesMs:inserts, forcedStyleLayoutSamplesMs:layouts,
+ rootAttributeContract:{{attributeCount:ATTRS.length,initialWrites,unchangedWrites,changedWrites,repairedWrites}},
+ longTasksMs:longTasks, layoutShiftTotal:shifts.reduce((a,b)=>a+b,0), userAgent:navigator.userAgent
+}})}},0);
+</script></body></html>'''
+
+def run_one(chromium: str, doc: Path, width: int, height: int) -> dict:
+    profile=tempfile.mkdtemp(prefix='mcms-chromium-')
+    cmd=[chromium,'--headless=new','--no-sandbox','--disable-gpu','--disable-dev-shm-usage',f'--user-data-dir={profile}','--disable-background-networking','--disable-component-update','--disable-default-apps','--disable-sync','--metrics-recording-only','--mute-audio','--run-all-compositor-stages-before-draw','--virtual-time-budget=2000',f'--window-size={width},{height}','--dump-dom',doc.as_uri()]
+    try:
+        proc=subprocess.run(cmd,text=True,capture_output=True,timeout=90)
+    finally:
+        shutil.rmtree(profile,ignore_errors=True)
+    if proc.returncode: raise RuntimeError(proc.stderr[-2000:])
+    m=re.search(r'<pre id="result">(.*?)</pre>',proc.stdout,re.S)
+    if not m: raise RuntimeError('Chromium result payload not found')
+    return json.loads(html.unescape(m.group(1)))
+
+def main()->int:
+    ap=argparse.ArgumentParser(); ap.add_argument('--source',default='src/MissionChief_Map_Command_Toolkit.user.js'); ap.add_argument('--json-output',default='docs/audits/controlled-browser-evidence-v4.20.24.json'); ap.add_argument('--markdown-output',default='docs/audits/controlled-browser-evidence-v4.20.24.md'); ap.add_argument('--chromium'); args=ap.parse_args()
+    source_path=Path(args.source); source=source_path.read_text(); css=extract_main_css(source); attrs=extract_root_attributes(source)
+    chromium=args.chromium or shutil.which('google-chrome') or shutil.which('chromium') or shutil.which('chromium-browser')
+    if not chromium: raise SystemExit('Chromium/Chrome executable not found')
+    scenarios=[]
+    with tempfile.TemporaryDirectory() as td:
+        td=Path(td)
+        for label,w,h in VIEWPORTS:
+            doc=td/f'{label}.html'; doc.write_text(html_document(css,attrs,label))
+            raw=run_one(chromium,doc,w,h)
+            raw['viewport']={'width':w,'height':h}
+            raw['styleInsertMedianMs']=median(raw['styleInsertSamplesMs'][1:])
+            raw['forcedStyleLayoutMedianMs']=median(raw['forcedStyleLayoutSamplesMs'][1:])
+            scenarios.append(raw)
+    source_sha=hashlib.sha256(source_path.read_bytes()).hexdigest()
+    result={'schemaVersion':1,'evidenceClass':'controlled-synthetic-browser','tool':'collect_controlled_browser_evidence.py','baseline':{'version':'4.20.24','sourceSha256':source_sha,'sourceBytes':source_path.stat().st_size,'sourceLines':sum(1 for _ in source_path.open()),'cssBytes':len(css.encode()),'cssRuleEstimate':css.count('{'),'rootAttributeCount':len(attrs)},'environment':{'browserExecutable':Path(chromium).name,'note':'Browser timings vary by runner and are not performance budgets.'},'scenarios':scenarios,'conclusions':{
+      'rootWriteSuppressionVerified':all(x['rootAttributeContract']=={'attributeCount':22,'initialWrites':22,'unchangedWrites':0,'changedWrites':1,'repairedWrites':1} for x in scenarios),
+      'cssTargetProven':False,'liveMissionChiefEvidenceCaptured':False,
+      'nextAction':'Capture equivalent authenticated idle map, settings, mission-window and map-pan profiler scenarios before changing style delivery or broader render paths.'}}
+    Path(args.json_output).write_text(json.dumps(result,indent=2)+"\n")
+    md=['# Controlled browser evidence — Toolkit v4.20.24','',
+      '> Controlled synthetic Chromium evidence. It verifies repeatable micro-contracts, but it is **not** authenticated MissionChief runtime evidence and does not justify CSS modularisation by itself.','',
+      '## Baseline','',f"- Source SHA-256: `{source_sha}`",f"- Main embedded CSS: **{len(css.encode()):,} bytes**, approximately **{css.count('{'):,}** rule blocks",f"- Guarded root attributes: **{len(attrs)}**,'',
+      '## Results','', '| Scenario | Viewport | CSS insertion median* | Forced style/layout median* | Initial writes | Unchanged repeat | Changed value | Tamper repair |','|---|---:|---:|---:|---:|---:|---:|---:|']
+    for x in scenarios:
+        c=x['rootAttributeContract']; v=x['viewport']; md.append(f"| {x['label']} | {v['width']}×{v['height']} | {x['styleInsertMedianMs']:.4f} ms | {x['forcedStyleLayoutMedianMs']:.4f} ms | {c['initialWrites']} | {c['unchangedWrites']} | {c['changedWrites']} | {c['repairedWrites']} |")
+    md += ['','* Median excludes the first warm-up sample. Values are diagnostic, hardware-specific and not release budgets.','',
+      '## Decisions','',
+      '- The existing `setAttributeIfChanged` optimisation is verified in a real browser DOM: first application writes all 22 missing attributes, an unchanged repeat writes zero, one changed state writes one, and external tampering is repaired with one write.','- This closes the isolated root-write question already implemented under #279; it does not prove that every `updateUI()` path is free from unchanged work.','- The CSS microbenchmark establishes a reproducible controlled baseline across Desktop, Tablet and iOS-sized viewports. It does not include MissionChief map, mission-window, settings or pan workloads, so #254 remains open.','- No production runtime change is recommended from this controlled evidence alone.','']
+    Path(args.markdown_output).write_text('\n'.join(md))
+    if not result['conclusions']['rootWriteSuppressionVerified']: raise SystemExit('root attribute browser contract failed')
+    print(json.dumps({'scenarios':len(scenarios),'cssBytes':len(css.encode()),'rootContract':True}))
+    return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/.github/scripts/collect_controlled_browser_evidence.py
+++ b/.github/scripts/collect_controlled_browser_evidence.py
@@ -75,7 +75,7 @@ def run_one(chromium: str, doc: Path, width: int, height: int) -> dict:
 def main()->int:
     ap=argparse.ArgumentParser(); ap.add_argument('--source',default='src/MissionChief_Map_Command_Toolkit.user.js'); ap.add_argument('--json-output',default='docs/audits/controlled-browser-evidence-v4.20.24.json'); ap.add_argument('--markdown-output',default='docs/audits/controlled-browser-evidence-v4.20.24.md'); ap.add_argument('--chromium'); args=ap.parse_args()
     source_path=Path(args.source); source=source_path.read_text(); css=extract_main_css(source); attrs=extract_root_attributes(source)
-    chromium=args.chromium or shutil.which('google-chrome') or shutil.which('chromium') or shutil.which('chromium-browser')
+    chromium=args.chromium or shutil.which('google-chrome') or shutil.which('google-chrome-stable') or shutil.which('chromium') or shutil.which('chromium-browser')
     if not chromium: raise SystemExit('Chromium/Chrome executable not found')
     scenarios=[]
     with tempfile.TemporaryDirectory() as td:
@@ -88,14 +88,15 @@ def main()->int:
             raw['forcedStyleLayoutMedianMs']=median(raw['forcedStyleLayoutSamplesMs'][1:])
             scenarios.append(raw)
     source_sha=hashlib.sha256(source_path.read_bytes()).hexdigest()
-    result={'schemaVersion':1,'evidenceClass':'controlled-synthetic-browser','tool':'collect_controlled_browser_evidence.py','baseline':{'version':'4.20.24','sourceSha256':source_sha,'sourceBytes':source_path.stat().st_size,'sourceLines':sum(1 for _ in source_path.open()),'cssBytes':len(css.encode()),'cssRuleEstimate':css.count('{'),'rootAttributeCount':len(attrs)},'environment':{'browserExecutable':Path(chromium).name,'note':'Browser timings vary by runner and are not performance budgets.'},'scenarios':scenarios,'conclusions':{
+    css_rule_estimate=css.count('{')
+    result={'schemaVersion':1,'evidenceClass':'controlled-synthetic-browser','tool':'collect_controlled_browser_evidence.py','baseline':{'version':'4.20.24','sourceSha256':source_sha,'sourceBytes':source_path.stat().st_size,'sourceLines':sum(1 for _ in source_path.open()),'cssBytes':len(css.encode()),'cssRuleEstimate':css_rule_estimate,'rootAttributeCount':len(attrs)},'environment':{'browserExecutable':Path(chromium).name,'note':'Browser timings vary by runner and are not performance budgets.'},'scenarios':scenarios,'conclusions':{
       'rootWriteSuppressionVerified':all(x['rootAttributeContract']=={'attributeCount':22,'initialWrites':22,'unchangedWrites':0,'changedWrites':1,'repairedWrites':1} for x in scenarios),
       'cssTargetProven':False,'liveMissionChiefEvidenceCaptured':False,
       'nextAction':'Capture equivalent authenticated idle map, settings, mission-window and map-pan profiler scenarios before changing style delivery or broader render paths.'}}
     Path(args.json_output).write_text(json.dumps(result,indent=2)+"\n")
     md=['# Controlled browser evidence — Toolkit v4.20.24','',
       '> Controlled synthetic Chromium evidence. It verifies repeatable micro-contracts, but it is **not** authenticated MissionChief runtime evidence and does not justify CSS modularisation by itself.','',
-      '## Baseline','',f"- Source SHA-256: `{source_sha}`",f"- Main embedded CSS: **{len(css.encode()):,} bytes**, approximately **{css.count('{'):,}** rule blocks",f"- Guarded root attributes: **{len(attrs)}**,'',
+      '## Baseline','',f"- Source SHA-256: `{source_sha}`",f"- Main embedded CSS: **{len(css.encode()):,} bytes**, approximately **{css_rule_estimate:,}** rule blocks",f"- Guarded root attributes: **{len(attrs)}**,'',
       '## Results','', '| Scenario | Viewport | CSS insertion median* | Forced style/layout median* | Initial writes | Unchanged repeat | Changed value | Tamper repair |','|---|---:|---:|---:|---:|---:|---:|---:|']
     for x in scenarios:
         c=x['rootAttributeContract']; v=x['viewport']; md.append(f"| {x['label']} | {v['width']}×{v['height']} | {x['styleInsertMedianMs']:.4f} ms | {x['forcedStyleLayoutMedianMs']:.4f} ms | {c['initialWrites']} | {c['unchangedWrites']} | {c['changedWrites']} | {c['repairedWrites']} |")

--- a/.github/scripts/test_observer_ownership_inventory.py
+++ b/.github/scripts/test_observer_ownership_inventory.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Regenerate and validate the pinned v4.20.24 observer ownership inventory."""
+from __future__ import annotations
+import json, subprocess, tempfile
+from pathlib import Path
+ROOT=Path(__file__).resolve().parents[2]
+with tempfile.TemporaryDirectory() as td:
+    td=Path(td); deep_json=td/'deep.json'; deep_md=td/'deep.md'; inv_json=td/'inventory.json'; inv_md=td/'inventory.md'
+    subprocess.run(['node','.github/scripts/deep_performance_audit.mjs','--source','src/MissionChief_Map_Command_Toolkit.user.js','--json-output',str(deep_json),'--markdown-output',str(deep_md)],check=True,cwd=ROOT)
+    subprocess.run(['python3','.github/scripts/build_observer_ownership_inventory.py','--source','src/MissionChief_Map_Command_Toolkit.user.js','--deep-json',str(deep_json),'--fixture','.github/fixtures/observer-ownership-v4.20.24.json','--json-output',str(inv_json),'--markdown-output',str(inv_md)],check=True,cwd=ROOT)
+    generated_inv=json.loads(inv_json.read_text())
+    if (ROOT/'docs/audits/observer-ownership-v4.20.24.md').read_text() != inv_md.read_text(): raise SystemExit('committed observer inventory Markdown is stale')
+    assert generated_inv['conclusion']['allLongLivedObserversOwned'] is True
+    assert generated_inv['metrics']['observeRegistrations'] == 19
+    assert generated_inv['metrics']['broadSubtreeRegistrations'] == 10
+print('Observer ownership inventory contract passed.')

--- a/.github/workflows/performance-evidence-audit.yml
+++ b/.github/workflows/performance-evidence-audit.yml
@@ -1,0 +1,69 @@
+name: Performance Evidence Audit
+
+run-name: Performance evidence · ${{ github.event_name }}
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/fixtures/observer-ownership-v4.20.24.json"
+      - ".github/scripts/build_observer_ownership_inventory.py"
+      - ".github/scripts/test_observer_ownership_inventory.py"
+      - ".github/scripts/collect_controlled_browser_evidence.py"
+      - ".github/workflows/performance-evidence-audit.yml"
+      - "docs/audits/observer-ownership-v4.20.24.md"
+      - "docs/audits/performance-evidence-v4.20.24.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  evidence:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Prove measurement-only source and distribution boundary
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin main --depth=1
+          if ! git diff --quiet origin/main...HEAD -- src dist; then
+            echo "::error::Measurement-only performance evidence changed src/ or dist/."
+            git diff --stat origin/main...HEAD -- src dist
+            exit 1
+          fi
+
+      - name: Install exact AST parser
+        run: npm install --no-save --ignore-scripts --no-audit --no-fund acorn@8.15.0
+
+      - name: Validate deep audit and observer ownership inventory
+        run: python3 .github/scripts/test_observer_ownership_inventory.py
+
+      - name: Collect controlled Chromium evidence
+        run: |
+          python3 .github/scripts/collect_controlled_browser_evidence.py \
+            --json-output controlled-browser-evidence-v4.20.24.json \
+            --markdown-output controlled-browser-evidence-v4.20.24.md
+
+      - name: Publish controlled evidence summary
+        run: cat controlled-browser-evidence-v4.20.24.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload measurement evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: toolkit-performance-evidence-v4.20.24
+          path: |
+            controlled-browser-evidence-v4.20.24.json
+            controlled-browser-evidence-v4.20.24.md
+            docs/audits/observer-ownership-v4.20.24.md
+            docs/audits/performance-evidence-v4.20.24.md
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/performance-evidence-audit.yml
+++ b/.github/workflows/performance-evidence-audit.yml
@@ -48,10 +48,43 @@ jobs:
         run: python3 .github/scripts/test_observer_ownership_inventory.py
 
       - name: Collect controlled Chromium evidence
+        id: browser
+        shell: bash
         run: |
+          set +e
+          {
+            echo "Browser candidates:"
+            command -v google-chrome || true
+            command -v google-chrome-stable || true
+            command -v chromium || true
+            command -v chromium-browser || true
+            google-chrome --version 2>/dev/null || true
+            google-chrome-stable --version 2>/dev/null || true
+            chromium --version 2>/dev/null || true
+          } > controlled-browser-diagnostic.txt 2>&1
           python3 .github/scripts/collect_controlled_browser_evidence.py \
             --json-output controlled-browser-evidence-v4.20.24.json \
-            --markdown-output controlled-browser-evidence-v4.20.24.md
+            --markdown-output controlled-browser-evidence-v4.20.24.md \
+            >> controlled-browser-diagnostic.txt 2>&1
+          STATUS=$?
+          echo "collector_exit_code=$STATUS" >> controlled-browser-diagnostic.txt
+          echo "exit_code=$STATUS" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Upload browser diagnostic
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: toolkit-controlled-browser-diagnostic
+          path: controlled-browser-diagnostic.txt
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Stop on controlled browser failure
+        if: steps.browser.outputs.exit_code != '0'
+        run: |
+          cat controlled-browser-diagnostic.txt
+          exit 1
 
       - name: Publish controlled evidence summary
         run: cat controlled-browser-evidence-v4.20.24.md >> "$GITHUB_STEP_SUMMARY"

--- a/docs/audits/observer-ownership-v4.20.24.md
+++ b/docs/audits/observer-ownership-v4.20.24.md
@@ -1,0 +1,44 @@
+# Observer ownership inventory — Toolkit v4.20.24
+
+> Measurement-only evidence. No observer scope, callback, timing or runtime behaviour is changed by this inventory.
+
+## Result
+
+- MutationObserver constructions: **12**
+- ResizeObserver constructions: **4**
+- Observe registrations: **19**
+- Broad `subtree: true` registrations: **10**
+- Explicit document/body subtree registrations: **3**
+- Long-lived observers with a documented owner and duplicate guard: **16 / 16**
+- AST-unresolved main-observer registrations manually reconciled: **3 / 3**
+
+The early Alliance Buildings observer is the sole deliberate page-process-lifetime exception. It is protected by `allianceBuildingsContextWatcherInstalled`; all other observers are owned by the replaceable Toolkit runtime, with several also having subsystem-specific disconnect paths.
+
+## Inventory
+
+| Subsystem | Type | Line | Registrations | Ownership | Duplicate guard | Teardown |
+|---|---:|---:|---:|---|---|---|
+| Alliance Buildings early suppression | MutationObserver | 421 | 1 | page-process-lifetime | allianceBuildingsContextWatcherInstalled | Browser document lifetime; not registered in the replaceable Toolkit runtime. |
+| Desktop panel workspace | ResizeObserver | 13849 | 1 | runtime | desktopPanelResizeObserver singleton plus desktopPanelObservedElements set | runtime.destroy disconnects; stopDesktopPanelWorkspaceObservation unobserves current elements. |
+| Tablet map area | ResizeObserver | 14028 | 1 | runtime | tabletDockResizeObserver singleton and observed-element identity | runtime.destroy disconnects; tablet observation reset disconnects/unobserves. |
+| Custom vehicle badges | MutationObserver | 15301 | 1 | runtime | customVehicleBadgeObservedDocuments WeakSet | runtime.destroy disconnects all tracked observers. |
+| Major Incident Feed | ResizeObserver | 19469 | 2 | runtime-and-subsystem | majorIncidentFeedObservedElement identity | resetMajorIncidentFeedObserver disconnects; runtime.destroy is final owner. |
+| Mission Value host sizing | ResizeObserver | 21539 | 1 | runtime-and-record | missionValueHostObservers Map keyed by spacer | pruneMissionValueHostObservers disconnects stale records; runtime.destroy is final owner. |
+| Mission Value toolbar content | MutationObserver | 21543 | 1 | runtime-and-record | missionValueHostObservers Map keyed by spacer | pruneMissionValueHostObservers disconnects stale records; runtime.destroy is final owner. |
+| Mission Value document discovery | MutationObserver | 21701 | 1 | runtime | missionValueObservedDocuments WeakSet | runtime.destroy disconnects. |
+| Mission Requirements live record | MutationObserver | 22986 | 1 | runtime-and-record | missionRequirementsRecords record identity | record cleanup disconnects; runtime.destroy is final owner. |
+| Mission Requirements document discovery | MutationObserver | 23087 | 1 | runtime | missionRequirementsObservedDocuments WeakSet | runtime.destroy disconnects. |
+| Credits total | MutationObserver | 25843 | 1 | runtime-and-element | observedCreditsElement identity plus creditsValueObserver | Explicitly disconnects and untracks before replacing; runtime.destroy is final owner. |
+| Alliance Buildings page rendering | MutationObserver | 30955 | 1 | runtime | install path returns early from normal boot for the page context | runtime.destroy disconnects. |
+| Auto-load mission root visibility | MutationObserver | 31163 | 1 | runtime-and-subsystem | Always disconnects previous root observer before binding. | disconnectAutoLoadAllVehiclesRootObserver and runtime.destroy. |
+| Auto-load native link state | MutationObserver | 31181 | 1 | runtime-and-subsystem | Always disconnects previous link observer before binding. | disconnectAutoLoadAllVehiclesLinkObserver and runtime.destroy. |
+| Auto-load document discovery | MutationObserver | 31294 | 1 | runtime-and-subsystem | autoLoadAllVehiclesObserver singleton | stopAutoLoadAllVehicles untracks/disconnects; runtime.destroy is final owner. |
+| Main map and mission lifecycle | MutationObserver | 31354 | 3 | runtime | bootStarted plus replaceable runtime singleton | runtime.destroy disconnects; connectMainMutationObserver disconnects before re-targeting. |
+
+## Review conclusion
+
+- No observer is currently orphaned.
+- The three previously unresolved `.observe()` calls belong to the runtime-tracked main MutationObserver created in `boot()`.
+- Raw observer count is not an optimisation target. Different ownership and timing semantics must remain separate.
+- No production observer change is justified from static ownership evidence alone.
+- Issue #256 can be closed as an inventory/audit task; any later narrowing must use one observer subsystem per PR and equivalent live browser evidence.

--- a/docs/audits/performance-evidence-v4.20.24.md
+++ b/docs/audits/performance-evidence-v4.20.24.md
@@ -1,0 +1,66 @@
+# Performance evidence checkpoint — Toolkit v4.20.24
+
+## Safety boundary
+
+This checkpoint is measurement-only. It changes no userscript source, distribution asset, version, release channel, observer scope, scheduler timing, selector, style rule or rendered state.
+
+Production baseline:
+
+- Toolkit: `4.20.24`
+- Source SHA-256: `4bd9a9f3708292a6a48523f2f4d69b105e5957395fb10bcbeec671a4d8a4029c`
+- Source: `2,060,506` bytes and `31,657` lines
+- Verified public release completed on 21 July 2026
+
+## Refreshed deep audit
+
+The AST-backed v4.20.24 evidence records:
+
+- 1,778 functions and callbacks;
+- 121 scheduler call sites;
+- 12 MutationObserver constructions;
+- 4 ResizeObserver constructions;
+- 19 total `.observe()` registrations after manual reconciliation;
+- 10 broad `subtree: true` registrations;
+- 3 explicit document/body subtree registrations;
+- 343 lines of remaining source headroom;
+- an 818,141-byte main embedded CSS template with approximately 6,394 rule blocks;
+- `updateUI()` as the highest non-style DOM hotspot at 52 reads and 49 writes in static evidence.
+
+Static concentration does not establish live frequency or user-visible cost.
+
+## Observer ownership conclusion — #256
+
+Every construction and registration has been inventoried with its installation condition, target/options, scheduling, owner, teardown, duplicate guard, replacement handling and current deterministic coverage.
+
+- 15 observers are owned by the replaceable Toolkit runtime, with several also having subsystem-specific disconnect paths.
+- The early Alliance Buildings context observer is the sole deliberate page-process-lifetime exception and is guarded by `allianceBuildingsContextWatcherInstalled`.
+- The three AST-unresolved registrations are all calls on the runtime-tracked main MutationObserver created by `boot()`.
+- No observer is orphaned.
+- No observer merge or scope reduction is justified by ownership evidence alone.
+
+Issue #256 can close as an audit/inventory task. Any later observer optimisation must remain a separate subsystem-specific PR with equivalent authenticated browser evidence.
+
+## Render evidence status — #255
+
+The existing #279 root-attribute optimisation already guards all 22 root attributes with `setAttributeIfChanged` and deterministic runtime tests. The controlled Chromium harness included in this checkpoint independently verifies the intended browser-DOM contract when executed in CI:
+
+- first application writes all 22 missing attributes;
+- an unchanged repeat writes zero;
+- one changed state writes one;
+- external removal is repaired with one write.
+
+This resolves only the isolated root-write surface. It does not measure unchanged operational-panel renders, mission-window replacements, map movement or settings interactions. Issue #255 therefore remains open pending authenticated scenarios from the external profiler.
+
+## CSS evidence status — #254
+
+The controlled browser harness injects the actual v4.20.24 main CSS template across Desktop, Tablet and iOS-sized viewports and records insertion plus forced style/layout samples. These values are runner-specific diagnostics, not budgets.
+
+Synthetic style installation cannot reproduce MissionChief map tiles, mission markers, settings, mission windows or map-pan workloads. Issue #254 remains open until equivalent authenticated browser captures prove that CSS parsing, style recalculation or layout is a material bottleneck.
+
+## Decision queue
+
+1. Close #256 after the measurement PR merges.
+2. Keep #254 and #255 open.
+3. Capture equivalent authenticated profiler sessions for idle map, settings open, mission open/close, unit selection, map pan and layout change on Desktop, Tablet and iOS-compatible scenarios.
+4. Select one isolated runtime change only when live evidence identifies a measurable target and deterministic invalidation/visual contracts exist.
+5. Do not create a public Toolkit release for this measurement-only checkpoint.


### PR DESCRIPTION
## Summary

Adds a measurement-only v4.20.24 performance checkpoint without changing Toolkit runtime, distribution, version or release state.

## Evidence

- Re-runs the AST-backed deep performance audit against the verified v4.20.24 source SHA.
- Accounts for all 12 MutationObservers, 4 ResizeObservers and 19 `.observe()` registrations.
- Manually reconciles the three main-observer registrations that cannot be linked cross-function by the AST audit.
- Records installation conditions, target/options, callback scheduling, lifecycle owner, teardown, duplicate guard, replacement handling and deterministic coverage for every observer.
- Confirms 16/16 long-lived observers have an explicit owner and duplicate guard.
- Adds a controlled Chromium harness using the actual embedded CSS and all 22 guarded root attributes across Desktop, Tablet and iOS-sized viewports.
- Explicitly classifies controlled browser timings as diagnostic evidence, not live MissionChief budgets.

## Decisions

- No observer is orphaned.
- No observer merge, scope narrowing or runtime change is justified by static ownership evidence alone.
- The root-attribute write suppression delivered under #279 is browser-verifiable, but broader unchanged-render evidence is still required.
- CSS modularisation remains blocked pending authenticated MissionChief map, settings, mission-window and pan captures.
- No public Toolkit release is required for this evidence-only change.

## Validation

The dedicated workflow:

- rejects any `src/` or `dist/` change;
- installs the pinned Acorn parser;
- regenerates and validates the observer inventory;
- collects controlled Chromium evidence;
- uploads the complete measurement artifact for review.

Closes #256
Refs #247
Refs #254
Refs #255