### PR TITLE
Prevent duplicate monitoring incidents and bot-authored rollback PRs

### DIFF
--- a/.github/actions-security-policy.json
+++ b/.github/actions-security-policy.json
@@ -40,11 +40,6 @@
     ".github/workflows/pages-production-monitor.yml": [
       "issues"
     ],
-    ".github/workflows/prepare-release-rollback.yml": [
-      "contents",
-      "issues",
-      "pull-requests"
-    ],
     ".github/workflows/publish-update-manifest.yml": [
       "contents"
     ],

--- a/.github/scripts/test_automation_record_hygiene.py
+++ b/.github/scripts/test_automation_record_hygiene.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Prevent workflows from recreating issue, PR and approval-gate clutter."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+ASSET = ROOT / ".github/workflows/asset-health-monitor.yml"
+ROLLBACK = ROOT / ".github/workflows/prepare-release-rollback.yml"
+PAGES = ROOT / ".github/scripts/reconcile_pages_incident.sh"
+POLICY = ROOT / ".github/actions-security-policy.json"
+
+
+def require(text: str, marker: str) -> None:
+    if marker not in text:
+        raise AssertionError(f"Missing automation hygiene marker: {marker}")
+
+
+def forbid(text: str, marker: str) -> None:
+    if marker in text:
+        raise AssertionError(f"Forbidden automation hygiene marker: {marker}")
+
+
+def main() -> int:
+    asset = ASSET.read_text(encoding="utf-8")
+    require(asset, "SEARCH_QUERY='\"Toolkit public assets unavailable\" in:title'")
+    require(asset, 'gh issue list \\\n            --state all \\\n            --search "$SEARCH_QUERY"')
+    require(asset, "TRANSITION=\"existing\"")
+    forbid(asset, "gh issue list --state all --limit 100")
+
+    pages = PAGES.read_text(encoding="utf-8")
+    require(pages, "SEARCH_QUERY='\"GitHub Pages production health incident\" in:title'")
+    require(pages, 'gh issue list --state all --search "$SEARCH_QUERY"')
+
+    rollback = ROLLBACK.read_text(encoding="utf-8")
+    permission_block = rollback[rollback.index("permissions:"):rollback.index("\nconcurrency:")]
+    require(permission_block, "contents: read")
+    forbid(permission_block, "contents: write")
+    forbid(permission_block, "pull-requests: write")
+    forbid(permission_block, "issues: write")
+    require(rollback, "Require owner rollback token")
+    require(rollback, "secrets.DEVELOPMENT_PR_TOKEN")
+    require(rollback, "DEVELOPMENT_PR_TOKEN is required to create an owner-authenticated rollback PR.")
+    require(rollback, 'git config user.name "Conroy1988"')
+    require(rollback, "27301455+Conroy1988@users.noreply.github.com")
+    require(rollback, "GH_TOKEN: ${{ secrets.DEVELOPMENT_PR_TOKEN }}")
+    forbid(rollback, 'git config user.name "github-actions[bot]"')
+    forbid(rollback, "41898282+github-actions[bot]@users.noreply.github.com")
+    forbid(rollback, "GH_TOKEN: ${{ github.token }}\n          SOURCE_VERSION")
+
+    policy = json.loads(POLICY.read_text(encoding="utf-8"))
+    if ".github/workflows/prepare-release-rollback.yml" in policy.get("allowedWritePermissions", {}):
+        raise AssertionError("Rollback workflow must not receive GITHUB_TOKEN write permissions")
+    if policy.get("allowedWritePermissions", {}).get(".github/workflows/asset-health-monitor.yml") != ["issues"]:
+        raise AssertionError("Asset-health monitor should retain issue-only incident write permission")
+
+    print("Automation record hygiene passed: managed incidents deduplicate and rollback PRs use owner identity.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/asset-health-monitor.yml
+++ b/.github/workflows/asset-health-monitor.yml
@@ -147,12 +147,17 @@ jobs:
         run: |
           set -euo pipefail
           TITLE="[Asset Health] Toolkit public assets unavailable"
+          SEARCH_QUERY='"Toolkit public assets unavailable" in:title'
           FAILURES="$(jq -r '.summary.failures // 1' asset-health-report.json)"
           WARNINGS="$(jq -r '.summary.warnings // 0' asset-health-report.json)"
           FINGERPRINT="$(jq -r '.fingerprint // "unknown"' asset-health-report.json)"
           VERSION="$(jq -r '.latestRelease.version // "unknown"' asset-health-report.json)"
 
-          gh issue list --state all --limit 100 --json number,title,state,url > /tmp/asset-health-issues.json
+          gh issue list \
+            --state all \
+            --search "$SEARCH_QUERY" \
+            --limit 20 \
+            --json number,title,state,url > /tmp/asset-health-issues.json
           NUMBER="$(jq -r --arg title "$TITLE" '[.[] | select(.title == $title)] | sort_by(.number) | last | .number // empty' /tmp/asset-health-issues.json)"
           STATE="$(jq -r --arg title "$TITLE" '[.[] | select(.title == $title)] | sort_by(.number) | last | .state // empty' /tmp/asset-health-issues.json)"
 

--- a/.github/workflows/prepare-release-rollback.yml
+++ b/.github/workflows/prepare-release-rollback.yml
@@ -18,9 +18,7 @@ on:
         type: string
 
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: read
 
 concurrency:
   group: toolkit-rollback-preparation
@@ -33,11 +31,23 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - name: Check out latest main
+      - name: Require owner rollback token
+        env:
+          OWNER_TOKEN: ${{ secrets.DEVELOPMENT_PR_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ -n "$OWNER_TOKEN" ]] || {
+            echo "::error::DEVELOPMENT_PR_TOKEN is required to create an owner-authenticated rollback PR."
+            exit 1
+          }
+
+      - name: Check out latest main with owner identity
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: main
           fetch-depth: 0
+          token: ${{ secrets.DEVELOPMENT_PR_TOKEN }}
 
       - name: Validate rollback request
         id: request
@@ -112,10 +122,10 @@ jobs:
             --json-output rollback-performance.json \
             --markdown-output rollback-performance.md
 
-      - name: Open rollback review pull request
+      - name: Open owner-authenticated rollback review pull request
         id: pr
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.DEVELOPMENT_PR_TOKEN }}
           SOURCE_VERSION: ${{ inputs.source_version }}
           RECOVERY_VERSION: ${{ inputs.recovery_version }}
           CURRENT_VERSION: ${{ steps.request.outputs.current_version }}
@@ -125,8 +135,8 @@ jobs:
           set -euo pipefail
           CANDIDATE_HASH="$(sha256sum src/MissionChief_Map_Command_Toolkit.user.js | awk '{print $1}')"
           BRANCH="recovery/rollback-v${SOURCE_VERSION}-to-v${RECOVERY_VERSION}-${GITHUB_RUN_ID}"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "Conroy1988"
+          git config user.email "27301455+Conroy1988@users.noreply.github.com"
           git switch -c "$BRANCH"
           git add \
             src/MissionChief_Map_Command_Toolkit.user.js \

--- a/.github/workflows/validate-development-package-workflow.yml
+++ b/.github/workflows/validate-development-package-workflow.yml
@@ -1,10 +1,15 @@
-name: Development Package Workflow Policy
+name: Development and Automation Workflow Policy
 
 on:
   pull_request:
     paths:
       - .github/workflows/apply-development-package.yml
+      - .github/workflows/asset-health-monitor.yml
+      - .github/workflows/prepare-release-rollback.yml
+      - .github/workflows/pages-production-monitor.yml
       - .github/workflows/validate-development-package-workflow.yml
+      - .github/scripts/reconcile_pages_incident.sh
+      - .github/scripts/test_automation_record_hygiene.py
       - .github/scripts/test_development_package_workflow.py
       - .github/actions-security-policy.json
       - docs/DEVELOPMENT_PACKAGE_WORKFLOW.md
@@ -24,20 +29,23 @@ jobs:
         with:
           show-progress: false
 
-      - name: Run development-package workflow policy
+      - name: Run workflow policy contracts
         id: policy
         continue-on-error: true
         shell: bash
         run: |
           set -o pipefail
-          python3 .github/scripts/test_development_package_workflow.py 2>&1 | tee "$RUNNER_TEMP/development-package-policy.log"
+          {
+            python3 .github/scripts/test_development_package_workflow.py
+            python3 .github/scripts/test_automation_record_hygiene.py
+          } 2>&1 | tee "$RUNNER_TEMP/workflow-policy.log"
 
       - name: Upload policy diagnostics
         if: steps.policy.outcome != 'success'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: development-package-policy-diagnostic
-          path: ${{ runner.temp }}/development-package-policy.log
+          name: workflow-policy-diagnostic
+          path: ${{ runner.temp }}/workflow-policy.log
           if-no-files-found: error
           retention-days: 7
 


### PR DESCRIPTION
## Purpose

Complete the repository-wide automation audit after the v5 recovery issue/PR storm.

## Changes

- Make Asset Health locate its persistent managed incident by exact GitHub search instead of scanning only the latest 100 issues.
- Preserve exactly one managed Asset Health incident across failure, recurrence and recovery cycles.
- Require `DEVELOPMENT_PR_TOKEN` before emergency rollback preparation begins.
- Create rollback branches, commits and pull requests under the `Conroy1988` owner identity rather than `github-actions[bot]`.
- Reduce the rollback workflow's `GITHUB_TOKEN` permissions to read-only.
- Add an automation-record hygiene contract covering Asset Health, GitHub Pages incident reconciliation, rollback identity and workflow permission policy.
- Expand the workflow-policy CI to enforce these invariants permanently.

## Expected result

Automated monitors may maintain one persistent incident per monitor, but cannot multiply incidents because the issue history exceeds 100 entries. Emergency rollback PRs continue to be created only after explicit manual confirmation, but their commits and PR updates are owner-authenticated and therefore do not trigger maintainer-approval-gated Actions.