### PR TITLE
Inventory and enforce every public main write path

### DIFF
--- a/.github/branch-write-inventory.json
+++ b/.github/branch-write-inventory.json
@@ -1,0 +1,179 @@
+{
+  "schemaVersion": 1,
+  "reviewedAt": "2026-07-24",
+  "reviewedMainCommit": "bfd3a786a17a2cf01a0aa0d3d6f9a3f235ab1f2c",
+  "strictProtectionEnabled": false,
+  "directMainWriters": [
+    {
+      "workflow": ".github/workflows/validate-userscript.yml",
+      "purpose": "Commit the validated distribution candidate and generated release dashboard state after canonical validation on main.",
+      "credential": "github.token",
+      "actor": "github-actions[bot]",
+      "writes": [
+        "dist/",
+        "status/release-dashboard.json",
+        "status/README.md"
+      ],
+      "migrationTarget": "generated-state branch or release artifact"
+    },
+    {
+      "workflow": ".github/workflows/greasyfork-release-monitor.yml",
+      "purpose": "Record and reconcile the Greasy Fork/Discord announcement version tracker.",
+      "credential": "github.token",
+      "actor": "github-actions[bot]",
+      "writes": [
+        ".github/greasyfork-version.txt"
+      ],
+      "migrationTarget": "release-state branch"
+    },
+    {
+      "workflow": ".github/workflows/import-canonical-userscript.yml",
+      "purpose": "Import the live Greasy Fork userscript and source baseline directly into the canonical repository.",
+      "credential": "github.token",
+      "actor": "github-actions[bot]",
+      "writes": [
+        "src/MissionChief_Map_Command_Toolkit.user.js",
+        "status/source-baseline.json"
+      ],
+      "migrationTarget": "owner-created pull request only; retire when GitHub remains authoritative"
+    },
+    {
+      "workflow": ".github/workflows/publish-update-manifest.yml",
+      "purpose": "Publish the stable update manifest after all release channels are verified.",
+      "credential": "github.token",
+      "actor": "github-actions[bot]",
+      "writes": [
+        "status/update-manifest.json"
+      ],
+      "migrationTarget": "release-state branch or immutable release asset"
+    },
+    {
+      "workflow": ".github/workflows/reconcile-release-announcement-state.yml",
+      "purpose": "Synchronize the fallback announcement tracker after a verified release.",
+      "credential": "github.token",
+      "actor": "github-actions[bot]",
+      "writes": [
+        ".github/greasyfork-version.txt"
+      ],
+      "migrationTarget": "release-state branch"
+    },
+    {
+      "workflow": ".github/workflows/release-recovery.yml",
+      "purpose": "Record controlled Greasy Fork, private-backup, Discord and dashboard recovery state.",
+      "credential": "github.token",
+      "actor": "github-actions[bot]",
+      "writes": [
+        "status/release-dashboard.json",
+        "status/README.md",
+        ".github/greasyfork-version.txt"
+      ],
+      "migrationTarget": "release-state branch; release-object repair remains API-based"
+    },
+    {
+      "workflow": ".github/workflows/release-toolkit-dry-run.yml",
+      "purpose": "Record a reviewable release dry-run result in the production dashboard.",
+      "credential": "github.token",
+      "actor": "github-actions[bot]",
+      "writes": [
+        "status/release-dashboard.json"
+      ],
+      "migrationTarget": "artifact-only dry run; no protected-branch mutation"
+    },
+    {
+      "workflow": ".github/workflows/release-toolkit.yml",
+      "purpose": "Commit the stable Greasy Fork root mirror and final verified release dashboard state.",
+      "credential": "github.token",
+      "actor": "github-actions[bot]",
+      "writes": [
+        "MissionChief_Map_Command_Toolkit.user.js",
+        "MissionChief_Map_Command_Toolkit.txt",
+        "status/release-dashboard.json",
+        "status/README.md"
+      ],
+      "helperScripts": [
+        ".github/scripts/sync_greasyfork_root_mirror.sh"
+      ],
+      "migrationTarget": "dedicated distribution branch plus release-state branch, written by a scoped GitHub App"
+    },
+    {
+      "workflow": ".github/workflows/repository-audit.yml",
+      "purpose": "Commit generated repository/dependency audit reports and their dashboard status.",
+      "credential": "github.token",
+      "actor": "github-actions[bot]",
+      "writes": [
+        "status/repository-audit.md",
+        "status/repository-audit.json",
+        "status/release-dashboard.json"
+      ],
+      "migrationTarget": "artifact and release-state branch"
+    },
+    {
+      "workflow": ".github/workflows/update-release-dashboard.yml",
+      "purpose": "Regenerate the human-readable dashboard from machine release state.",
+      "credential": "github.token",
+      "actor": "github-actions[bot]",
+      "writes": [
+        "status/README.md"
+      ],
+      "migrationTarget": "generated Pages artifact or release-state branch"
+    }
+  ],
+  "indirectMainWriteOrchestrators": [
+    {
+      "workflow": ".github/workflows/auto-release-after-validation.yml",
+      "invokes": ".github/workflows/release-toolkit.yml",
+      "purpose": "Automatically invoke the guarded production release after a validated main candidate."
+    },
+    {
+      "workflow": ".github/workflows/owner-release-command.yml",
+      "invokes": ".github/workflows/release-toolkit.yml",
+      "purpose": "Owner-authorized manual release orchestration and result reporting."
+    }
+  ],
+  "directMainPushSources": [
+    ".github/workflows/validate-userscript.yml",
+    ".github/workflows/greasyfork-release-monitor.yml",
+    ".github/workflows/import-canonical-userscript.yml",
+    ".github/workflows/publish-update-manifest.yml",
+    ".github/workflows/reconcile-release-announcement-state.yml",
+    ".github/workflows/release-recovery.yml",
+    ".github/workflows/release-toolkit-dry-run.yml",
+    ".github/workflows/release-toolkit.yml",
+    ".github/workflows/repository-audit.yml",
+    ".github/workflows/update-release-dashboard.yml",
+    ".github/scripts/sync_greasyfork_root_mirror.sh"
+  ],
+  "externalRepositoryMainPushSources": [
+    {
+      "path": ".github/scripts/backup_release_to_private_repo.sh",
+      "repository": "Conroy1988/missionchief-map-command-toolkit-private",
+      "credential": "MIGRATION_REPO_TOKEN"
+    }
+  ],
+  "reviewBranchWriters": [
+    {
+      "workflow": ".github/workflows/apply-development-package.yml",
+      "target": "existing owner-created pull-request branch",
+      "credential": "DEVELOPMENT_PR_TOKEN"
+    },
+    {
+      "workflow": ".github/workflows/prepare-release-rollback.yml",
+      "target": "new recovery branch and owner-created pull request",
+      "credential": "DEVELOPMENT_PR_TOKEN"
+    }
+  ],
+  "contentsWriteAuthority": [
+    ".github/workflows/auto-release-after-validation.yml",
+    ".github/workflows/greasyfork-release-monitor.yml",
+    ".github/workflows/import-canonical-userscript.yml",
+    ".github/workflows/owner-release-command.yml",
+    ".github/workflows/publish-update-manifest.yml",
+    ".github/workflows/reconcile-release-announcement-state.yml",
+    ".github/workflows/release-recovery.yml",
+    ".github/workflows/release-toolkit-dry-run.yml",
+    ".github/workflows/release-toolkit.yml",
+    ".github/workflows/repository-audit.yml",
+    ".github/workflows/update-release-dashboard.yml",
+    ".github/workflows/validate-userscript.yml"
+  ]
+}

--- a/.github/scripts/test_branch_write_inventory.py
+++ b/.github/scripts/test_branch_write_inventory.py
@@ -42,7 +42,7 @@ def workflow_files() -> list[Path]:
 def executable_automation_files() -> list[Path]:
     files = workflow_files()
     files.extend(sorted(SCRIPT_DIR.glob("*.sh")))
-    files.extend(sorted(SCRIPT_DIR.glob("*.py")))
+    files.extend(sorted(path for path in SCRIPT_DIR.glob("*.py") if not path.name.startswith("test_")))
     return [path for path in files if path.resolve() != SELF]
 
 

--- a/.github/scripts/test_branch_write_inventory.py
+++ b/.github/scripts/test_branch_write_inventory.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Enforce the public-main write inventory used by Issue #41.
+
+The contract is intentionally static and fail-closed. It classifies every workflow
+with contents write authority, every executable public-main push source, explicit
+review-branch writers, and the separate private-recovery repository writer.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+INVENTORY_PATH = ROOT / ".github" / "branch-write-inventory.json"
+POLICY_PATH = ROOT / ".github" / "actions-security-policy.json"
+DOCUMENT_PATH = ROOT / "docs" / "BRANCH_WRITE_INVENTORY.md"
+WORKFLOW_DIR = ROOT / ".github" / "workflows"
+SCRIPT_DIR = ROOT / ".github" / "scripts"
+SELF = Path(__file__).resolve()
+
+
+def fail(message: str) -> None:
+    raise AssertionError(message)
+
+
+def load_json(path: Path) -> dict:
+    if not path.exists():
+        fail(f"Required inventory input is missing: {path.relative_to(ROOT)}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def relative(path: Path) -> str:
+    return path.relative_to(ROOT).as_posix()
+
+
+def workflow_files() -> list[Path]:
+    return sorted([*WORKFLOW_DIR.glob("*.yml"), *WORKFLOW_DIR.glob("*.yaml")])
+
+
+def executable_automation_files() -> list[Path]:
+    files = workflow_files()
+    files.extend(sorted(SCRIPT_DIR.glob("*.sh")))
+    files.extend(sorted(SCRIPT_DIR.glob("*.py")))
+    return [path for path in files if path.resolve() != SELF]
+
+
+def contains_main_ref_mutation(text: str) -> bool:
+    push = re.search(
+        r"\bgit\s+push\b[^\n]*(?:HEAD:main|(?:origin|upstream)\s+main(?:\s|$))",
+        text,
+    )
+    update_ref = re.search(r"\bgit\s+update-ref\s+refs/heads/main\b", text)
+    api_ref = re.search(
+        r"(?:gh\s+api|curl)[\s\S]{0,240}(?:git/refs/heads/main|refs/heads/main)",
+        text,
+    )
+    return bool(push or update_ref or api_ref)
+
+
+def main() -> int:
+    inventory = load_json(INVENTORY_PATH)
+    policy = load_json(POLICY_PATH)
+    document = DOCUMENT_PATH.read_text(encoding="utf-8")
+
+    if inventory.get("schemaVersion") != 1:
+        fail("Branch-write inventory schemaVersion must remain 1 until a reviewed migration updates the contract")
+    if inventory.get("strictProtectionEnabled") is not False:
+        fail("Strict branch protection must remain disabled during the inventory-only stage")
+
+    direct_entries = inventory.get("directMainWriters") or []
+    orchestrator_entries = inventory.get("indirectMainWriteOrchestrators") or []
+    external_entries = inventory.get("externalRepositoryMainPushSources") or []
+    review_entries = inventory.get("reviewBranchWriters") or []
+
+    direct_workflows = {str(entry.get("workflow") or "") for entry in direct_entries}
+    orchestrator_workflows = {str(entry.get("workflow") or "") for entry in orchestrator_entries}
+    classified_contents = direct_workflows | orchestrator_workflows
+
+    if "" in classified_contents:
+        fail("Every classified workflow requires a repository-relative path")
+    if direct_workflows & orchestrator_workflows:
+        fail("A workflow cannot be both a direct main writer and an indirect orchestrator")
+    if len(direct_workflows) != 10:
+        fail(f"Expected ten reviewed direct public-main writers, found {len(direct_workflows)}")
+    if len(orchestrator_workflows) != 2:
+        fail(f"Expected two reviewed release orchestrators, found {len(orchestrator_workflows)}")
+
+    policy_contents = {
+        path
+        for path, permissions in (policy.get("allowedWritePermissions") or {}).items()
+        if "contents" in (permissions or [])
+    }
+    inventory_contents = set(inventory.get("contentsWriteAuthority") or [])
+    if policy_contents != inventory_contents:
+        fail(
+            "Contents-write authority differs between actions-security-policy.json and "
+            f"branch-write-inventory.json: policy-only={sorted(policy_contents - inventory_contents)}, "
+            f"inventory-only={sorted(inventory_contents - policy_contents)}"
+        )
+    if classified_contents != inventory_contents:
+        fail(
+            "Every contents-write workflow must be classified as a direct writer or orchestrator: "
+            f"unclassified={sorted(inventory_contents - classified_contents)}, "
+            f"unexpected={sorted(classified_contents - inventory_contents)}"
+        )
+
+    declared_contents_write: set[str] = set()
+    for workflow in workflow_files():
+        text = workflow.read_text(encoding="utf-8")
+        if re.search(r"(?m)^\s*contents:\s*write\s*$", text):
+            declared_contents_write.add(relative(workflow))
+    if declared_contents_write != inventory_contents:
+        fail(
+            "Workflow declarations and approved contents-write authority differ: "
+            f"declared-only={sorted(declared_contents_write - inventory_contents)}, "
+            f"inventory-only={sorted(inventory_contents - declared_contents_write)}"
+        )
+
+    for workflow in sorted(classified_contents):
+        path = ROOT / workflow
+        if not path.is_file():
+            fail(f"Classified workflow is missing: {workflow}")
+        if workflow not in document:
+            fail(f"Human branch-write inventory does not mention classified workflow: {workflow}")
+
+    discovered_main_sources = {
+        relative(path)
+        for path in executable_automation_files()
+        if contains_main_ref_mutation(path.read_text(encoding="utf-8", errors="replace"))
+    }
+    expected_public_sources = set(inventory.get("directMainPushSources") or [])
+    expected_external_sources = {str(entry.get("path") or "") for entry in external_entries}
+    expected_all_sources = expected_public_sources | expected_external_sources
+
+    if discovered_main_sources != expected_all_sources:
+        fail(
+            "Executable main-ref mutation sources differ from the reviewed inventory: "
+            f"unclassified={sorted(discovered_main_sources - expected_all_sources)}, "
+            f"missing={sorted(expected_all_sources - discovered_main_sources)}"
+        )
+
+    missing_direct_pushes = direct_workflows - expected_public_sources
+    if missing_direct_pushes:
+        fail(f"Direct writer workflows missing from directMainPushSources: {sorted(missing_direct_pushes)}")
+    if orchestrator_workflows & discovered_main_sources:
+        fail("Release orchestrators must not contain their own public-main push or ref-update command")
+
+    for entry in orchestrator_entries:
+        workflow = str(entry["workflow"])
+        invoked = str(entry["invokes"])
+        text = (ROOT / workflow).read_text(encoding="utf-8")
+        if invoked.replace(".github/workflows/", "./.github/workflows/") not in text:
+            fail(f"Orchestrator {workflow} no longer invokes its reviewed reusable workflow {invoked}")
+
+    for entry in external_entries:
+        path = ROOT / str(entry["path"])
+        repository = str(entry["repository"])
+        if not path.is_file():
+            fail(f"External-repository writer is missing: {relative(path)}")
+        text = path.read_text(encoding="utf-8")
+        if repository not in text:
+            fail(f"External writer {relative(path)} no longer pins the reviewed repository {repository}")
+        if relative(path) not in discovered_main_sources:
+            fail(f"External writer no longer contains the reviewed main push: {relative(path)}")
+
+    for entry in review_entries:
+        workflow = ROOT / str(entry["workflow"])
+        if not workflow.is_file():
+            fail(f"Review-branch writer is missing: {relative(workflow)}")
+        if relative(workflow) in discovered_main_sources:
+            fail(f"Review-branch writer contains a prohibited public-main mutation: {relative(workflow)}")
+        if str(entry.get("credential") or "") not in workflow.read_text(encoding="utf-8"):
+            fail(f"Review-branch writer no longer uses its reviewed owner credential: {relative(workflow)}")
+
+    for path in sorted(expected_public_sources | expected_external_sources):
+        if path not in document and path not in {str(entry["path"]) for entry in external_entries}:
+            fail(f"Human inventory omits executable write source: {path}")
+
+    required_document_claims = [
+        "Strict pull-request-only protection is **not yet safe to enable**",
+        "ten workflows that can commit directly to public `main`",
+        "Stage one is complete",
+    ]
+    for claim in required_document_claims:
+        if claim not in document:
+            fail(f"Human inventory is missing required stage-one claim: {claim}")
+
+    print(
+        "Branch-write inventory passed: "
+        f"{len(direct_workflows)} direct main writers, "
+        f"{len(orchestrator_workflows)} orchestrators, "
+        f"{len(review_entries)} review-branch writers and "
+        f"{len(external_entries)} external-repository writer."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_branch_write_inventory.py
+++ b/.github/scripts/test_branch_write_inventory.py
@@ -59,6 +59,10 @@ def contains_main_ref_mutation(text: str) -> bool:
     return bool(push or update_ref or api_ref)
 
 
+def document_mentions(document: str, repository_path: str) -> bool:
+    return repository_path in document or Path(repository_path).name in document
+
+
 def main() -> int:
     inventory = load_json(INVENTORY_PATH)
     policy = load_json(POLICY_PATH)
@@ -122,7 +126,7 @@ def main() -> int:
         path = ROOT / workflow
         if not path.is_file():
             fail(f"Classified workflow is missing: {workflow}")
-        if workflow not in document:
+        if not document_mentions(document, workflow):
             fail(f"Human branch-write inventory does not mention classified workflow: {workflow}")
 
     discovered_main_sources = {
@@ -175,7 +179,7 @@ def main() -> int:
             fail(f"Review-branch writer no longer uses its reviewed owner credential: {relative(workflow)}")
 
     for path in sorted(expected_public_sources | expected_external_sources):
-        if path not in document and path not in {str(entry["path"]) for entry in external_entries}:
+        if not document_mentions(document, path):
             fail(f"Human inventory omits executable write source: {path}")
 
     required_document_claims = [

--- a/.github/workflows/validate-development-package-workflow.yml
+++ b/.github/workflows/validate-development-package-workflow.yml
@@ -3,16 +3,17 @@ name: Development and Automation Workflow Policy
 on:
   pull_request:
     paths:
-      - .github/workflows/apply-development-package.yml
-      - .github/workflows/asset-health-monitor.yml
-      - .github/workflows/prepare-release-rollback.yml
-      - .github/workflows/pages-production-monitor.yml
-      - .github/workflows/validate-development-package-workflow.yml
-      - .github/scripts/reconcile_pages_incident.sh
-      - .github/scripts/test_automation_record_hygiene.py
-      - .github/scripts/test_development_package_workflow.py
-      - .github/actions-security-policy.json
-      - docs/DEVELOPMENT_PACKAGE_WORKFLOW.md
+      - ".github/workflows/*.yml"
+      - ".github/workflows/*.yaml"
+      - ".github/scripts/*.sh"
+      - ".github/actions-security-policy.json"
+      - ".github/branch-write-inventory.json"
+      - ".github/scripts/test_automation_record_hygiene.py"
+      - ".github/scripts/test_branch_write_inventory.py"
+      - ".github/scripts/test_development_package_workflow.py"
+      - "docs/BRANCH_PROTECTION_MIGRATION.md"
+      - "docs/BRANCH_WRITE_INVENTORY.md"
+      - "docs/DEVELOPMENT_PACKAGE_WORKFLOW.md"
   workflow_dispatch:
 
 permissions:
@@ -20,7 +21,7 @@ permissions:
 
 jobs:
   policy:
-    name: Validate workflow notification policy
+    name: Validate workflow and branch-write policy
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -38,6 +39,7 @@ jobs:
           {
             python3 .github/scripts/test_development_package_workflow.py
             python3 .github/scripts/test_automation_record_hygiene.py
+            python3 .github/scripts/test_branch_write_inventory.py
           } 2>&1 | tee "$RUNNER_TEMP/workflow-policy.log"
 
       - name: Upload policy diagnostics

--- a/.github/workflows/validate-development-package-workflow.yml
+++ b/.github/workflows/validate-development-package-workflow.yml
@@ -5,7 +5,13 @@ on:
     paths:
       - ".github/workflows/*.yml"
       - ".github/workflows/*.yaml"
+      - ".github/workflows/apply-development-package.yml"
+      - ".github/workflows/asset-health-monitor.yml"
+      - ".github/workflows/prepare-release-rollback.yml"
+      - ".github/workflows/pages-production-monitor.yml"
+      - ".github/workflows/validate-development-package-workflow.yml"
       - ".github/scripts/*.sh"
+      - ".github/scripts/reconcile_pages_incident.sh"
       - ".github/actions-security-policy.json"
       - ".github/branch-write-inventory.json"
       - ".github/scripts/test_automation_record_hygiene.py"

--- a/docs/BRANCH_PROTECTION_MIGRATION.md
+++ b/docs/BRANCH_PROTECTION_MIGRATION.md
@@ -1,6 +1,12 @@
 # Branch Protection Migration Plan
 
-The repository currently permits controlled automation commits to `main` because release validation, dashboard reconciliation, Greasy Fork tracking and recovery workflows update verified state directly.
+Strict pull-request-only protection is **not yet enabled**. The repository still permits controlled automation commits because production validation, distribution mirroring, release state, update manifests, monitoring and recovery currently mutate public `main`.
+
+The migration is tracked by Issue #41. The reviewed writer inventory is maintained in:
+
+- `docs/BRANCH_WRITE_INVENTORY.md` — human architecture and migration decisions;
+- `.github/branch-write-inventory.json` — machine-readable authority;
+- `.github/scripts/test_branch_write_inventory.py` — fail-closed drift enforcement.
 
 ## Current safe controls
 
@@ -8,22 +14,90 @@ The repository currently permits controlled automation commits to `main` because
 - force-push protection;
 - reviewed pull requests for normal development;
 - code-integrity, performance, asset, recovery and documentation validation;
-- immutable GitHub Action pins and permission auditing.
+- immutable GitHub Action pins and permission auditing;
+- owner-authenticated review branches for development packages and rollback preparation;
+- explicit production and recovery confirmation phrases.
 
-## Why strict PR-only enforcement is deferred
+## Stage 1 — write-path inventory ✅
 
-A strict requirement that every `main` update arrive through a pull request would block the current release architecture unless automation is moved to a bypass-capable GitHub App identity or generated state is stored outside the protected branch.
+The 24 July 2026 audit against `main` commit `bfd3a786a17a2cf01a0aa0d3d6f9a3f235ab1f2c` identified:
 
-## Migration stages
+- **10 direct public-`main` writing workflows**;
+- **2 indirect release orchestrators** that invoke the reusable production writer;
+- **2 owner-token review-branch writers** that cannot update public `main` directly;
+- **1 separate private-repository `main` writer** used only for recovery backups.
 
-1. Inventory every workflow that writes to `main`.
-2. Separate immutable release source from generated operational state.
-3. Move dashboard, announcement and tracker state to a dedicated state branch, release asset or external store.
-4. Give production release automation a narrowly scoped GitHub App identity.
-5. Require pull requests, required checks and resolved conversations for human changes.
-6. Verify normal release, Greasy Fork retry, private-backup retry, Discord retry and rollback preparation under the new identity.
-7. Enable strict protection only after a full non-production rehearsal.
+Every workflow with declared `contents: write` authority is classified. CI now scans executable automation for direct `main` pushes and ref updates and fails when an unclassified writer appears.
+
+No branch-protection setting is changed by Stage 1.
+
+## Why strict PR-only enforcement remains deferred
+
+The protected branch currently mixes several distinct data classes:
+
+1. canonical userscript source and reviewed repository policy;
+2. generated distribution files;
+3. stable Greasy Fork root mirrors;
+4. release dashboard and announcement state;
+5. stable update-manifest state;
+6. repository audit output;
+7. generated human-readable dashboard files.
+
+Blocking all direct automation pushes before these responsibilities are separated would stop normal releases, recovery operations or external update reconciliation. Granting an unrestricted personal token a bypass would merely replace one architectural risk with another.
+
+## Target architecture
+
+### Public `main`
+
+Reviewed source, workflows, tests, policies, documentation and stable configuration only. Human changes arrive through pull requests with required checks and resolved conversations.
+
+### Distribution branch
+
+Stable root userscript mirrors required by Greasy Fork or replacement distribution tooling. Written only by a narrowly scoped release GitHub App.
+
+### Release-state branch
+
+Mutable generated state, including:
+
+- release dashboard JSON and Markdown;
+- Greasy Fork/Discord announcement tracker;
+- stable update manifest;
+- repository audit summaries;
+- recovery claim and completion state.
+
+This branch is operational evidence, not a competing product-code source.
+
+### Immutable evidence
+
+Validated release bundles, checksums, changelog extracts, migration handovers and dry-run evidence remain GitHub Release assets or Actions artifacts.
+
+## Remaining migration stages
+
+1. ✅ Inventory every workflow and script capable of updating public `main`.
+2. Separate immutable canonical source from generated operational state.
+3. Move dashboard, announcement, manifest and audit state to a dedicated release-state branch or immutable assets.
+4. Move stable Greasy Fork mirrors to a dedicated distribution branch.
+5. Introduce a narrowly scoped GitHub App identity for distribution and state writes.
+6. Remove unnecessary `contents: write` authority from orchestration-only workflows.
+7. Rehearse all supported paths without public-`main` mutation:
+   - normal Release Readiness;
+   - full production publication;
+   - Greasy Fork-only retry;
+   - private-backup-only retry;
+   - Discord-only retry;
+   - dashboard reconstruction;
+   - stable release-asset repair;
+   - emergency rollback-candidate preparation.
+8. Require pull requests, approved checks, current branches and resolved conversations for human changes.
+9. Block direct human pushes and enable strict protection only after the complete rehearsal passes.
 
 ## Exit criteria
 
-Strict protection is ready when no workflow depends on unrestricted human-token pushes to `main`, every bypass actor is explicit and auditable, recovery procedures still work, and a failed publication stage cannot leave release state split across systems.
+Strict protection is ready only when:
+
+- no workflow depends on a direct public-`main` commit;
+- every bypass actor is a narrowly scoped and auditable GitHub App;
+- personal tokens can write only owner-created review branches or the separate private recovery repository;
+- generated release state can be reconstructed from immutable evidence;
+- every release and recovery path passes a non-production rehearsal;
+- a failed publication stage cannot leave release state split across GitHub, Greasy Fork, private backup and Discord.

--- a/docs/BRANCH_WRITE_INVENTORY.md
+++ b/docs/BRANCH_WRITE_INVENTORY.md
@@ -1,0 +1,113 @@
+# Protected-branch write inventory
+
+**Reviewed:** 24 July 2026  
+**Reviewed `main`:** `bfd3a786a17a2cf01a0aa0d3d6f9a3f235ab1f2c`  
+**Issue:** #41 — Migrate release state for strict main-branch protection
+
+## Current conclusion
+
+Strict pull-request-only protection is **not yet safe to enable**.
+
+The repository has ten workflows that can commit directly to public `main`. Two additional release workflows do not push themselves, but invoke the reusable production workflow that does. The direct writes are deliberate and guarded, but they mix canonical source, generated distribution, release state, announcement state, audit output and human-readable dashboards in one protected branch.
+
+This document is an inventory, not an authorization to add more bypasses. `.github/branch-write-inventory.json` is the machine-readable authority and `.github/scripts/test_branch_write_inventory.py` prevents unclassified write paths from being introduced.
+
+## Direct public `main` writers
+
+| Workflow | Trigger | Current mutation | Credential / actor | Required migration |
+|---|---|---|---|---|
+| `validate-userscript.yml` | validated `main` push or manual run | `dist/`, candidate dashboard JSON and generated dashboard Markdown | `github.token` / `github-actions[bot]` | Move generated candidate state outside protected `main`. |
+| `greasyfork-release-monitor.yml` | five-minute schedule or manual run | `.github/greasyfork-version.txt` | `github.token` / `github-actions[bot]` | Move announcement state to a release-state branch. |
+| `import-canonical-userscript.yml` | manual run or workflow-definition push | canonical userscript and source baseline | `github.token` / `github-actions[bot]` | Convert to an owner-created PR and retire when GitHub remains authoritative. |
+| `publish-update-manifest.yml` | release-dispatched manual run | `status/update-manifest.json` | `github.token` / `github-actions[bot]` | Publish from a release-state branch or immutable release asset. |
+| `reconcile-release-announcement-state.yml` | successful release completion or manual run | `.github/greasyfork-version.txt` | `github.token` / `github-actions[bot]` | Move announcement state to a release-state branch. |
+| `release-recovery.yml` | explicitly confirmed manual recovery | dashboard JSON/Markdown and announcement tracker | `github.token` / `github-actions[bot]` | Keep release-object repair in the API; move mutable state to the release-state branch. |
+| `release-toolkit-dry-run.yml` | manual run | dry-run dashboard state | `github.token` / `github-actions[bot]` | Make dry runs artifact-only. |
+| `release-toolkit.yml` | reusable release call or manual run | stable root userscript mirrors and final release dashboard | `github.token` / `github-actions[bot]` | Move mirrors to a distribution branch and state to a release-state branch under a scoped GitHub App. |
+| `repository-audit.yml` | relevant `main` push or manual run | repository audit reports and dashboard state | `github.token` / `github-actions[bot]` | Retain reports as artifacts and publish only summary state outside protected `main`. |
+| `update-release-dashboard.yml` | dashboard change or manual run | generated `status/README.md` | `github.token` / `github-actions[bot]` | Generate at Pages/deployment time or from the release-state branch. |
+
+### Production release write sequence
+
+The production release currently performs multiple branch mutations:
+
+1. `validate-userscript.yml` commits the validated distribution candidate.
+2. `release-toolkit.yml` calls `sync_greasyfork_root_mirror.sh`, which commits stable root mirrors.
+3. `release-toolkit.yml` publishes the GitHub Release, verifies Greasy Fork, backs up privately and posts Discord.
+4. `release-toolkit.yml` commits the verified release dashboard.
+5. `release-toolkit.yml` dispatches `publish-update-manifest.yml`, which commits the stable update manifest.
+6. Dashboard and announcement reconciliation workflows may create further generated-state commits.
+
+Strict protection must preserve this sequencing without permitting unrestricted human-token pushes or leaving the release ledger split between branches and external channels.
+
+## Indirect release orchestrators
+
+These workflows hold or request `contents: write` authority but contain no direct public-`main` push:
+
+| Workflow | Delegated writer | Role |
+|---|---|---|
+| `auto-release-after-validation.yml` | `release-toolkit.yml` | Starts the guarded release after successful candidate validation. |
+| `owner-release-command.yml` | `release-toolkit.yml` | Authorizes a manual release command and reports the result. |
+
+Their own jobs should ultimately use read-only contents access; write authority should exist only on the called release job and its scoped GitHub App identity.
+
+## Explicit non-public-main writers
+
+These write paths are intentionally excluded from the public-`main` count and are machine-classified so they cannot be confused with bypasses:
+
+| Automation | Target | Credential | Protection posture |
+|---|---|---|---|
+| `apply-development-package.yml` | Existing owner-created PR branch | `DEVELOPMENT_PR_TOKEN` | Review branch only; cannot create or update public `main`. |
+| `prepare-release-rollback.yml` | New recovery branch and PR | `DEVELOPMENT_PR_TOKEN` | Review branch only; public release still requires merge and release gates. |
+| `backup_release_to_private_repo.sh` | `Conroy1988/missionchief-map-command-toolkit-private` `main` | `MIGRATION_REPO_TOKEN` | Separate recovery repository; not a public-repository bypass. |
+
+## Target architecture
+
+### Canonical protected branch
+
+Public `main` should contain only reviewed source, workflows, policies, deterministic tests, documentation and stable configuration. Human changes should arrive through pull requests with required checks and resolved conversations.
+
+### Distribution branch
+
+A dedicated automation-owned branch should contain the stable root mirrors required by Greasy Fork or equivalent external distribution tooling. Only the release GitHub App should be able to update it.
+
+### Release-state branch
+
+Mutable operational records should move together:
+
+- release dashboard JSON;
+- human-readable dashboard output;
+- stable update manifest;
+- Greasy Fork/Discord announcement tracker;
+- repository audit summaries;
+- recovery claim and completion state.
+
+The state branch must be reconstructed deterministically from immutable release evidence and must never become a competing source for product code.
+
+### Immutable evidence
+
+Release bundles, checksums, changelog extracts and recovery handovers should remain GitHub Release assets and workflow artifacts. Dry-run output should be artifact-only.
+
+### Automation identity
+
+The final writer should be a narrowly scoped GitHub App with explicit repository permissions. Personal tokens remain appropriate only for owner-created review branches and the separate private recovery repository.
+
+## Migration order
+
+1. ✅ Inventory every public-`main` writer and enforce the inventory in CI.
+2. Separate generated candidate, dashboard, manifest, tracker and audit state from canonical source.
+3. Move stable Greasy Fork mirrors to a dedicated distribution branch.
+4. Introduce a narrowly scoped GitHub App for distribution and release-state writes.
+5. Rehearse normal release and every recovery operation without public-`main` mutation.
+6. Configure required pull requests, required checks, current-branch enforcement and conversation resolution.
+7. Enable strict protection only after all rehearsals pass.
+
+## Stage-one exit criteria
+
+Stage one is complete when:
+
+- every workflow with `contents: write` authority is classified;
+- every executable public-`main` push source is listed;
+- private-repository and review-branch writers are explicitly separated;
+- CI fails when a new writer, write-capable workflow or hidden main-ref mutation appears;
+- strict branch protection remains disabled pending later migration stages.


### PR DESCRIPTION
## Purpose

Advance Issue #41 with the complete Stage 1 inventory required before strict `main` branch protection can be designed safely.

## Verified findings

The current repository contains:

- 10 workflows that can commit directly to public `main`;
- 2 release orchestrators that invoke the reusable production writer;
- 2 owner-token workflows restricted to review branches;
- 1 separate private-repository `main` writer used for release recovery backups.

## Changes

- Add `.github/branch-write-inventory.json` as the machine-readable authority.
- Add `docs/BRANCH_WRITE_INVENTORY.md` with every writer, trigger, mutation, credential and migration target.
- Update `docs/BRANCH_PROTECTION_MIGRATION.md` to mark Stage 1 complete while keeping strict protection disabled.
- Add `test_branch_write_inventory.py` to detect:
  - unclassified `contents: write` workflows;
  - direct `HEAD:main` pushes;
  - direct main-ref updates through Git/API commands;
  - confusion between public `main`, PR branches and the private recovery repository.
- Run the new contract through the permanent Development and Automation Workflow Policy check on every workflow or shell-automation change.

## Safety

- No branch-protection setting is changed.
- No userscript, distribution, version or release state is changed.
- No existing writer is removed or granted new authority.
- Later migration stages must move generated state and distribution mirrors before strict protection is enabled.

## Validation

All checks pass on exact head `b8ccd1140906ae7c26becd62bad36e6d4fd43d4f`:

- Development and Automation Workflow Policy
- Actions security
- Development status

The new scanner was proven fail-closed during review: it rejected an omitted explicit trigger marker and a test-fixture false positive before passing only after both boundaries were corrected.

Advances #41