### PR TITLE
Make release dry runs artifact-only

### DIFF
--- a/.github/actions-security-policy.json
+++ b/.github/actions-security-policy.json
@@ -49,9 +49,6 @@
     ".github/workflows/release-recovery.yml": [
       "contents"
     ],
-    ".github/workflows/release-toolkit-dry-run.yml": [
-      "contents"
-    ],
     ".github/workflows/release-toolkit.yml": [
       "actions",
       "contents"

--- a/.github/branch-write-inventory.json
+++ b/.github/branch-write-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "reviewedAt": "2026-07-24",
-  "reviewedMainCommit": "bfd3a786a17a2cf01a0aa0d3d6f9a3f235ab1f2c",
+  "reviewedMainCommit": "93c23b844108a6f56ebd2c10ef5a71eff6fe1eed",
   "strictProtectionEnabled": false,
   "directMainWriters": [
     {
@@ -70,16 +70,6 @@
       "migrationTarget": "release-state branch; release-object repair remains API-based"
     },
     {
-      "workflow": ".github/workflows/release-toolkit-dry-run.yml",
-      "purpose": "Record a reviewable release dry-run result in the production dashboard.",
-      "credential": "github.token",
-      "actor": "github-actions[bot]",
-      "writes": [
-        "status/release-dashboard.json"
-      ],
-      "migrationTarget": "artifact-only dry run; no protected-branch mutation"
-    },
-    {
       "workflow": ".github/workflows/release-toolkit.yml",
       "purpose": "Commit the stable Greasy Fork root mirror and final verified release dashboard state.",
       "credential": "github.token",
@@ -130,6 +120,18 @@
       "purpose": "Owner-authorized manual release orchestration and result reporting."
     }
   ],
+  "artifactOnlyEvidenceWorkflows": [
+    {
+      "workflow": ".github/workflows/release-toolkit-dry-run.yml",
+      "purpose": "Validate and package a candidate without changing public main or any publication channel.",
+      "permission": "contents: read",
+      "artifact": "missionchief-toolkit-v<version>-release-dry-run",
+      "evidence": [
+        "release-dry-run-v<version>.json",
+        "release-dry-run-v<version>.md"
+      ]
+    }
+  ],
   "directMainPushSources": [
     ".github/workflows/validate-userscript.yml",
     ".github/workflows/greasyfork-release-monitor.yml",
@@ -137,7 +139,6 @@
     ".github/workflows/publish-update-manifest.yml",
     ".github/workflows/reconcile-release-announcement-state.yml",
     ".github/workflows/release-recovery.yml",
-    ".github/workflows/release-toolkit-dry-run.yml",
     ".github/workflows/release-toolkit.yml",
     ".github/workflows/repository-audit.yml",
     ".github/workflows/update-release-dashboard.yml",
@@ -170,7 +171,6 @@
     ".github/workflows/publish-update-manifest.yml",
     ".github/workflows/reconcile-release-announcement-state.yml",
     ".github/workflows/release-recovery.yml",
-    ".github/workflows/release-toolkit-dry-run.yml",
     ".github/workflows/release-toolkit.yml",
     ".github/workflows/repository-audit.yml",
     ".github/workflows/update-release-dashboard.yml",

--- a/.github/scripts/test_branch_write_inventory.py
+++ b/.github/scripts/test_branch_write_inventory.py
@@ -3,7 +3,8 @@
 
 The contract is intentionally static and fail-closed. It classifies every workflow
 with contents write authority, every executable public-main push source, explicit
-review-branch writers, and the separate private-recovery repository writer.
+review-branch writers, artifact-only evidence workflows, and the separate private
+recovery repository writer.
 """
 
 from __future__ import annotations
@@ -71,25 +72,31 @@ def main() -> int:
     if inventory.get("schemaVersion") != 1:
         fail("Branch-write inventory schemaVersion must remain 1 until a reviewed migration updates the contract")
     if inventory.get("strictProtectionEnabled") is not False:
-        fail("Strict branch protection must remain disabled during the inventory-only stage")
+        fail("Strict branch protection must remain disabled during the migration stages")
 
     direct_entries = inventory.get("directMainWriters") or []
     orchestrator_entries = inventory.get("indirectMainWriteOrchestrators") or []
+    artifact_entries = inventory.get("artifactOnlyEvidenceWorkflows") or []
     external_entries = inventory.get("externalRepositoryMainPushSources") or []
     review_entries = inventory.get("reviewBranchWriters") or []
 
     direct_workflows = {str(entry.get("workflow") or "") for entry in direct_entries}
     orchestrator_workflows = {str(entry.get("workflow") or "") for entry in orchestrator_entries}
+    artifact_workflows = {str(entry.get("workflow") or "") for entry in artifact_entries}
     classified_contents = direct_workflows | orchestrator_workflows
 
-    if "" in classified_contents:
+    if "" in direct_workflows | orchestrator_workflows | artifact_workflows:
         fail("Every classified workflow requires a repository-relative path")
     if direct_workflows & orchestrator_workflows:
         fail("A workflow cannot be both a direct main writer and an indirect orchestrator")
-    if len(direct_workflows) != 10:
-        fail(f"Expected ten reviewed direct public-main writers, found {len(direct_workflows)}")
+    if artifact_workflows & classified_contents:
+        fail("Artifact-only workflows cannot retain contents-write classification")
+    if len(direct_workflows) != 9:
+        fail(f"Expected nine reviewed direct public-main writers, found {len(direct_workflows)}")
     if len(orchestrator_workflows) != 2:
         fail(f"Expected two reviewed release orchestrators, found {len(orchestrator_workflows)}")
+    if artifact_workflows != {".github/workflows/release-toolkit-dry-run.yml"}:
+        fail(f"Unexpected artifact-only workflow inventory: {sorted(artifact_workflows)}")
 
     policy_contents = {
         path
@@ -122,7 +129,7 @@ def main() -> int:
             f"inventory-only={sorted(inventory_contents - declared_contents_write)}"
         )
 
-    for workflow in sorted(classified_contents):
+    for workflow in sorted(classified_contents | artifact_workflows):
         path = ROOT / workflow
         if not path.is_file():
             fail(f"Classified workflow is missing: {workflow}")
@@ -150,6 +157,8 @@ def main() -> int:
         fail(f"Direct writer workflows missing from directMainPushSources: {sorted(missing_direct_pushes)}")
     if orchestrator_workflows & discovered_main_sources:
         fail("Release orchestrators must not contain their own public-main push or ref-update command")
+    if artifact_workflows & discovered_main_sources:
+        fail("Artifact-only workflows must not contain public-main push or ref-update commands")
 
     for entry in orchestrator_entries:
         workflow = str(entry["workflow"])
@@ -157,6 +166,31 @@ def main() -> int:
         text = (ROOT / workflow).read_text(encoding="utf-8")
         if invoked.replace(".github/workflows/", "./.github/workflows/") not in text:
             fail(f"Orchestrator {workflow} no longer invokes its reviewed reusable workflow {invoked}")
+
+    dry_run_path = ROOT / ".github/workflows/release-toolkit-dry-run.yml"
+    dry_run = dry_run_path.read_text(encoding="utf-8")
+    required_dry_run_markers = [
+        "permissions:\n  contents: read",
+        "persist-credentials: false",
+        "Write immutable dry-run evidence",
+        "release-dry-run-v${RELEASE_VERSION}.json",
+        "release-dry-run-v${RELEASE_VERSION}.md",
+        "publicMainChanged: false",
+        "Upload reviewable release bundle and evidence",
+    ]
+    for marker in required_dry_run_markers:
+        if marker not in dry_run:
+            fail(f"Artifact-only dry-run workflow is missing required marker: {marker}")
+    for forbidden in [
+        "contents: write",
+        "status/release-dashboard.json",
+        "git commit",
+        "git push",
+        "git pull --rebase",
+        "github-actions[bot]",
+    ]:
+        if forbidden in dry_run:
+            fail(f"Artifact-only dry-run workflow contains forbidden branch mutation marker: {forbidden}")
 
     for entry in external_entries:
         path = ROOT / str(entry["path"])
@@ -184,17 +218,18 @@ def main() -> int:
 
     required_document_claims = [
         "Strict pull-request-only protection is **not yet safe to enable**",
-        "ten workflows that can commit directly to public `main`",
-        "Stage one is complete",
+        "nine workflows that can commit directly to public `main`",
+        "Release dry runs are now artifact-only",
     ]
     for claim in required_document_claims:
         if claim not in document:
-            fail(f"Human inventory is missing required stage-one claim: {claim}")
+            fail(f"Human inventory is missing required migration claim: {claim}")
 
     print(
         "Branch-write inventory passed: "
         f"{len(direct_workflows)} direct main writers, "
         f"{len(orchestrator_workflows)} orchestrators, "
+        f"{len(artifact_workflows)} artifact-only workflow, "
         f"{len(review_entries)} review-branch writers and "
         f"{len(external_entries)} external-repository writer."
     )

--- a/.github/workflows/release-toolkit-dry-run.yml
+++ b/.github/workflows/release-toolkit-dry-run.yml
@@ -6,11 +6,10 @@ on:
       version:
         description: "Validated Toolkit version to prepare"
         required: true
-        default: "4.10.4"
         type: string
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: toolkit-release-dry-run
@@ -23,11 +22,12 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - name: Check out latest main
+      - name: Check out latest main without write credentials
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: main
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Validate canonical source and rebuild distribution
         run: python3 .github/scripts/validate_userscript.py
@@ -54,15 +54,7 @@ jobs:
           cmp --silent "$USER_FILE" "$TXT_FILE"
           test "$(sha256sum "$USER_FILE" | awk '{print $1}')" = "$(jq -r '.sha256' "release-bundle/release-manifest-v${RELEASE_VERSION}.json")"
 
-      - name: Upload reviewable release bundle
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: missionchief-toolkit-v${{ inputs.version }}-release-dry-run
-          path: release-bundle/
-          if-no-files-found: error
-          retention-days: 30
-
-      - name: Update release dashboard
+      - name: Write immutable dry-run evidence
         env:
           RELEASE_VERSION: ${{ inputs.version }}
         shell: bash
@@ -70,57 +62,64 @@ jobs:
           set -euo pipefail
           NOW="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
           HASH="$(jq -r '.sha256' "release-bundle/release-manifest-v${RELEASE_VERSION}.json")"
+          REPORT="release-bundle/release-dry-run-v${RELEASE_VERSION}.json"
+          SUMMARY="release-bundle/release-dry-run-v${RELEASE_VERSION}.md"
 
-          jq \
+          jq -n \
+            --arg project "MissionChief Map Command Toolkit" \
             --arg version "$RELEASE_VERSION" \
-            --arg hash "$HASH" \
-            --arg now "$NOW" \
-            '.currentVersion = $version
-             | .status.validation = "passed"
-             | .status.githubRelease = "dry-run-ready"
-             | .status.greasyForkSync = "legacy-monitor"
-             | .status.backup = "dry-run-bundle-prepared"
-             | .status.discordRelease = "configured-not-sent-in-dry-run"
-             | .releaseDryRun = {
-                 version: $version,
-                 sha256: $hash,
-                 state: "passed",
-                 githubReleaseCreated: false,
-                 greasyForkChanged: false,
-                 discordPosted: false,
-                 completedAt: $now
-               }
-             | .lastUpdated = $now' \
-            status/release-dashboard.json > status/release-dashboard.tmp
+            --arg sha256 "$HASH" \
+            --arg sourceCommit "$GITHUB_SHA" \
+            --arg completedAt "$NOW" \
+            '{
+              schemaVersion: 1,
+              project: $project,
+              version: $version,
+              sha256: $sha256,
+              sourceCommit: $sourceCommit,
+              state: "passed",
+              githubReleaseCreated: false,
+              greasyForkChanged: false,
+              privateBackupChanged: false,
+              discordPosted: false,
+              publicMainChanged: false,
+              completedAt: $completedAt
+            }' > "$REPORT"
 
-          mv status/release-dashboard.tmp status/release-dashboard.json
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add status/release-dashboard.json
+          {
+            echo "# Toolkit v${RELEASE_VERSION} release dry run"
+            echo
+            echo "- State: **passed**"
+            echo "- Source commit: \`${GITHUB_SHA}\`"
+            echo "- SHA-256: \`${HASH}\`"
+            echo "- GitHub Release created: **no**"
+            echo "- Greasy Fork changed: **no**"
+            echo "- Private backup changed: **no**"
+            echo "- Discord posted: **no**"
+            echo "- Public main changed: **no**"
+            echo "- Completed: \`${NOW}\`"
+          } > "$SUMMARY"
 
-          if git diff --cached --quiet; then
-            echo "Release dashboard already records this dry run."
-            exit 0
-          fi
+          jq -e \
+            '.state == "passed" and
+             .githubReleaseCreated == false and
+             .greasyForkChanged == false and
+             .privateBackupChanged == false and
+             .discordPosted == false and
+             .publicMainChanged == false' \
+            "$REPORT" >/dev/null
 
-          git commit -m "Record Toolkit ${RELEASE_VERSION} release dry run"
-          git pull --rebase origin main
-          git push origin HEAD:main
+      - name: Upload reviewable release bundle and evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: missionchief-toolkit-v${{ inputs.version }}-release-dry-run
+          path: release-bundle/
+          if-no-files-found: error
+          retention-days: 30
 
       - name: Write workflow summary
         env:
           RELEASE_VERSION: ${{ inputs.version }}
         shell: bash
         run: |
-          {
-            echo "# Toolkit v${RELEASE_VERSION} release dry run"
-            echo
-            echo "- ✅ Canonical source validated"
-            echo "- ✅ JavaScript syntax checked"
-            echo "- ✅ Version and changelog matched"
-            echo "- ✅ Immutable backup bundle prepared"
-            echo "- ✅ SHA-256 integrity verified"
-            echo "- ⏸️ GitHub Release not published"
-            echo "- ⏸️ Greasy Fork not changed"
-            echo "- ⏸️ Discord release announcement not sent"
-          } >> "$GITHUB_STEP_SUMMARY"
+          cat "release-bundle/release-dry-run-v${RELEASE_VERSION}.md" >> "$GITHUB_STEP_SUMMARY"

--- a/docs/BRANCH_PROTECTION_MIGRATION.md
+++ b/docs/BRANCH_PROTECTION_MIGRATION.md
@@ -20,20 +20,35 @@ The migration is tracked by Issue #41. The reviewed writer inventory is maintain
 
 ## Stage 1 — write-path inventory ✅
 
-The 24 July 2026 audit against `main` commit `bfd3a786a17a2cf01a0aa0d3d6f9a3f235ab1f2c` identified:
+The 24 July 2026 audit identified:
 
-- **10 direct public-`main` writing workflows**;
+- **10 direct public-`main` writing workflows** at the Stage 1 baseline;
 - **2 indirect release orchestrators** that invoke the reusable production writer;
 - **2 owner-token review-branch writers** that cannot update public `main` directly;
 - **1 separate private-repository `main` writer** used only for recovery backups.
 
-Every workflow with declared `contents: write` authority is classified. CI now scans executable automation for direct `main` pushes and ref updates and fails when an unclassified writer appears.
+Every workflow with declared `contents: write` authority is classified. CI scans executable automation for direct `main` pushes and ref updates and fails when an unclassified writer appears.
 
-No branch-protection setting is changed by Stage 1.
+## Stage 2 — generated-state separation in progress
 
-## Why strict PR-only enforcement remains deferred
+### Release dry runs ✅
 
-The protected branch currently mixes several distinct data classes:
+`release-toolkit-dry-run.yml` is the first direct writer removed from public `main`.
+
+The workflow now:
+
+- has `contents: read` only;
+- checks out `main` without persisted write credentials;
+- validates the canonical userscript, syntax, distribution parity and release bundle;
+- writes deterministic JSON and Markdown evidence inside `release-bundle/`;
+- uploads the complete evidence artifact for 30 days;
+- records explicitly that GitHub Release, Greasy Fork, private backup, Discord and public `main` were not changed.
+
+The former dashboard mutation was removed. Direct public-`main` writers are therefore reduced from **10 to 9**.
+
+### Remaining generated state
+
+The protected branch still mixes:
 
 1. canonical userscript source and reviewed repository policy;
 2. generated distribution files;
@@ -43,7 +58,7 @@ The protected branch currently mixes several distinct data classes:
 6. repository audit output;
 7. generated human-readable dashboard files.
 
-Blocking all direct automation pushes before these responsibilities are separated would stop normal releases, recovery operations or external update reconciliation. Granting an unrestricted personal token a bypass would merely replace one architectural risk with another.
+Blocking all remaining automation pushes before these responsibilities are separated would stop normal releases, recovery operations or external update reconciliation. Granting an unrestricted personal token a bypass would merely replace one architectural risk with another.
 
 ## Target architecture
 
@@ -74,7 +89,10 @@ Validated release bundles, checksums, changelog extracts, migration handovers an
 ## Remaining migration stages
 
 1. ✅ Inventory every workflow and script capable of updating public `main`.
-2. Separate immutable canonical source from generated operational state.
+2. 🟡 Separate immutable canonical source from generated operational state.
+   - [x] Convert release dry runs to artifact-only evidence.
+   - [ ] Move validated distribution-candidate output away from public `main`.
+   - [ ] Move repository audit output away from public `main`.
 3. Move dashboard, announcement, manifest and audit state to a dedicated release-state branch or immutable assets.
 4. Move stable Greasy Fork mirrors to a dedicated distribution branch.
 5. Introduce a narrowly scoped GitHub App identity for distribution and state writes.

--- a/docs/BRANCH_WRITE_INVENTORY.md
+++ b/docs/BRANCH_WRITE_INVENTORY.md
@@ -1,14 +1,16 @@
 # Protected-branch write inventory
 
 **Reviewed:** 24 July 2026  
-**Reviewed `main`:** `bfd3a786a17a2cf01a0aa0d3d6f9a3f235ab1f2c`  
+**Reviewed `main`:** `93c23b844108a6f56ebd2c10ef5a71eff6fe1eed`  
 **Issue:** #41 — Migrate release state for strict main-branch protection
 
 ## Current conclusion
 
 Strict pull-request-only protection is **not yet safe to enable**.
 
-The repository has ten workflows that can commit directly to public `main`. Two additional release workflows do not push themselves, but invoke the reusable production workflow that does. The direct writes are deliberate and guarded, but they mix canonical source, generated distribution, release state, announcement state, audit output and human-readable dashboards in one protected branch.
+The repository now has nine workflows that can commit directly to public `main`. Two additional release workflows do not push themselves, but invoke the reusable production workflow that does. The direct writes are deliberate and guarded, but they still mix canonical source, generated distribution, release state, announcement state, audit output and human-readable dashboards in one protected branch.
+
+Release dry runs are now artifact-only. They validate and package the requested candidate with read-only repository permission, retain JSON and Markdown evidence for 30 days, and cannot mutate public `main` or any publication channel.
 
 This document is an inventory, not an authorization to add more bypasses. `.github/branch-write-inventory.json` is the machine-readable authority and `.github/scripts/test_branch_write_inventory.py` prevents unclassified write paths from being introduced.
 
@@ -22,14 +24,21 @@ This document is an inventory, not an authorization to add more bypasses. `.gith
 | `publish-update-manifest.yml` | release-dispatched manual run | `status/update-manifest.json` | `github.token` / `github-actions[bot]` | Publish from a release-state branch or immutable release asset. |
 | `reconcile-release-announcement-state.yml` | successful release completion or manual run | `.github/greasyfork-version.txt` | `github.token` / `github-actions[bot]` | Move announcement state to a release-state branch. |
 | `release-recovery.yml` | explicitly confirmed manual recovery | dashboard JSON/Markdown and announcement tracker | `github.token` / `github-actions[bot]` | Keep release-object repair in the API; move mutable state to the release-state branch. |
-| `release-toolkit-dry-run.yml` | manual run | dry-run dashboard state | `github.token` / `github-actions[bot]` | Make dry runs artifact-only. |
 | `release-toolkit.yml` | reusable release call or manual run | stable root userscript mirrors and final release dashboard | `github.token` / `github-actions[bot]` | Move mirrors to a distribution branch and state to a release-state branch under a scoped GitHub App. |
 | `repository-audit.yml` | relevant `main` push or manual run | repository audit reports and dashboard state | `github.token` / `github-actions[bot]` | Retain reports as artifacts and publish only summary state outside protected `main`. |
 | `update-release-dashboard.yml` | dashboard change or manual run | generated `status/README.md` | `github.token` / `github-actions[bot]` | Generate at Pages/deployment time or from the release-state branch. |
 
+## Artifact-only evidence workflows
+
+| Workflow | Permission | Retained evidence | Branch effect |
+|---|---|---|---|
+| `release-toolkit-dry-run.yml` | `contents: read` | complete release bundle plus `release-dry-run-v<version>.json` and `.md` | No branch, release, Greasy Fork, private backup or Discord change. |
+
+The former dry-run dashboard commit was removed because it wrote transient test state into the production ledger and the last retained value was stale at v4.10.4 while production was v5.0.7.
+
 ### Production release write sequence
 
-The production release currently performs multiple branch mutations:
+The production release still performs multiple branch mutations:
 
 1. `validate-userscript.yml` commits the validated distribution candidate.
 2. `release-toolkit.yml` calls `sync_greasyfork_root_mirror.sh`, which commits stable root mirrors.
@@ -52,8 +61,6 @@ These workflows hold or request `contents: write` authority but contain no direc
 Their own jobs should ultimately use read-only contents access; write authority should exist only on the called release job and its scoped GitHub App identity.
 
 ## Explicit non-public-main writers
-
-These write paths are intentionally excluded from the public-`main` count and are machine-classified so they cannot be confused with bypasses:
 
 | Automation | Target | Credential | Protection posture |
 |---|---|---|---|
@@ -86,7 +93,7 @@ The state branch must be reconstructed deterministically from immutable release 
 
 ### Immutable evidence
 
-Release bundles, checksums, changelog extracts and recovery handovers should remain GitHub Release assets and workflow artifacts. Dry-run output should be artifact-only.
+Release bundles, checksums, changelog extracts, recovery handovers and dry-run evidence remain GitHub Release assets and workflow artifacts. Dry-run output is artifact-only.
 
 ### Automation identity
 
@@ -95,19 +102,16 @@ The final writer should be a narrowly scoped GitHub App with explicit repository
 ## Migration order
 
 1. ✅ Inventory every public-`main` writer and enforce the inventory in CI.
-2. Separate generated candidate, dashboard, manifest, tracker and audit state from canonical source.
-3. Move stable Greasy Fork mirrors to a dedicated distribution branch.
-4. Introduce a narrowly scoped GitHub App for distribution and release-state writes.
-5. Rehearse normal release and every recovery operation without public-`main` mutation.
-6. Configure required pull requests, required checks, current-branch enforcement and conversation resolution.
-7. Enable strict protection only after all rehearsals pass.
+2. ✅ Convert release dry runs to read-only, artifact-only evidence.
+3. Separate generated candidate, dashboard, manifest, tracker and audit state from canonical source.
+4. Move stable Greasy Fork mirrors to a dedicated distribution branch.
+5. Introduce a narrowly scoped GitHub App for distribution and release-state writes.
+6. Rehearse normal release and every recovery operation without public-`main` mutation.
+7. Configure required pull requests, required checks, current-branch enforcement and conversation resolution.
+8. Enable strict protection only after all rehearsals pass.
 
-## Stage-one exit criteria
+## Current migration evidence
 
-Stage one is complete when:
-
-- every workflow with `contents: write` authority is classified;
-- every executable public-`main` push source is listed;
-- private-repository and review-branch writers are explicitly separated;
-- CI fails when a new writer, write-capable workflow or hidden main-ref mutation appears;
-- strict branch protection remains disabled pending later migration stages.
+- Stage 1 inventory enforcement: PR #498, merge commit `93c23b844108a6f56ebd2c10ef5a71eff6fe1eed`.
+- First writer removal: `release-toolkit-dry-run.yml`, migrated from dashboard commit to immutable artifact evidence.
+- Strict branch protection remains disabled pending the remaining state/distribution migration and rehearsals.


### PR DESCRIPTION
## Purpose

Advance Issue #41 by removing the first direct automation writer from public `main`.

## Problem

`release-toolkit-dry-run.yml` had `contents: write` authority and committed transient dry-run state into the production release dashboard. The retained dashboard value is still v4.10.4 while production is v5.0.7, demonstrating that this branch mutation was neither current nor required for release safety.

## Changes

- Reduce the dry-run workflow to `contents: read`.
- Check out `main` with `persist-credentials: false`.
- Remove all dashboard, Git commit and public-main push logic.
- Produce deterministic JSON and Markdown dry-run evidence inside the release bundle.
- Retain the complete reviewable bundle and evidence as a 30-day Actions artifact.
- Record explicitly that GitHub Release, Greasy Fork, private backup, Discord and public `main` were not changed.
- Remove the workflow from the Actions write-permission allowlist.
- Reclassify it as artifact-only in the protected-branch inventory.
- Reduce the enforced direct public-main writer count from 10 to 9.

## Safety

- No userscript, distribution, version or live release state changes.
- No production publication path is modified.
- No branch-protection setting is enabled.
- Release dry runs continue to perform canonical validation, JavaScript syntax, distribution parity, release-bundle preparation and checksum verification.

## Validation

All checks pass on exact head `1d06aff70c9956c5949b09035b62774677862c27`:

- Development and Automation Workflow Policy
- Actions security
- Development status

The permanent contract requires read-only contents permission, disabled checkout credentials, immutable JSON/Markdown evidence and absence of dashboard, commit, push or publication markers.

Advances #41