### PR TITLE
Make dashboard projection verification read-only

### DIFF
--- a/.github/actions-security-policy.json
+++ b/.github/actions-security-policy.json
@@ -55,9 +55,6 @@
     ],
     ".github/workflows/sync-repository-labels.yml": [
       "issues"
-    ],
-    ".github/workflows/update-release-dashboard.yml": [
-      "contents"
     ]
   },
   "forbiddenTriggers": [

--- a/.github/branch-write-inventory.json
+++ b/.github/branch-write-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "reviewedAt": "2026-07-24",
-  "reviewedMainCommit": "a97c830be5cdaf786aabe8d66e1c140ef6da78f0",
+  "reviewedMainCommit": "fab00e46be8c1e6d2e193af66407fb04ed0c309a",
   "strictProtectionEnabled": false,
   "directMainWriters": [
     {
@@ -9,7 +9,9 @@
       "purpose": "Record and reconcile the Greasy Fork/Discord announcement version tracker.",
       "credential": "github.token",
       "actor": "github-actions[bot]",
-      "writes": [".github/greasyfork-version.txt"],
+      "writes": [
+        ".github/greasyfork-version.txt"
+      ],
       "migrationTarget": "release-state branch"
     },
     {
@@ -17,7 +19,10 @@
       "purpose": "Import the live Greasy Fork userscript and source baseline directly into the canonical repository.",
       "credential": "github.token",
       "actor": "github-actions[bot]",
-      "writes": ["src/MissionChief_Map_Command_Toolkit.user.js", "status/source-baseline.json"],
+      "writes": [
+        "src/MissionChief_Map_Command_Toolkit.user.js",
+        "status/source-baseline.json"
+      ],
       "migrationTarget": "owner-created pull request only; retire when GitHub remains authoritative"
     },
     {
@@ -25,7 +30,9 @@
       "purpose": "Publish the stable update manifest after all release channels are verified.",
       "credential": "github.token",
       "actor": "github-actions[bot]",
-      "writes": ["status/update-manifest.json"],
+      "writes": [
+        "status/update-manifest.json"
+      ],
       "migrationTarget": "release-state branch or immutable release asset"
     },
     {
@@ -33,7 +40,9 @@
       "purpose": "Synchronize the fallback announcement tracker after a verified release.",
       "credential": "github.token",
       "actor": "github-actions[bot]",
-      "writes": [".github/greasyfork-version.txt"],
+      "writes": [
+        ".github/greasyfork-version.txt"
+      ],
       "migrationTarget": "release-state branch"
     },
     {
@@ -41,7 +50,11 @@
       "purpose": "Record controlled Greasy Fork, private-backup, Discord and dashboard recovery state.",
       "credential": "github.token",
       "actor": "github-actions[bot]",
-      "writes": ["status/release-dashboard.json", "status/README.md", ".github/greasyfork-version.txt"],
+      "writes": [
+        "status/release-dashboard.json",
+        "status/README.md",
+        ".github/greasyfork-version.txt"
+      ],
       "migrationTarget": "release-state branch; release-object repair remains API-based"
     },
     {
@@ -56,16 +69,10 @@
         "status/release-dashboard.json",
         "status/README.md"
       ],
-      "helperScripts": [".github/scripts/sync_greasyfork_root_mirror.sh"],
+      "helperScripts": [
+        ".github/scripts/sync_greasyfork_root_mirror.sh"
+      ],
       "migrationTarget": "dedicated distribution branch plus release-state branch, written by a scoped GitHub App"
-    },
-    {
-      "workflow": ".github/workflows/update-release-dashboard.yml",
-      "purpose": "Regenerate the human-readable dashboard from machine release state.",
-      "credential": "github.token",
-      "actor": "github-actions[bot]",
-      "writes": ["status/README.md"],
-      "migrationTarget": "generated Pages artifact or release-state branch"
     }
   ],
   "indirectMainWriteOrchestrators": [
@@ -86,21 +93,44 @@
       "purpose": "Validate canonical source and retain the exact commit/ref distribution candidate without changing public main or release state.",
       "permission": "contents: read",
       "artifact": "missionchief-toolkit-validation-candidate-<commit>",
-      "evidence": ["validation-candidate.json", "dist userscript", "dist text", "checksums", "release manifest"]
+      "evidence": [
+        "validation-candidate.json",
+        "dist userscript",
+        "dist text",
+        "checksums",
+        "release manifest"
+      ]
     },
     {
       "workflow": ".github/workflows/release-toolkit-dry-run.yml",
       "purpose": "Validate and package a candidate without changing public main or any publication channel.",
       "permission": "contents: read",
       "artifact": "missionchief-toolkit-v<version>-release-dry-run",
-      "evidence": ["release-dry-run-v<version>.json", "release-dry-run-v<version>.md"]
+      "evidence": [
+        "release-dry-run-v<version>.json",
+        "release-dry-run-v<version>.md"
+      ]
     },
     {
       "workflow": ".github/workflows/repository-audit.yml",
       "purpose": "Audit repository dependencies and live Greasy Fork references without changing public main or the release dashboard.",
       "permission": "contents: read",
       "artifact": "missionchief-repository-audit-<commit>",
-      "evidence": ["repository-audit.json", "repository-audit.md"]
+      "evidence": [
+        "repository-audit.json",
+        "repository-audit.md"
+      ]
+    },
+    {
+      "workflow": ".github/workflows/update-release-dashboard.yml",
+      "purpose": "Verify the committed release-dashboard JSON and Markdown projection without changing public main.",
+      "permission": "contents: read",
+      "artifact": "missionchief-release-dashboard-projection-<commit>",
+      "evidence": [
+        "status-README.md",
+        "status-README.diff",
+        "projection.log"
+      ]
     }
   ],
   "directMainPushSources": [
@@ -110,7 +140,6 @@
     ".github/workflows/reconcile-release-announcement-state.yml",
     ".github/workflows/release-recovery.yml",
     ".github/workflows/release-toolkit.yml",
-    ".github/workflows/update-release-dashboard.yml",
     ".github/scripts/sync_greasyfork_root_mirror.sh"
   ],
   "externalRepositoryMainPushSources": [
@@ -140,7 +169,6 @@
     ".github/workflows/publish-update-manifest.yml",
     ".github/workflows/reconcile-release-announcement-state.yml",
     ".github/workflows/release-recovery.yml",
-    ".github/workflows/release-toolkit.yml",
-    ".github/workflows/update-release-dashboard.yml"
+    ".github/workflows/release-toolkit.yml"
   ]
 }

--- a/.github/scripts/generate_release_dashboard.py
+++ b/.github/scripts/generate_release_dashboard.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import argparse
 import hashlib
 import json
 import re
@@ -10,8 +11,8 @@ from copy import deepcopy
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
-SOURCE = ROOT / "status" / "release-dashboard.json"
-OUTPUT = ROOT / "status" / "README.md"
+DEFAULT_SOURCE = ROOT / "status" / "release-dashboard.json"
+DEFAULT_OUTPUT = ROOT / "status" / "README.md"
 CANONICAL = ROOT / "src" / "MissionChief_Map_Command_Toolkit.user.js"
 VERSION_RE = re.compile(r"^//\s*@version\s+([^\s]+)", re.MULTILINE)
 
@@ -66,12 +67,7 @@ def sanitize_verified_ledger(data: dict) -> dict:
     return sanitized
 
 
-def main() -> None:
-    original = json.loads(SOURCE.read_text(encoding="utf-8"))
-    data = sanitize_verified_ledger(original)
-    if data != original:
-        SOURCE.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
-
+def render_dashboard(data: dict) -> str:
     status = data.get("status", {})
     latest = data.get("latestRelease") or {}
     assets = data.get("assets", {})
@@ -152,10 +148,41 @@ def main() -> None:
         "",
         "The JSON file remains the machine-readable verified-release ledger. Transient validation candidates are retained as immutable workflow artifacts and are never written into this dashboard.",
     ])
+    return "\n".join(lines) + "\n"
 
-    OUTPUT.write_text("\n".join(lines) + "\n", encoding="utf-8")
-    print(f"Generated {OUTPUT.relative_to(ROOT)}")
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source", type=Path, default=DEFAULT_SOURCE)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Render without mutating the JSON ledger and fail if sanitation would change it.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    original = json.loads(args.source.read_text(encoding="utf-8"))
+    data = sanitize_verified_ledger(original)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(render_dashboard(data), encoding="utf-8")
+
+    if args.check:
+        if data != original:
+            print("Dashboard ledger sanitation would change the committed JSON; refusing projection-only validation.")
+            return 1
+        print(f"Verified dashboard projection at {args.output}")
+        return 0
+
+    if data != original:
+        args.source.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    print(f"Generated {args.output.relative_to(ROOT) if args.output.is_relative_to(ROOT) else args.output}")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/.github/scripts/test_branch_write_inventory.py
+++ b/.github/scripts/test_branch_write_inventory.py
@@ -92,14 +92,15 @@ def main() -> int:
         fail("A workflow cannot be both a direct main writer and an orchestrator")
     if artifact_workflows & classified_contents:
         fail("Artifact-only workflows cannot retain contents-write classification")
-    if len(direct_workflows) != 7:
-        fail(f"Expected seven reviewed direct public-main writers, found {len(direct_workflows)}")
+    if len(direct_workflows) != 6:
+        fail(f"Expected six reviewed direct public-main writers, found {len(direct_workflows)}")
     if len(orchestrator_workflows) != 2:
         fail(f"Expected two reviewed release orchestrators, found {len(orchestrator_workflows)}")
     expected_artifacts = {
         ".github/workflows/validate-userscript.yml",
         ".github/workflows/release-toolkit-dry-run.yml",
         ".github/workflows/repository-audit.yml",
+        ".github/workflows/update-release-dashboard.yml",
     }
     if artifact_workflows != expected_artifacts:
         fail(f"Unexpected artifact-only workflow inventory: {sorted(artifact_workflows)}")
@@ -209,6 +210,29 @@ def main() -> int:
         'dashboard["lastUpdated"]',
     ], "Repository-audit script")
 
+    dashboard_workflow = (ROOT / ".github/workflows/update-release-dashboard.yml").read_text(encoding="utf-8")
+    dashboard_generator = (ROOT / ".github/scripts/generate_release_dashboard.py").read_text(encoding="utf-8")
+    require_markers(dashboard_workflow, [
+        "permissions:\n  contents: read",
+        "persist-credentials: false",
+        "Generate and compare read-only dashboard projection",
+        "--check",
+        "--output dashboard-projection/status-README.md",
+        "cmp --silent status/README.md dashboard-projection/status-README.md",
+        "Upload dashboard projection evidence",
+        "Public main changed: no",
+    ], "Artifact-only dashboard-projection workflow")
+    forbid_markers(dashboard_workflow, [
+        "contents: write", "git commit", "git push", "git pull --rebase", "github-actions[bot]",
+    ], "Artifact-only dashboard-projection workflow")
+    require_markers(dashboard_generator, [
+        'parser.add_argument("--output"',
+        '"--check"',
+        "if args.check:",
+        "Dashboard ledger sanitation would change the committed JSON",
+        "def render_dashboard(data: dict) -> str:",
+    ], "Dashboard generator projection mode")
+
     for entry in external_entries:
         path = ROOT / str(entry["path"])
         repository = str(entry["repository"])
@@ -233,8 +257,8 @@ def main() -> int:
 
     for claim in [
         "Strict pull-request-only protection is **not yet safe to enable**",
-        "seven workflows that can commit directly to public `main`",
-        "Canonical validation, release dry runs and repository audits are now artifact-only",
+        "six workflows that can commit directly to public `main`",
+        "Canonical validation, release dry runs, repository audits and dashboard projection are now artifact-only",
     ]:
         if claim not in document:
             fail(f"Human inventory is missing migration claim: {claim}")

--- a/.github/workflows/update-release-dashboard.yml
+++ b/.github/workflows/update-release-dashboard.yml
@@ -1,66 +1,101 @@
-name: Update Release Dashboard
+name: Verify Release Dashboard Projection
 
 on:
-  workflow_dispatch:
+  pull_request:
+    paths:
+      - "status/release-dashboard.json"
+      - "status/README.md"
+      - ".github/scripts/generate_release_dashboard.py"
+      - ".github/workflows/update-release-dashboard.yml"
   push:
     branches:
       - main
     paths:
       - "status/release-dashboard.json"
+      - "status/README.md"
       - ".github/scripts/generate_release_dashboard.py"
       - ".github/workflows/update-release-dashboard.yml"
+  workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
-  group: update-release-dashboard
+  group: verify-release-dashboard-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  update:
-    name: Generate Toolkit control panel
+  verify:
+    name: Verify release-dashboard projection
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:
-      - name: Check out latest main
+      - name: Check out exact repository state
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
-          ref: main
-          fetch-depth: 0
+          fetch-depth: 1
+          persist-credentials: false
+          show-progress: false
 
       - name: Validate dashboard JSON
         run: python3 -m json.tool status/release-dashboard.json >/dev/null
 
-      - name: Generate human-readable dashboard
-        run: python3 .github/scripts/generate_release_dashboard.py
-
-      - name: Commit dashboard update
+      - name: Generate and compare read-only dashboard projection
+        id: projection
+        continue-on-error: true
         shell: bash
         run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add status/README.md
+          set -o pipefail
+          mkdir -p dashboard-projection
 
-          if git diff --cached --quiet; then
-            echo "Dashboard is already current."
-            exit 0
+          python3 .github/scripts/generate_release_dashboard.py \
+            --check \
+            --output dashboard-projection/status-README.md \
+            2>&1 | tee dashboard-projection/projection.log
+          generator_status=${PIPESTATUS[0]}
+
+          compare_status=0
+          if ! cmp --silent status/README.md dashboard-projection/status-README.md; then
+            diff -u status/README.md dashboard-projection/status-README.md \
+              > dashboard-projection/status-README.diff || true
+            cat dashboard-projection/status-README.diff
+            compare_status=1
+          else
+            printf '%s\n' "Committed status/README.md matches the deterministic projection." \
+              > dashboard-projection/status-README.diff
           fi
 
-          git commit -m "Refresh Toolkit release dashboard"
-          git pull --rebase origin main
-          git push origin HEAD:main
+          if [[ "$generator_status" -ne 0 || "$compare_status" -ne 0 ]]; then
+            exit 1
+          fi
+
+      - name: Upload dashboard projection evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: missionchief-release-dashboard-projection-${{ github.sha }}
+          path: dashboard-projection/
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Enforce dashboard projection result
+        if: steps.projection.outcome != 'success'
+        run: |
+          echo "Release dashboard JSON/Markdown projection is inconsistent. Review the retained evidence."
+          exit 1
 
       - name: Write workflow summary
         shell: bash
         run: |
           VERSION="$(jq -r '.currentVersion' status/release-dashboard.json)"
           {
-            echo "# MissionChief Toolkit dashboard"
+            echo "# MissionChief Toolkit dashboard projection"
             echo
             echo "- ✅ Dashboard JSON validated"
-            echo "- ✅ Human-readable control panel generated"
+            echo "- ✅ Ledger sanitation required no mutation"
+            echo "- ✅ Human-readable projection matches status/README.md"
+            echo "- ✅ Repository permission: contents read"
+            echo "- ✅ Public main changed: no"
             echo "- ✅ Current version: ${VERSION}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/BRANCH_PROTECTION_MIGRATION.md
+++ b/docs/BRANCH_PROTECTION_MIGRATION.md
@@ -17,13 +17,14 @@ The migration is tracked by Issue #41. Authority is maintained in:
 - immutable Action pins and permission auditing;
 - owner-authenticated review branches for packages and rollback preparation;
 - explicit production and recovery confirmation phrases;
-- exact commit/ref/hash validation evidence for automatic releases.
+- exact commit/ref/hash validation evidence for automatic releases;
+- deterministic dashboard JSON/Markdown projection checks.
 
 ## Stage 1 — write-path inventory ✅
 
 The 24 July 2026 baseline identified 10 direct public-main writers, two release orchestrators, two owner-token review-branch writers and one private-repository backup writer. Every `contents: write` workflow and executable main-ref mutation is classified and fail-closed in CI.
 
-## Stage 2 — generated-state separation in progress
+## Stage 2 — validation and generated-evidence separation ✅
 
 ### Release dry runs ✅
 
@@ -37,7 +38,7 @@ Repository audits are read-only and artifact-only. They retain commit-scoped JSO
 
 Canonical validation no longer commits `dist/` or transient dashboard candidate fields.
 
-The workflow now:
+The workflow:
 
 - has `contents: read` only;
 - checks out without persisted credentials;
@@ -46,27 +47,39 @@ The workflow now:
 - uploads `missionchief-toolkit-validation-candidate-<commit>` for 14 days;
 - proves that public `main` and the release dashboard were not changed.
 
-Automatic release downloads the artifact from the exact triggering workflow run, verifies all hashes and paths, rejects a stale commit when `main` has advanced, and checks the GitHub Release tag directly. It no longer trusts persistent dashboard candidate fields.
+Automatic release downloads the artifact from the exact triggering workflow run, verifies all hashes and paths, rejects a stale commit when `main` has advanced, and checks the GitHub Release tag directly. The owner release command performs a fresh validation of current `main`.
 
-The owner release command performs a fresh validation of current `main`, verifies the requested version and hash, and refuses an existing GitHub Release before readiness begins.
+Stable public `dist/` paths remain current because `release-toolkit.yml` publishes `dist/` and the two root Greasy Fork mirrors together after readiness passes and production release begins.
 
-Stable public `dist/` paths remain current because `release-toolkit.yml` publishes `dist/` and the two root Greasy Fork mirrors together after readiness passes and production release begins. Candidate output is therefore artifact-only; public distribution output is release-only.
+### Dashboard projection ✅
 
-The persistent release ledger no longer contains `distributionCandidate` or stale `releaseDryRun` records. Dashboard generation sanitizes those legacy fields and refreshes the canonical source hash only when the verified dashboard version matches source.
+The standalone dashboard refresher no longer commits `status/README.md`.
 
-Direct public-main writers are reduced from **10 to 7**.
+Production release and recovery already generate `status/README.md` in the same commit as `status/release-dashboard.json`. The former follow-up writer duplicated that work and created an unnecessary additional commit.
 
-### Remaining generated state
+`update-release-dashboard.yml` now:
+
+- has `contents: read` only;
+- checks out the exact event state with persisted credentials disabled;
+- validates the JSON ledger;
+- renders the dashboard to `dashboard-projection/status-README.md` using `--check`;
+- fails when ledger sanitation would change committed JSON;
+- compares the generated Markdown byte-for-byte with `status/README.md`;
+- uploads the projection, diff and log for 30 days;
+- never commits, pushes or changes release state.
+
+Direct public-main writers are reduced from **10 to 6**.
+
+## Remaining generated state
 
 The protected branch still mixes:
 
 1. canonical userscript source and policy;
 2. stable distribution and root Greasy Fork mirrors;
 3. release dashboard and announcement state;
-4. stable update-manifest state;
-5. generated human-readable dashboard files.
+4. stable update-manifest state.
 
-The remaining writers cannot be disabled until their data is moved and every release/recovery path is rehearsed.
+The remaining writers cannot be disabled until those data classes are moved and every release/recovery path is rehearsed.
 
 ## Target architecture
 
@@ -84,15 +97,24 @@ Mutable dashboard, announcement, manifest and recovery state. It is operational 
 
 ### Immutable evidence
 
-Validation candidates, release bundles, checksums, audits, dry runs, changelog extracts and handovers remain GitHub Release assets or Actions artifacts.
+Validation candidates, dashboard projections, release bundles, checksums, audits, dry runs, changelog extracts and handovers remain GitHub Release assets or Actions artifacts.
+
+## Access and speed requirements
+
+The final protection design must retain fast owner operation:
+
+- `Conroy1988` remains repository administrator and recovery authority;
+- normal changes use owner-created branches and fast parallel CI;
+- no mandatory external reviewer is introduced;
+- admin bypass, where configured, is limited to pull-request operation rather than routine direct pushes;
+- auto-merge should be enabled after the workflow and settings rehearsal;
+- distribution and release-state branches retain explicit administrator recovery access;
+- strict enforcement is not enabled until branch creation, PR update, merge, release, recovery and ruleset rollback access are all proven.
 
 ## Remaining migration stages
 
 1. ✅ Inventory every workflow and script capable of updating public `main`.
-2. ✅ Separate validation/dry-run/audit evidence from public `main`.
-   - [x] Convert release dry runs to artifact-only evidence.
-   - [x] Convert repository audits to artifact-only evidence.
-   - [x] Convert canonical validation candidates to artifact-only evidence.
+2. ✅ Separate validation, dry-run, audit and dashboard-projection evidence from public `main`.
 3. Move dashboard, announcement and manifest state to a release-state branch or immutable assets.
 4. Move stable `dist/` and Greasy Fork mirrors to a distribution branch.
 5. Introduce a narrowly scoped GitHub App identity.
@@ -106,9 +128,16 @@ Validation candidates, release bundles, checksums, audits, dry runs, changelog e
    - dashboard reconstruction;
    - stable release-asset repair;
    - emergency rollback-candidate preparation.
-8. Require pull requests, approved checks, current branches and resolved conversations.
-9. Block direct human pushes and enable strict protection only after complete rehearsal.
+8. Rehearse owner/admin access:
+   - create and update an owner branch;
+   - open and update a pull request;
+   - auto-merge after green checks;
+   - use PR-only administrator bypass where required;
+   - repair distribution and release-state branches;
+   - disable or amend the ruleset.
+9. Require pull requests, approved checks, current branches and resolved conversations.
+10. Block direct human pushes and enable strict protection only after complete rehearsal.
 
 ## Exit criteria
 
-Strict protection is ready only when no workflow requires a public-main commit, every bypass actor is a scoped GitHub App, generated state is reconstructable, and every release/recovery path has passed non-production rehearsal.
+Strict protection is ready only when no workflow requires a public-main commit, every bypass actor is a scoped GitHub App or explicit administrator recovery actor, generated state is reconstructable, owner update speed is preserved, and every release/recovery/access path has passed non-production rehearsal.

--- a/docs/BRANCH_PROTECTION_MIGRATION.md
+++ b/docs/BRANCH_PROTECTION_MIGRATION.md
@@ -110,6 +110,7 @@ The final protection design must retain fast owner operation:
 - auto-merge should be enabled after the workflow and settings rehearsal;
 - distribution and release-state branches retain explicit administrator recovery access;
 - strict enforcement is not enabled until branch creation, PR update, merge, release, recovery and ruleset rollback access are all proven.
+- `Verify release-dashboard projection` is designated as a future required status check whenever the ledger, renderer or projection workflow changes.
 
 ## Remaining migration stages
 

--- a/docs/BRANCH_WRITE_INVENTORY.md
+++ b/docs/BRANCH_WRITE_INVENTORY.md
@@ -1,16 +1,16 @@
 # Protected-branch write inventory
 
 **Reviewed:** 24 July 2026  
-**Reviewed `main`:** `a97c830be5cdaf786aabe8d66e1c140ef6da78f0`  
+**Reviewed `main`:** `fab00e46be8c1e6d2e193af66407fb04ed0c309a`  
 **Issue:** #41 — Migrate release state for strict main-branch protection
 
 ## Current conclusion
 
 Strict pull-request-only protection is **not yet safe to enable**.
 
-The repository now has seven workflows that can commit directly to public `main`. Two additional release orchestrators invoke the reusable production writer but contain no direct public-main push. The remaining writes are limited to release distribution, release state, announcement state, source import and generated dashboard output.
+The repository now has six workflows that can commit directly to public `main`. Two release orchestrators invoke the reusable production writer but contain no direct public-main push. The remaining writes are limited to release distribution, release state, announcement state and the legacy source-import path.
 
-Canonical validation, release dry runs and repository audits are now artifact-only. All three use read-only contents permission, disable persisted checkout credentials and retain immutable evidence without mutating public `main` or the production release dashboard.
+Canonical validation, release dry runs, repository audits and dashboard projection are now artifact-only. All four use read-only contents permission, disable persisted checkout credentials where checkout is required, and retain deterministic evidence without mutating public `main`.
 
 `.github/branch-write-inventory.json` is the machine-readable authority. `.github/scripts/test_branch_write_inventory.py` and `.github/scripts/test_validation_candidate_pipeline.py` fail closed when a writer, permission, evidence schema or release-consumption boundary changes.
 
@@ -24,9 +24,8 @@ Canonical validation, release dry runs and repository audits are now artifact-on
 | `reconcile-release-announcement-state.yml` | `.github/greasyfork-version.txt` | Move announcement state to a release-state branch. |
 | `release-recovery.yml` | dashboard JSON/Markdown and announcement tracker | Keep release-object repair in the API; move mutable state to the release-state branch. |
 | `release-toolkit.yml` | stable `dist/`, root Greasy Fork mirrors and final release dashboard | Move distribution output to a dedicated branch and state to a release-state branch under a scoped GitHub App. |
-| `update-release-dashboard.yml` | generated `status/README.md` | Generate at Pages/deployment time or from the release-state branch. |
 
-The executable public-main push helper `.github/scripts/sync_greasyfork_root_mirror.sh` is owned by `release-toolkit.yml`. It now publishes `dist/` and the two stable root mirrors together only after release readiness has passed and the guarded production release has started.
+The executable public-main push helper `.github/scripts/sync_greasyfork_root_mirror.sh` is owned by `release-toolkit.yml`. It publishes `dist/` and the two stable root mirrors together only after release readiness has passed and the guarded production release has started.
 
 ## Artifact-only evidence workflows
 
@@ -35,10 +34,13 @@ The executable public-main push helper `.github/scripts/sync_greasyfork_root_mir
 | `validate-userscript.yml` | `contents: read` | exact commit/ref candidate JSON, userscript, text copy, checksums and release manifest | No branch or dashboard change. |
 | `release-toolkit-dry-run.yml` | `contents: read` | release bundle plus versioned JSON/Markdown dry-run report | No branch or publication-channel change. |
 | `repository-audit.yml` | `contents: read` | `repository-audit.json` and `.md` in `missionchief-repository-audit-<commit>` | No branch or release-dashboard change. |
+| `update-release-dashboard.yml` | `contents: read` | generated control-panel Markdown, comparison result and projection log | No branch change; fails when JSON and Markdown diverge. |
 
-Canonical validation artifacts are named `missionchief-toolkit-validation-candidate-<commit>`. The evidence records the exact source commit, source ref, version, SHA-256 and a fixed distribution inventory. The verifier rejects stale commits, mismatched hashes, altered refs and any evidence claiming a public-main or dashboard mutation.
+The dashboard projection workflow replaces the old independent dashboard commit. Production release and recovery workflows already generate `status/README.md` in the same commit as `status/release-dashboard.json`. The read-only workflow now regenerates the Markdown into a temporary directory, verifies that ledger sanitation requires no mutation, compares the result byte-for-byte and retains evidence for 30 days.
 
-The former committed dry-run record was stale at v4.10.4 while production was v5.0.7. The former committed repository audit described v4.13.1 and wrote a fixed `2026-07-14` timestamp into the production dashboard. The former validation workflow committed transient candidate output and release-dashboard fields before publication. All three write paths are now removed and permanently forbidden by CI.
+Canonical validation artifacts are named `missionchief-toolkit-validation-candidate-<commit>`. The evidence records the exact source commit, source ref, version, SHA-256 and fixed distribution inventory. The verifier rejects stale commits, mismatched hashes, altered refs and any evidence claiming a public-main or dashboard mutation.
+
+The former committed dry-run record was stale at v4.10.4 while production was v5.0.7. The former committed repository audit described v4.13.1 and wrote a fixed `2026-07-14` timestamp into the production dashboard. The former validation workflow committed transient candidate output before publication. The former dashboard refresher produced an additional automation commit for data already generated by release/recovery. All four direct write paths are removed and permanently forbidden by CI.
 
 ## Production release write sequence
 
@@ -47,9 +49,10 @@ The former committed dry-run record was stale at v4.10.4 while production was v5
 3. Release Readiness independently rebuilds and validates `dist/` from canonical source.
 4. `release-toolkit.yml` rebuilds again and calls `.github/scripts/sync_greasyfork_root_mirror.sh` to publish stable `dist/` and root mirrors.
 5. `release-toolkit.yml` publishes GitHub Release, verifies Greasy Fork, backs up privately and posts Discord.
-6. `release-toolkit.yml` commits the verified release dashboard.
+6. `release-toolkit.yml` commits the verified release dashboard JSON and Markdown together.
 7. `publish-update-manifest.yml` commits the stable update manifest.
-8. Dashboard and announcement reconciliation may create further generated-state commits.
+8. Announcement reconciliation may create further generated-state commits.
+9. `update-release-dashboard.yml` only verifies the committed JSON/Markdown projection; it never writes.
 
 The owner command does not trust persistent candidate state. It freshly validates current `main`, verifies the requested version and hash, refuses an existing release, then starts the same readiness and production workflows.
 
@@ -75,7 +78,7 @@ Their write authority remains only because the reusable production workflow stil
 - **Public `main`:** reviewed source, workflows, tests, policy, documentation and stable configuration only.
 - **Distribution branch:** stable `dist/` and root Greasy Fork mirrors, written only by the release GitHub App.
 - **Release-state branch:** dashboard, manifest, announcement and recovery state; never product source.
-- **Immutable evidence:** validation candidates, bundles, checksums, audits, dry-runs and handovers as release assets or workflow artifacts.
+- **Immutable evidence:** validation candidates, dashboard projections, bundles, checksums, audits, dry-runs and handovers as release assets or workflow artifacts.
 
 ## Migration order
 
@@ -83,16 +86,18 @@ Their write authority remains only because the reusable production workflow stil
 2. ✅ Convert release dry runs to artifact-only evidence.
 3. ✅ Convert repository audits to artifact-only evidence.
 4. ✅ Convert canonical validation candidates to artifact-only evidence and remove persistent candidate state.
-5. Separate release dashboard, manifest and announcement state from canonical source.
-6. Move stable distribution output to a dedicated branch.
-7. Introduce a narrowly scoped GitHub App for distribution and release-state writes.
-8. Rehearse every release and recovery path without public-main mutation.
-9. Enable strict protection only after all rehearsals pass.
+5. ✅ Convert standalone dashboard refreshes to read-only projection verification.
+6. Separate release dashboard, manifest and announcement state from canonical source.
+7. Move stable distribution output to a dedicated branch.
+8. Introduce a narrowly scoped GitHub App for distribution and release-state writes.
+9. Rehearse every release and recovery path without public-main mutation.
+10. Enable strict protection only after all rehearsals pass.
 
 ## Current migration evidence
 
 - PR #498: initial inventory and fail-closed enforcement.
 - PR #499: dry-run writer removed.
 - PR #500: repository-audit writer removed.
-- Canonical validation writer removed on the current Issue #41 migration branch.
-- Direct public-main writers reduced from **10 to 7**.
+- PR #501: canonical validation writer removed and release authorization rewired.
+- Current change: standalone dashboard writer converted to read-only projection verification.
+- Direct public-main writers reduced from **10 to 6**.


### PR DESCRIPTION
## Purpose

Advance Issue #41 by removing the standalone release-dashboard refresher as the fourth direct automation writer to public `main`.

## Problem

`release-toolkit.yml` and `release-recovery.yml` already generate `status/README.md` in the same commit as `status/release-dashboard.json`. `update-release-dashboard.yml` then repeated that work and could create an additional bot commit for the same state.

## Changes

- Reduce `update-release-dashboard.yml` to `contents: read`.
- Add pull-request coverage and disable persisted checkout credentials.
- Add a read-only `--check`/`--output` projection mode to `generate_release_dashboard.py` while preserving the existing default release/recovery behaviour.
- Render the control panel into `dashboard-projection/status-README.md`.
- Fail if ledger sanitation would modify the committed JSON.
- Compare the generated Markdown byte-for-byte with committed `status/README.md`.
- Retain the projection, comparison result and log for 30 days.
- Remove the workflow from the Actions write-permission allowlist.
- Reclassify it as artifact-only evidence.
- Reduce direct public-main writers from 7 to 6.
- Record owner/admin access, PR-only bypass and auto-merge as mandatory final-protection requirements.

## Safety

- No userscript, distribution, version or release-ledger content change.
- Production release and recovery continue to generate JSON and Markdown together before their existing guarded commit.
- No release is published.
- No branch-protection setting is enabled.
- The workflow can only validate and retain evidence; it cannot commit or push.

## Validation

All four checks pass on exact head `9b7947d8b3532b4fc1c3b99d894e613110cca630`:

- Verify Release Dashboard Projection
- Development and Automation Workflow Policy
- Actions security
- Development status

The projection job completed JSON validation, ledger-sanitation verification, deterministic rendering, byte comparison and evidence upload successfully. Its failure gate was skipped because no inconsistency was found.

Retained evidence: `missionchief-release-dashboard-projection-695f1eac26e5f4bbe93f2c80c76358a989c725fb`, retained for 30 days.

Advances #41