### PR TITLE
Retire automatic Greasy Fork source importing

### DIFF
--- a/.github/actions-security-policy.json
+++ b/.github/actions-security-policy.json
@@ -29,9 +29,6 @@
     ".github/workflows/greasyfork-release-monitor.yml": [
       "contents"
     ],
-    ".github/workflows/import-canonical-userscript.yml": [
-      "contents"
-    ],
     ".github/workflows/owner-release-command.yml": [
       "actions",
       "contents",

--- a/.github/branch-write-inventory.json
+++ b/.github/branch-write-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "reviewedAt": "2026-07-24",
-  "reviewedMainCommit": "220531fc65c65d210c871dda7fd8ffad7b5df528",
+  "reviewedMainCommit": "fc2fcb206df00d28a1b4752409d9352728585c9e",
   "strictProtectionEnabled": false,
   "directMainWriters": [
     {
@@ -13,17 +13,6 @@
         ".github/greasyfork-version.txt"
       ],
       "migrationTarget": "release-state branch"
-    },
-    {
-      "workflow": ".github/workflows/import-canonical-userscript.yml",
-      "purpose": "Import the live Greasy Fork userscript and source baseline directly into the canonical repository.",
-      "credential": "github.token",
-      "actor": "github-actions[bot]",
-      "writes": [
-        "src/MissionChief_Map_Command_Toolkit.user.js",
-        "status/source-baseline.json"
-      ],
-      "migrationTarget": "owner-created pull request only; retire when GitHub remains authoritative"
     },
     {
       "workflow": ".github/workflows/publish-update-manifest.yml",
@@ -131,11 +120,22 @@
         "status-README.diff",
         "projection.log"
       ]
+    },
+    {
+      "workflow": ".github/workflows/import-canonical-userscript.yml",
+      "purpose": "Verify GitHub-authoritative canonical source against live Greasy Fork without importing or modifying repository state.",
+      "permission": "contents: read",
+      "artifact": "missionchief-greasyfork-canonical-parity-<commit>",
+      "evidence": [
+        "greasyfork-canonical-parity.json",
+        "greasyfork-canonical-parity.md",
+        "live userscript",
+        "parity.log"
+      ]
     }
   ],
   "directMainPushSources": [
     ".github/workflows/greasyfork-release-monitor.yml",
-    ".github/workflows/import-canonical-userscript.yml",
     ".github/workflows/publish-update-manifest.yml",
     ".github/workflows/reconcile-release-announcement-state.yml",
     ".github/workflows/release-recovery.yml",
@@ -164,7 +164,6 @@
   "contentsWriteAuthority": [
     ".github/workflows/auto-release-after-validation.yml",
     ".github/workflows/greasyfork-release-monitor.yml",
-    ".github/workflows/import-canonical-userscript.yml",
     ".github/workflows/owner-release-command.yml",
     ".github/workflows/publish-update-manifest.yml",
     ".github/workflows/reconcile-release-announcement-state.yml",

--- a/.github/scripts/audit_greasyfork_canonical_parity.py
+++ b/.github/scripts/audit_greasyfork_canonical_parity.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Audit live Greasy Fork against the GitHub-authoritative canonical userscript.
+
+The audit is deliberately read-only. A canonical version ahead of Greasy Fork is an
+expected pre-publication state. A live version ahead of GitHub, or equal-version
+content drift, fails closed and requires an owner-reviewed repository change.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CANONICAL = ROOT / "src" / "MissionChief_Map_Command_Toolkit.user.js"
+VERSION_RE = re.compile(r"^//\s*@version\s+([^\s]+)", re.MULTILINE)
+NAME_RE = re.compile(r"^//\s*@name\s+(.+?)\s*$", re.MULTILINE)
+SEMVER_RE = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-([0-9A-Za-z.-]+))?(?:\+([0-9A-Za-z.-]+))?$"
+)
+
+
+def sha256(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def metadata(path: Path) -> dict[str, object]:
+    payload = path.read_bytes()
+    text = payload.decode("utf-8")
+    if "// ==UserScript==" not in text or "// ==/UserScript==" not in text:
+        raise ValueError(f"userscript metadata block is missing: {path}")
+    versions = VERSION_RE.findall(text)
+    names = NAME_RE.findall(text)
+    if len(versions) != 1:
+        raise ValueError(f"userscript must contain exactly one @version: {path}")
+    if len(names) != 1 or "MissionChief Map Command Toolkit" not in names[0]:
+        raise ValueError(f"userscript has an unexpected @name: {path}")
+    version = versions[0].strip()
+    if not SEMVER_RE.fullmatch(version):
+        raise ValueError(f"userscript has a non-semantic @version {version!r}: {path}")
+    return {
+        "name": names[0].strip(),
+        "version": version,
+        "sha256": sha256(payload),
+        "bytes": len(payload),
+        "lines": text.count("\n") + 1,
+    }
+
+
+def prerelease_key(value: str | None) -> tuple[tuple[int, object], ...] | None:
+    if value is None:
+        return None
+    parts: list[tuple[int, object]] = []
+    for token in value.split("."):
+        if token.isdigit():
+            parts.append((0, int(token)))
+        else:
+            parts.append((1, token))
+    return tuple(parts)
+
+
+def compare_semver(left: str, right: str) -> int:
+    left_match = SEMVER_RE.fullmatch(left)
+    right_match = SEMVER_RE.fullmatch(right)
+    if not left_match or not right_match:
+        raise ValueError("semantic versions are required")
+
+    left_core = tuple(int(value) for value in left_match.groups()[:3])
+    right_core = tuple(int(value) for value in right_match.groups()[:3])
+    if left_core != right_core:
+        return 1 if left_core > right_core else -1
+
+    left_pre = prerelease_key(left_match.group(4))
+    right_pre = prerelease_key(right_match.group(4))
+    if left_pre is None and right_pre is None:
+        return 0
+    if left_pre is None:
+        return 1
+    if right_pre is None:
+        return -1
+    if left_pre == right_pre:
+        return 0
+    return 1 if left_pre > right_pre else -1
+
+
+def classify(canonical: dict[str, object], live: dict[str, object]) -> tuple[str, bool, str]:
+    canonical_version = str(canonical["version"])
+    live_version = str(live["version"])
+    canonical_hash = str(canonical["sha256"])
+    live_hash = str(live["sha256"])
+
+    if canonical_version == live_version:
+        if canonical_hash == live_hash:
+            return (
+                "in-sync",
+                True,
+                "GitHub canonical source and the live Greasy Fork distribution are byte-identical.",
+            )
+        return (
+            "equal-version-content-mismatch",
+            False,
+            "GitHub and Greasy Fork report the same version but different content hashes.",
+        )
+
+    ordering = compare_semver(canonical_version, live_version)
+    if ordering > 0:
+        return (
+            "canonical-ahead",
+            True,
+            "GitHub canonical source is ahead of Greasy Fork; this is an expected pre-publication state.",
+        )
+    return (
+        "live-ahead",
+        False,
+        "Greasy Fork is ahead of GitHub canonical source. Automatic importing is retired; owner review is required.",
+    )
+
+
+def build_report(
+    canonical: dict[str, object],
+    live: dict[str, object],
+    *,
+    source_url: str,
+    source_commit: str,
+    generated_at: str,
+) -> dict[str, object]:
+    state, acceptable, summary = classify(canonical, live)
+    return {
+        "schemaVersion": 1,
+        "project": "MissionChief Map Command Toolkit",
+        "authority": "GitHub canonical source",
+        "state": state,
+        "acceptable": acceptable,
+        "summary": summary,
+        "sourceCommit": source_commit,
+        "generatedAt": generated_at,
+        "canonical": canonical,
+        "greasyFork": {
+            **live,
+            "sourceUrl": source_url,
+        },
+        "mutation": {
+            "publicMainChanged": False,
+            "canonicalSourceChanged": False,
+            "sourceBaselineChanged": False,
+            "pullRequestCreated": False,
+        },
+        "policy": {
+            "automaticImportEnabled": False,
+            "liveAheadRequiresOwnerReview": True,
+            "equalVersionHashMismatchRequiresOwnerReview": True,
+        },
+    }
+
+
+def render_markdown(report: dict[str, object]) -> str:
+    canonical = report["canonical"]
+    live = report["greasyFork"]
+    mutation = report["mutation"]
+    assert isinstance(canonical, dict)
+    assert isinstance(live, dict)
+    assert isinstance(mutation, dict)
+    marker = "✅" if report["acceptable"] else "❌"
+    return "\n".join(
+        [
+            "# Greasy Fork canonical parity audit",
+            "",
+            f"- State: **{marker} {report['state']}**",
+            f"- Authority: **{report['authority']}**",
+            f"- Summary: {report['summary']}",
+            f"- Source commit: `{report['sourceCommit']}`",
+            f"- Generated: `{report['generatedAt']}`",
+            "",
+            "## Canonical GitHub source",
+            "",
+            f"- Version: `{canonical['version']}`",
+            f"- SHA-256: `{canonical['sha256']}`",
+            f"- Bytes: `{canonical['bytes']}`",
+            f"- Lines: `{canonical['lines']}`",
+            "",
+            "## Live Greasy Fork distribution",
+            "",
+            f"- Version: `{live['version']}`",
+            f"- SHA-256: `{live['sha256']}`",
+            f"- Bytes: `{live['bytes']}`",
+            f"- Lines: `{live['lines']}`",
+            "",
+            "## Mutation proof",
+            "",
+            f"- Public `main` changed: **{'yes' if mutation['publicMainChanged'] else 'no'}**",
+            f"- Canonical source changed: **{'yes' if mutation['canonicalSourceChanged'] else 'no'}**",
+            f"- Bootstrap baseline changed: **{'yes' if mutation['sourceBaselineChanged'] else 'no'}**",
+            f"- Pull request created: **{'yes' if mutation['pullRequestCreated'] else 'no'}**",
+            "",
+            "The former automatic importer is retired. Any live-ahead or equal-version content drift requires an owner-reviewed repository change.",
+            "",
+        ]
+    )
+
+
+def self_test() -> None:
+    base = {
+        "name": "MissionChief Map Command Toolkit",
+        "version": "5.0.7",
+        "sha256": "a" * 64,
+        "bytes": 100,
+        "lines": 10,
+    }
+    assert classify(base, dict(base))[0:2] == ("in-sync", True)
+
+    mismatch = {**base, "sha256": "b" * 64}
+    assert classify(base, mismatch)[0:2] == ("equal-version-content-mismatch", False)
+
+    older = {**base, "version": "5.0.6", "sha256": "c" * 64}
+    assert classify(base, older)[0:2] == ("canonical-ahead", True)
+
+    newer = {**base, "version": "5.0.8", "sha256": "d" * 64}
+    assert classify(base, newer)[0:2] == ("live-ahead", False)
+
+    assert compare_semver("5.1.0", "5.0.9") > 0
+    assert compare_semver("5.0.7", "5.0.7-rc.1") > 0
+    assert compare_semver("5.0.7-rc.2", "5.0.7-rc.1") > 0
+    print("Greasy Fork canonical parity self-tests passed.")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--canonical", type=Path, default=DEFAULT_CANONICAL)
+    parser.add_argument("--live", type=Path)
+    parser.add_argument("--source-url", default="")
+    parser.add_argument("--source-commit", default="local")
+    parser.add_argument("--json-output", type=Path)
+    parser.add_argument("--markdown-output", type=Path)
+    parser.add_argument("--self-test", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.self_test:
+        self_test()
+        return 0
+    if not args.live or not args.json_output or not args.markdown_output:
+        raise SystemExit("--live, --json-output and --markdown-output are required")
+
+    canonical = metadata(args.canonical)
+    live = metadata(args.live)
+    generated_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    report = build_report(
+        canonical,
+        live,
+        source_url=args.source_url,
+        source_commit=args.source_commit,
+        generated_at=generated_at,
+    )
+
+    args.json_output.parent.mkdir(parents=True, exist_ok=True)
+    args.markdown_output.parent.mkdir(parents=True, exist_ok=True)
+    args.json_output.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    args.markdown_output.write_text(render_markdown(report), encoding="utf-8")
+    print(json.dumps(report, indent=2))
+    return 0 if report["acceptable"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_branch_write_inventory.py
+++ b/.github/scripts/test_branch_write_inventory.py
@@ -92,8 +92,8 @@ def main() -> int:
         fail("A workflow cannot be both a direct main writer and an orchestrator")
     if artifact_workflows & classified_contents:
         fail("Artifact-only workflows cannot retain contents-write classification")
-    if len(direct_workflows) != 6:
-        fail(f"Expected six reviewed direct public-main writers, found {len(direct_workflows)}")
+    if len(direct_workflows) != 5:
+        fail(f"Expected five reviewed direct public-main writers, found {len(direct_workflows)}")
     if len(orchestrator_workflows) != 2:
         fail(f"Expected two reviewed release orchestrators, found {len(orchestrator_workflows)}")
     expected_artifacts = {
@@ -101,6 +101,7 @@ def main() -> int:
         ".github/workflows/release-toolkit-dry-run.yml",
         ".github/workflows/repository-audit.yml",
         ".github/workflows/update-release-dashboard.yml",
+        ".github/workflows/import-canonical-userscript.yml",
     }
     if artifact_workflows != expected_artifacts:
         fail(f"Unexpected artifact-only workflow inventory: {sorted(artifact_workflows)}")
@@ -233,6 +234,30 @@ def main() -> int:
         "def render_dashboard(data: dict) -> str:",
     ], "Dashboard generator projection mode")
 
+    parity_workflow = (ROOT / ".github/workflows/import-canonical-userscript.yml").read_text(encoding="utf-8")
+    parity_auditor = (ROOT / ".github/scripts/audit_greasyfork_canonical_parity.py").read_text(encoding="utf-8")
+    require_markers(parity_workflow, [
+        "name: Verify Greasy Fork Canonical Parity",
+        "permissions:\n  contents: read",
+        "persist-credentials: false",
+        "Audit GitHub canonical authority",
+        "Upload immutable parity evidence",
+        "missionchief-greasyfork-canonical-parity-${{ github.sha }}",
+        "Automatic importing is retired; owner review is required.",
+    ], "Artifact-only Greasy Fork parity workflow")
+    forbid_markers(parity_workflow, [
+        "contents: write", "git commit", "git push", "git pull --rebase",
+        "github-actions[bot]", "DEVELOPMENT_PR_TOKEN", "gh pr create",
+    ], "Artifact-only Greasy Fork parity workflow")
+    require_markers(parity_auditor, [
+        '"authority": "GitHub canonical source"',
+        '"automaticImportEnabled": False',
+        '"publicMainChanged": False',
+        '"canonicalSourceChanged": False',
+        '"sourceBaselineChanged": False',
+        '"liveAheadRequiresOwnerReview": True',
+    ], "Greasy Fork parity auditor")
+
     for entry in external_entries:
         path = ROOT / str(entry["path"])
         repository = str(entry["repository"])
@@ -257,8 +282,8 @@ def main() -> int:
 
     for claim in [
         "Strict pull-request-only protection is **not yet safe to enable**",
-        "six workflows that can commit directly to public `main`",
-        "Canonical validation, release dry runs, repository audits and dashboard projection are now artifact-only",
+        "five workflows that can commit directly to public `main`",
+        "Canonical validation, release dry runs, repository audits, dashboard projection and Greasy Fork parity are now artifact-only",
     ]:
         if claim not in document:
             fail(f"Human inventory is missing migration claim: {claim}")

--- a/.github/scripts/test_greasyfork_parity_pipeline.py
+++ b/.github/scripts/test_greasyfork_parity_pipeline.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Structural and executable contracts for the retired Greasy Fork importer."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "import-canonical-userscript.yml"
+AUDITOR = ROOT / ".github" / "scripts" / "audit_greasyfork_canonical_parity.py"
+BASELINE = ROOT / "status" / "source-baseline.json"
+
+
+def require(text: str, markers: list[str], label: str) -> None:
+    for marker in markers:
+        if marker not in text:
+            raise AssertionError(f"{label} is missing required marker: {marker}")
+
+
+def forbid(text: str, markers: list[str], label: str) -> None:
+    for marker in markers:
+        if marker in text:
+            raise AssertionError(f"{label} contains forbidden marker: {marker}")
+
+
+def main() -> int:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    auditor = AUDITOR.read_text(encoding="utf-8")
+    baseline = json.loads(BASELINE.read_text(encoding="utf-8"))
+
+    require(workflow, [
+        "name: Verify Greasy Fork Canonical Parity",
+        "schedule:",
+        'cron: "17 5 * * *"',
+        "permissions:\n  contents: read",
+        "persist-credentials: false",
+        "Validate parity-auditor self-tests",
+        "audit_greasyfork_canonical_parity.py --self-test",
+        "Download live Greasy Fork distribution",
+        "Audit GitHub canonical authority",
+        "Upload immutable parity evidence",
+        "missionchief-greasyfork-canonical-parity-${{ github.sha }}",
+        "retention-days: 30",
+        "Automatic importing is retired; owner review is required.",
+    ], "Greasy Fork parity workflow")
+    forbid(workflow, [
+        "contents: write",
+        "git commit",
+        "git push",
+        "git pull --rebase",
+        "github-actions[bot]",
+        "DEVELOPMENT_PR_TOKEN",
+        "gh pr create",
+        "status/source-baseline.json >",
+        "cp \"$TEMP\" \"$TARGET\"",
+    ], "Greasy Fork parity workflow")
+
+    require(auditor, [
+        '"authority": "GitHub canonical source"',
+        '"automaticImportEnabled": False',
+        '"publicMainChanged": False',
+        '"canonicalSourceChanged": False',
+        '"sourceBaselineChanged": False',
+        '"pullRequestCreated": False',
+        '"liveAheadRequiresOwnerReview": True',
+        '"equalVersionHashMismatchRequiresOwnerReview": True',
+        '"canonical-ahead"',
+        '"live-ahead"',
+        '"equal-version-content-mismatch"',
+    ], "Greasy Fork parity auditor")
+    forbid(auditor, [
+        "git commit",
+        "git push",
+        "gh pr create",
+        "DEVELOPMENT_PR_TOKEN",
+    ], "Greasy Fork parity auditor")
+
+    if baseline.get("schemaVersion") != 2:
+        raise AssertionError("Historical source baseline must use schemaVersion 2")
+    if baseline.get("recordType") != "historical-bootstrap-baseline":
+        raise AssertionError("Source baseline must be explicitly historical")
+    if baseline.get("automaticImportEnabled") is not False:
+        raise AssertionError("Historical source baseline must disable automatic importing")
+    if baseline.get("canonicalStatus") != "historical-bootstrap-record-github-authoritative":
+        raise AssertionError("Source baseline must identify GitHub as current authority")
+    if baseline.get("currentAuthority") != "src/MissionChief_Map_Command_Toolkit.user.js":
+        raise AssertionError("Source baseline current authority path changed")
+
+    result = subprocess.run(["python3", str(AUDITOR), "--self-test"], cwd=ROOT)
+    if result.returncode != 0:
+        raise AssertionError("Greasy Fork parity auditor self-tests failed")
+
+    print("Greasy Fork parity pipeline passed: GitHub authority, read-only audit, no automatic import.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/import-canonical-userscript.yml
+++ b/.github/workflows/import-canonical-userscript.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
+      - "src/MissionChief_Map_Command_Toolkit.user.js"
       - ".github/workflows/import-canonical-userscript.yml"
       - ".github/scripts/audit_greasyfork_canonical_parity.py"
       - ".github/actions-security-policy.json"
@@ -17,6 +18,7 @@ on:
     branches:
       - main
     paths:
+      - "src/MissionChief_Map_Command_Toolkit.user.js"
       - ".github/workflows/import-canonical-userscript.yml"
       - ".github/scripts/audit_greasyfork_canonical_parity.py"
       - "status/source-baseline.json"

--- a/.github/workflows/import-canonical-userscript.yml
+++ b/.github/workflows/import-canonical-userscript.yml
@@ -1,44 +1,56 @@
-name: Import Canonical Userscript Baseline
+name: Verify Greasy Fork Canonical Parity
 
 on:
+  schedule:
+    - cron: "17 5 * * *"
   workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/import-canonical-userscript.yml"
+      - ".github/scripts/audit_greasyfork_canonical_parity.py"
+      - ".github/actions-security-policy.json"
+      - ".github/branch-write-inventory.json"
+      - "docs/BRANCH_PROTECTION_MIGRATION.md"
+      - "docs/BRANCH_WRITE_INVENTORY.md"
+      - "status/source-baseline.json"
   push:
     branches:
       - main
     paths:
       - ".github/workflows/import-canonical-userscript.yml"
+      - ".github/scripts/audit_greasyfork_canonical_parity.py"
+      - "status/source-baseline.json"
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
-  group: import-canonical-userscript
-  cancel-in-progress: false
+  group: greasyfork-canonical-parity-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  import:
-    name: Import live Greasy Fork script as GitHub baseline
+  audit:
+    name: Verify GitHub authority against live Greasy Fork
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
-      - name: Check out latest main
+      - name: Check out exact repository state
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
-          ref: main
-          fetch-depth: 0
+          fetch-depth: 1
+          persist-credentials: false
+          show-progress: false
 
-      - name: Download and validate live userscript
-        id: source
+      - name: Validate parity-auditor self-tests
+        run: python3 .github/scripts/audit_greasyfork_canonical_parity.py --self-test
+
+      - name: Download live Greasy Fork distribution
         shell: bash
         run: |
           set -euo pipefail
-
+          mkdir -p greasyfork-parity/live
           URL="https://update.greasyfork.org/scripts/586018/MissionChief%20Map%20Command%20Toolkit.user.js"
-          TARGET="src/MissionChief_Map_Command_Toolkit.user.js"
-          BASELINE="status/source-baseline.json"
-          TEMP="$(mktemp)"
-
           curl \
             --fail \
             --silent \
@@ -50,83 +62,49 @@ jobs:
             --retry-delay 5 \
             --header "Cache-Control: no-cache" \
             "${URL}?cache_bust=$(date +%s%N)" \
-            --output "$TEMP"
+            --output greasyfork-parity/live/MissionChief_Map_Command_Toolkit.user.js
 
-          grep -q '^// ==UserScript==$' "$TEMP"
-          grep -q '^// ==/UserScript==$' "$TEMP"
-
-          VERSION="$(
-            sed -nE 's|^//[[:space:]]*@version[[:space:]]+(.+)$|\1|p' "$TEMP" |
-              head -n 1 |
-              xargs
-          )"
-
-          NAME="$(
-            sed -nE 's|^//[[:space:]]*@name[[:space:]]+(.+)$|\1|p' "$TEMP" |
-              head -n 1 |
-              xargs
-          )"
-
-          if [[ -z "$VERSION" || ! "$VERSION" =~ ^[0-9A-Za-z][0-9A-Za-z._+-]*$ ]]; then
-            echo "::error::The downloaded userscript has no valid @version value."
-            exit 1
-          fi
-
-          if [[ "$NAME" != *"MissionChief Map Command Toolkit"* ]]; then
-            echo "::error::The downloaded userscript name was unexpected: $NAME"
-            exit 1
-          fi
-
-          mkdir -p "$(dirname "$TARGET")" "$(dirname "$BASELINE")"
-          cp "$TEMP" "$TARGET"
-
-          SHA256="$(sha256sum "$TARGET" | awk '{print $1}')"
-          BYTES="$(wc -c < "$TARGET" | tr -d ' ')"
-          LINES="$(wc -l < "$TARGET" | tr -d ' ')"
-          IMPORTED_AT="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-
-          jq -n \
-            --arg project "MissionChief Map Command Toolkit" \
-            --arg source "$URL" \
-            --arg version "$VERSION" \
-            --arg sha256 "$SHA256" \
-            --arg importedAt "$IMPORTED_AT" \
-            --arg commit "$GITHUB_SHA" \
-            --argjson bytes "$BYTES" \
-            --argjson lines "$LINES" \
-            '{
-              project: $project,
-              source: "Greasy Fork live distribution",
-              sourceUrl: $source,
-              importedVersion: $version,
-              sha256: $sha256,
-              bytes: $bytes,
-              lines: $lines,
-              importedAt: $importedAt,
-              workflowCommit: $commit,
-              canonicalStatus: "baseline-imported-not-yet-distribution-source"
-            }' > "$BASELINE"
-
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "sha256=$SHA256" >> "$GITHUB_OUTPUT"
-          echo "Imported live userscript version $VERSION"
-          echo "SHA-256: $SHA256"
-
-      - name: Commit canonical baseline
+      - name: Audit GitHub canonical authority
+        id: parity
+        continue-on-error: true
         env:
-          VERSION: ${{ steps.source.outputs.version }}
+          SOURCE_COMMIT: ${{ github.sha }}
         shell: bash
         run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add src/MissionChief_Map_Command_Toolkit.user.js status/source-baseline.json
+          set -o pipefail
+          python3 .github/scripts/audit_greasyfork_canonical_parity.py \
+            --live greasyfork-parity/live/MissionChief_Map_Command_Toolkit.user.js \
+            --source-url "https://update.greasyfork.org/scripts/586018/MissionChief%20Map%20Command%20Toolkit.user.js" \
+            --source-commit "$SOURCE_COMMIT" \
+            --json-output greasyfork-parity/greasyfork-canonical-parity.json \
+            --markdown-output greasyfork-parity/greasyfork-canonical-parity.md \
+            2>&1 | tee greasyfork-parity/parity.log
 
-          if git diff --cached --quiet; then
-            echo "Canonical baseline already matches Greasy Fork version $VERSION."
-            exit 0
+      - name: Upload immutable parity evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: missionchief-greasyfork-canonical-parity-${{ github.sha }}
+          path: greasyfork-parity/
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Publish parity summary
+        if: always()
+        shell: bash
+        run: |
+          if [[ -f greasyfork-parity/greasyfork-canonical-parity.md ]]; then
+            cat greasyfork-parity/greasyfork-canonical-parity.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "# Greasy Fork canonical parity audit"
+              echo
+              echo "- ❌ Parity evidence was not generated."
+            } >> "$GITHUB_STEP_SUMMARY"
           fi
 
-          git commit -m "Import canonical userscript baseline v${VERSION}"
-          git pull --rebase origin main
-          git push origin HEAD:main
+      - name: Enforce parity result
+        if: steps.parity.outcome != 'success'
+        run: |
+          echo "Greasy Fork is ahead of GitHub or equal-version content differs. Automatic importing is retired; owner review is required."
+          exit 1

--- a/.github/workflows/validate-development-package-workflow.yml
+++ b/.github/workflows/validate-development-package-workflow.yml
@@ -11,6 +11,7 @@ on:
       - ".github/workflows/pages-production-monitor.yml"
       - ".github/workflows/validate-development-package-workflow.yml"
       - ".github/scripts/*.sh"
+      - ".github/scripts/audit_greasyfork_canonical_parity.py"
       - ".github/scripts/audit_repository.py"
       - ".github/scripts/generate_release_dashboard.py"
       - ".github/scripts/reconcile_pages_incident.sh"
@@ -21,12 +22,14 @@ on:
       - ".github/scripts/test_automation_record_hygiene.py"
       - ".github/scripts/test_branch_write_inventory.py"
       - ".github/scripts/test_development_package_workflow.py"
+      - ".github/scripts/test_greasyfork_parity_pipeline.py"
       - ".github/scripts/test_validation_candidate_pipeline.py"
       - "docs/BRANCH_PROTECTION_MIGRATION.md"
       - "docs/BRANCH_WRITE_INVENTORY.md"
       - "docs/DEVELOPMENT_PACKAGE_WORKFLOW.md"
       - "status/release-dashboard.json"
       - "status/README.md"
+      - "status/source-baseline.json"
   workflow_dispatch:
 
 permissions:
@@ -54,6 +57,7 @@ jobs:
             python3 .github/scripts/test_automation_record_hygiene.py
             python3 .github/scripts/test_branch_write_inventory.py
             python3 .github/scripts/test_validation_candidate_pipeline.py
+            python3 .github/scripts/test_greasyfork_parity_pipeline.py
           } 2>&1 | tee "$RUNNER_TEMP/workflow-policy.log"
 
       - name: Upload policy diagnostics

--- a/docs/BRANCH_PROTECTION_MIGRATION.md
+++ b/docs/BRANCH_PROTECTION_MIGRATION.md
@@ -7,7 +7,8 @@ The migration is tracked by Issue #41. Authority is maintained in:
 - `docs/BRANCH_WRITE_INVENTORY.md`;
 - `.github/branch-write-inventory.json`;
 - `.github/scripts/test_branch_write_inventory.py`;
-- `.github/scripts/test_validation_candidate_pipeline.py`.
+- `.github/scripts/test_validation_candidate_pipeline.py`;
+- `.github/scripts/test_greasyfork_parity_pipeline.py`.
 
 ## Current safe controls
 
@@ -18,7 +19,8 @@ The migration is tracked by Issue #41. Authority is maintained in:
 - owner-authenticated review branches for packages and rollback preparation;
 - explicit production and recovery confirmation phrases;
 - exact commit/ref/hash validation evidence for automatic releases;
-- deterministic dashboard JSON/Markdown projection checks.
+- deterministic dashboard JSON/Markdown projection checks;
+- GitHub-authoritative Greasy Fork parity evidence with no automatic import path.
 
 ## Stage 1 — write-path inventory ✅
 
@@ -38,16 +40,7 @@ Repository audits are read-only and artifact-only. They retain commit-scoped JSO
 
 Canonical validation no longer commits `dist/` or transient dashboard candidate fields.
 
-The workflow:
-
-- has `contents: read` only;
-- checks out without persisted credentials;
-- validates canonical source, documentation, JavaScript syntax and distribution parity;
-- writes exact commit/ref/version/SHA-256 evidence;
-- uploads `missionchief-toolkit-validation-candidate-<commit>` for 14 days;
-- proves that public `main` and the release dashboard were not changed.
-
-Automatic release downloads the artifact from the exact triggering workflow run, verifies all hashes and paths, rejects a stale commit when `main` has advanced, and checks the GitHub Release tag directly. The owner release command performs a fresh validation of current `main`.
+The workflow has read-only contents permission, checks out without persisted credentials, validates exact source/ref/version/hash evidence, and uploads `missionchief-toolkit-validation-candidate-<commit>`. Automatic release consumes the exact successful-run artifact and rejects stale commits. The owner release command performs a fresh validation of current `main`.
 
 Stable public `dist/` paths remain current because `release-toolkit.yml` publishes `dist/` and the two root Greasy Fork mirrors together after readiness passes and production release begins.
 
@@ -55,20 +48,28 @@ Stable public `dist/` paths remain current because `release-toolkit.yml` publish
 
 The standalone dashboard refresher no longer commits `status/README.md`.
 
-Production release and recovery already generate `status/README.md` in the same commit as `status/release-dashboard.json`. The former follow-up writer duplicated that work and created an unnecessary additional commit.
+Production release and recovery generate `status/README.md` in the same commit as `status/release-dashboard.json`. `update-release-dashboard.yml` now validates the JSON, renders to a temporary path with `--check`, compares Markdown byte-for-byte, retains evidence for 30 days and never writes.
 
-`update-release-dashboard.yml` now:
+### Greasy Fork canonical parity ✅
+
+The legacy source importer is retired. GitHub remains authoritative.
+
+`import-canonical-userscript.yml` now:
 
 - has `contents: read` only;
-- checks out the exact event state with persisted credentials disabled;
-- validates the JSON ledger;
-- renders the dashboard to `dashboard-projection/status-README.md` using `--check`;
-- fails when ledger sanitation would change committed JSON;
-- compares the generated Markdown byte-for-byte with `status/README.md`;
-- uploads the projection, diff and log for 30 days;
-- never commits, pushes or changes release state.
+- runs daily, manually and when its policy changes;
+- checks out without persisted credentials;
+- downloads the live Greasy Fork userscript without copying it into canonical source;
+- validates metadata, semantic version, bytes, lines and SHA-256;
+- reports `in-sync`, `canonical-ahead`, `live-ahead` or `equal-version-content-mismatch`;
+- accepts `canonical-ahead` as an expected pre-publication state;
+- fails closed when Greasy Fork is ahead or equal-version content differs;
+- retains the live distribution, JSON/Markdown report and log for 30 days;
+- never changes source, `status/source-baseline.json`, a branch or a pull request.
 
-Direct public-main writers are reduced from **10 to 6**.
+`status/source-baseline.json` is an immutable historical v4.11.2 bootstrap record and explicitly identifies `src/MissionChief_Map_Command_Toolkit.user.js` as current authority.
+
+Direct public-main writers are reduced from **10 to 5**.
 
 ## Remaining generated state
 
@@ -97,7 +98,7 @@ Mutable dashboard, announcement, manifest and recovery state. It is operational 
 
 ### Immutable evidence
 
-Validation candidates, dashboard projections, release bundles, checksums, audits, dry runs, changelog extracts and handovers remain GitHub Release assets or Actions artifacts.
+Validation candidates, parity audits, dashboard projections, release bundles, checksums, audits, dry runs, changelog extracts and handovers remain GitHub Release assets or Actions artifacts.
 
 ## Access and speed requirements
 
@@ -109,13 +110,14 @@ The final protection design must retain fast owner operation:
 - admin bypass, where configured, is limited to pull-request operation rather than routine direct pushes;
 - auto-merge should be enabled after the workflow and settings rehearsal;
 - distribution and release-state branches retain explicit administrator recovery access;
-- strict enforcement is not enabled until branch creation, PR update, merge, release, recovery and ruleset rollback access are all proven.
-- `Verify release-dashboard projection` is designated as a future required status check whenever the ledger, renderer or projection workflow changes.
+- strict enforcement is not enabled until branch creation, PR update, merge, release, recovery and ruleset rollback access are all proven;
+- `Verify release-dashboard projection` is designated as a required status check when the ledger, renderer or projection workflow changes;
+- `Verify Greasy Fork Canonical Parity` is designated as a required status check when parity policy or the retired-importer workflow changes.
 
 ## Remaining migration stages
 
 1. ✅ Inventory every workflow and script capable of updating public `main`.
-2. ✅ Separate validation, dry-run, audit and dashboard-projection evidence from public `main`.
+2. ✅ Separate validation, dry-run, audit, dashboard-projection and Greasy Fork parity evidence from public `main`.
 3. Move dashboard, announcement and manifest state to a release-state branch or immutable assets.
 4. Move stable `dist/` and Greasy Fork mirrors to a distribution branch.
 5. Introduce a narrowly scoped GitHub App identity.
@@ -137,7 +139,7 @@ The final protection design must retain fast owner operation:
    - repair distribution and release-state branches;
    - disable or amend the ruleset.
 9. Require pull requests, approved checks, current branches and resolved conversations.
-10. Block direct human pushes and enable strict protection only after complete rehearsal.
+10. Block routine direct human pushes and enable strict protection only after complete rehearsal.
 
 ## Exit criteria
 

--- a/docs/BRANCH_WRITE_INVENTORY.md
+++ b/docs/BRANCH_WRITE_INVENTORY.md
@@ -1,25 +1,24 @@
 # Protected-branch write inventory
 
 **Reviewed:** 24 July 2026  
-**Reviewed `main`:** `fab00e46be8c1e6d2e193af66407fb04ed0c309a`  
+**Reviewed `main`:** `fc2fcb206df00d28a1b4752409d9352728585c9e`  
 **Issue:** #41 — Migrate release state for strict main-branch protection
 
 ## Current conclusion
 
 Strict pull-request-only protection is **not yet safe to enable**.
 
-The repository now has six workflows that can commit directly to public `main`. Two release orchestrators invoke the reusable production writer but contain no direct public-main push. The remaining writes are limited to release distribution, release state, announcement state and the legacy source-import path.
+The repository now has five workflows that can commit directly to public `main`. Two release orchestrators invoke the reusable production writer but contain no direct public-main push. The remaining writes are limited to stable distribution publication, release state, announcement state and the update manifest.
 
-Canonical validation, release dry runs, repository audits and dashboard projection are now artifact-only. All four use read-only contents permission, disable persisted checkout credentials where checkout is required, and retain deterministic evidence without mutating public `main`.
+Canonical validation, release dry runs, repository audits, dashboard projection and Greasy Fork parity are now artifact-only. All five use read-only contents permission, disable persisted checkout credentials where checkout is required, and retain deterministic evidence without mutating public `main`.
 
-`.github/branch-write-inventory.json` is the machine-readable authority. `.github/scripts/test_branch_write_inventory.py` and `.github/scripts/test_validation_candidate_pipeline.py` fail closed when a writer, permission, evidence schema or release-consumption boundary changes.
+`.github/branch-write-inventory.json` is the machine-readable authority. `.github/scripts/test_branch_write_inventory.py`, `.github/scripts/test_validation_candidate_pipeline.py` and `.github/scripts/test_greasyfork_parity_pipeline.py` fail closed when a writer, permission, authority or evidence boundary changes.
 
 ## Direct public `main` writers
 
 | Workflow | Current mutation | Required migration |
 |---|---|---|
 | `greasyfork-release-monitor.yml` | `.github/greasyfork-version.txt` | Move announcement state to a release-state branch. |
-| `import-canonical-userscript.yml` | canonical userscript and source baseline | Convert to an owner-created PR and retire when GitHub remains authoritative. |
 | `publish-update-manifest.yml` | `status/update-manifest.json` | Publish from a release-state branch or immutable release asset. |
 | `reconcile-release-announcement-state.yml` | `.github/greasyfork-version.txt` | Move announcement state to a release-state branch. |
 | `release-recovery.yml` | dashboard JSON/Markdown and announcement tracker | Keep release-object repair in the API; move mutable state to the release-state branch. |
@@ -33,37 +32,52 @@ The executable public-main push helper `.github/scripts/sync_greasyfork_root_mir
 |---|---|---|---|
 | `validate-userscript.yml` | `contents: read` | exact commit/ref candidate JSON, userscript, text copy, checksums and release manifest | No branch or dashboard change. |
 | `release-toolkit-dry-run.yml` | `contents: read` | release bundle plus versioned JSON/Markdown dry-run report | No branch or publication-channel change. |
-| `repository-audit.yml` | `contents: read` | `repository-audit.json` and `.md` in `missionchief-repository-audit-<commit>` | No branch or release-dashboard change. |
+| `repository-audit.yml` | `contents: read` | repository audit JSON/Markdown | No branch or release-dashboard change. |
 | `update-release-dashboard.yml` | `contents: read` | generated control-panel Markdown, comparison result and projection log | No branch change; fails when JSON and Markdown diverge. |
+| `import-canonical-userscript.yml` | `contents: read` | live userscript plus canonical-parity JSON/Markdown/log | No source, baseline, branch or PR change. |
 
-The dashboard projection workflow replaces the old independent dashboard commit. Production release and recovery workflows already generate `status/README.md` in the same commit as `status/release-dashboard.json`. The read-only workflow now regenerates the Markdown into a temporary directory, verifies that ledger sanitation requires no mutation, compares the result byte-for-byte and retains evidence for 30 days.
+### Greasy Fork authority boundary
 
-Canonical validation artifacts are named `missionchief-toolkit-validation-candidate-<commit>`. The evidence records the exact source commit, source ref, version, SHA-256 and fixed distribution inventory. The verifier rejects stale commits, mismatched hashes, altered refs and any evidence claiming a public-main or dashboard mutation.
+The former automatic importer is retired. GitHub is the canonical source of truth.
 
-The former committed dry-run record was stale at v4.10.4 while production was v5.0.7. The former committed repository audit described v4.13.1 and wrote a fixed `2026-07-14` timestamp into the production dashboard. The former validation workflow committed transient candidate output before publication. The former dashboard refresher produced an additional automation commit for data already generated by release/recovery. All four direct write paths are removed and permanently forbidden by CI.
+The read-only parity audit:
+
+- downloads the live Greasy Fork userscript;
+- validates metadata and semantic versions;
+- compares version, bytes, lines and SHA-256 with `src/MissionChief_Map_Command_Toolkit.user.js`;
+- treats `canonical-ahead` as an expected pre-publication state;
+- fails on `live-ahead` or equal-version content mismatch;
+- retains the live userscript and audit evidence for 30 days;
+- never changes canonical source, the historical bootstrap baseline, a branch or a pull request.
+
+`status/source-baseline.json` is now an immutable historical v4.11.2 bootstrap record. It is not refreshed from Greasy Fork and does not compete with current source authority.
+
+### Other retired writers
+
+The former committed dry-run record was stale at v4.10.4 while production was v5.0.7. The former committed repository audit described v4.13.1 and wrote a fixed dashboard timestamp. The former validation workflow committed transient candidate output before publication. The former dashboard refresher created an additional automation commit for data already generated by release/recovery. All five removed direct-write paths are permanently forbidden by CI.
 
 ## Production release write sequence
 
 1. `validate-userscript.yml` validates the exact `main` commit and uploads immutable candidate evidence.
-2. `auto-release-after-validation.yml` downloads the artifact from that exact successful run, verifies it and rejects a stale commit.
+2. `auto-release-after-validation.yml` downloads the artifact from that exact run, verifies it and rejects a stale commit.
 3. Release Readiness independently rebuilds and validates `dist/` from canonical source.
-4. `release-toolkit.yml` rebuilds again and calls `.github/scripts/sync_greasyfork_root_mirror.sh` to publish stable `dist/` and root mirrors.
+4. `release-toolkit.yml` publishes stable `dist/` and root mirrors.
 5. `release-toolkit.yml` publishes GitHub Release, verifies Greasy Fork, backs up privately and posts Discord.
-6. `release-toolkit.yml` commits the verified release dashboard JSON and Markdown together.
+6. `release-toolkit.yml` commits verified release dashboard JSON and Markdown together.
 7. `publish-update-manifest.yml` commits the stable update manifest.
 8. Announcement reconciliation may create further generated-state commits.
-9. `update-release-dashboard.yml` only verifies the committed JSON/Markdown projection; it never writes.
+9. Dashboard projection and Greasy Fork parity only verify; neither writes.
 
-The owner command does not trust persistent candidate state. It freshly validates current `main`, verifies the requested version and hash, refuses an existing release, then starts the same readiness and production workflows.
+The owner command freshly validates current `main`, verifies the requested version and hash, refuses an existing release, then starts the same readiness and production workflows.
 
 ## Indirect release orchestrators
 
 | Workflow | Delegated writer | Role |
 |---|---|---|
-| `auto-release-after-validation.yml` | `release-toolkit.yml` | Consumes exact immutable validation evidence, suppresses stale runs and starts the guarded release. |
+| `auto-release-after-validation.yml` | `release-toolkit.yml` | Consumes exact immutable validation evidence and starts the guarded release. |
 | `owner-release-command.yml` | `release-toolkit.yml` | Performs owner authorization plus fresh validation, then starts the guarded release. |
 
-Their write authority remains only because the reusable production workflow still writes distribution and release state. It will be narrowed after the distribution/state branch migration.
+Their write authority remains only because the reusable production workflow still writes distribution and release state.
 
 ## Explicit non-public-main writers
 
@@ -78,20 +92,21 @@ Their write authority remains only because the reusable production workflow stil
 - **Public `main`:** reviewed source, workflows, tests, policy, documentation and stable configuration only.
 - **Distribution branch:** stable `dist/` and root Greasy Fork mirrors, written only by the release GitHub App.
 - **Release-state branch:** dashboard, manifest, announcement and recovery state; never product source.
-- **Immutable evidence:** validation candidates, dashboard projections, bundles, checksums, audits, dry-runs and handovers as release assets or workflow artifacts.
+- **Immutable evidence:** validation candidates, parity audits, dashboard projections, bundles, checksums, audits, dry-runs and handovers.
 
 ## Migration order
 
 1. ✅ Inventory every public-main writer and enforce it in CI.
 2. ✅ Convert release dry runs to artifact-only evidence.
 3. ✅ Convert repository audits to artifact-only evidence.
-4. ✅ Convert canonical validation candidates to artifact-only evidence and remove persistent candidate state.
+4. ✅ Convert canonical validation candidates to artifact-only evidence.
 5. ✅ Convert standalone dashboard refreshes to read-only projection verification.
-6. Separate release dashboard, manifest and announcement state from canonical source.
-7. Move stable distribution output to a dedicated branch.
-8. Introduce a narrowly scoped GitHub App for distribution and release-state writes.
-9. Rehearse every release and recovery path without public-main mutation.
-10. Enable strict protection only after all rehearsals pass.
+6. ✅ Retire automatic Greasy Fork importing and replace it with read-only parity evidence.
+7. Separate release dashboard, manifest and announcement state from canonical source.
+8. Move stable distribution output to a dedicated branch.
+9. Introduce a narrowly scoped GitHub App for distribution and release-state writes.
+10. Rehearse every release, recovery and administrator-access path.
+11. Enable strict protection only after all rehearsals pass.
 
 ## Current migration evidence
 
@@ -99,5 +114,6 @@ Their write authority remains only because the reusable production workflow stil
 - PR #499: dry-run writer removed.
 - PR #500: repository-audit writer removed.
 - PR #501: canonical validation writer removed and release authorization rewired.
-- Current change: standalone dashboard writer converted to read-only projection verification.
-- Direct public-main writers reduced from **10 to 6**.
+- PR #502: standalone dashboard writer removed.
+- Current change: legacy Greasy Fork importer retired.
+- Direct public-main writers reduced from **10 to 5**.

--- a/status/source-baseline.json
+++ b/status/source-baseline.json
@@ -1,5 +1,7 @@
 {
+  "schemaVersion": 2,
   "project": "MissionChief Map Command Toolkit",
+  "recordType": "historical-bootstrap-baseline",
   "source": "Greasy Fork live distribution",
   "sourceUrl": "https://update.greasyfork.org/scripts/586018/MissionChief%20Map%20Command%20Toolkit.user.js",
   "importedVersion": "4.11.2",
@@ -8,5 +10,8 @@
   "lines": 27905,
   "importedAt": "2026-07-15T03:38:58Z",
   "workflowCommit": "abc55273f66467a249183d66860723ec7730226d",
-  "canonicalStatus": "baseline-imported-not-yet-distribution-source"
+  "canonicalStatus": "historical-bootstrap-record-github-authoritative",
+  "automaticImportEnabled": false,
+  "currentAuthority": "src/MissionChief_Map_Command_Toolkit.user.js",
+  "note": "This immutable record documents the original Greasy Fork bootstrap. Current parity is verified by read-only workflow artifacts; this file is never refreshed from the live distribution."
 }


### PR DESCRIPTION
## Purpose

Advance Issue #41 by removing the legacy Greasy Fork source importer as the fifth direct automation writer to public `main`.

## Problem

`import-canonical-userscript.yml` could download the live Greasy Fork script, overwrite canonical GitHub source and commit directly to `main`. That bootstrap behaviour is obsolete now that GitHub is authoritative and conflicts with strict branch protection.

## Changes

- Rename the workflow role to **Verify Greasy Fork Canonical Parity**.
- Reduce it to `contents: read` and disable persisted checkout credentials.
- Run daily, manually and immediately on canonical source or parity-policy changes.
- Download the live distribution only into temporary evidence storage.
- Add semantic-version, metadata, size, line-count and SHA-256 comparison.
- Accept `canonical-ahead` as an expected pre-publication state.
- Fail closed on `live-ahead` or equal-version content mismatch.
- Retain the live userscript, JSON/Markdown report and log for 30 days.
- Mark `status/source-baseline.json` as an immutable historical v4.11.2 bootstrap record.
- Remove the workflow from the Actions write-permission allowlist.
- Add executable parity and branch-write contracts.
- Reclassify the workflow as artifact-only and reduce direct public-main writers from 6 to 5.

## Safety

- No canonical userscript, distribution or production version change.
- No live Greasy Fork change.
- No branch, baseline refresh or pull request is created by the workflow.
- GitHub remains the explicit source authority.
- Any unexpected live-ahead or equal-version drift requires owner review rather than automatic import.
- No branch-protection setting is enabled.

## Validation

All five checks pass on exact head `f62277501689974a369cae005e667b924326f1b5`:

- Verify Greasy Fork Canonical Parity
- Validate Canonical Userscript
- Development and Automation Workflow Policy
- Actions security
- Development status

The live audit reports **in-sync**:

- GitHub canonical version: `5.0.7`
- Greasy Fork version: `5.0.7`
- GitHub SHA-256: `97a71c7df20a9d896872e554b671f789c74069f2ec8a1dbb8f4afd7135c303da`
- Greasy Fork SHA-256: `97a71c7df20a9d896872e554b671f789c74069f2ec8a1dbb8f4afd7135c303da`
- Bytes: `2060765` on both
- Lines: `31761` on both

The mutation proof records no public-main, canonical-source, bootstrap-baseline or pull-request change.

Retained evidence: `missionchief-greasyfork-canonical-parity-a417de1c1cae75d2a58b7835ac909ef0a12e3c00`, retained for 30 days.

Advances #41