### PR TITLE
Make release announcement state atomic

### DIFF
--- a/.github/actions-security-policy.json
+++ b/.github/actions-security-policy.json
@@ -40,9 +40,6 @@
     ".github/workflows/publish-update-manifest.yml": [
       "contents"
     ],
-    ".github/workflows/reconcile-release-announcement-state.yml": [
-      "contents"
-    ],
     ".github/workflows/release-recovery.yml": [
       "contents"
     ],

--- a/.github/branch-write-inventory.json
+++ b/.github/branch-write-inventory.json
@@ -1,12 +1,12 @@
 {
   "schemaVersion": 1,
   "reviewedAt": "2026-07-24",
-  "reviewedMainCommit": "fc2fcb206df00d28a1b4752409d9352728585c9e",
+  "reviewedMainCommit": "0b43be27b5857206adb55de85777425be9160816",
   "strictProtectionEnabled": false,
   "directMainWriters": [
     {
       "workflow": ".github/workflows/greasyfork-release-monitor.yml",
-      "purpose": "Record and reconcile the Greasy Fork/Discord announcement version tracker.",
+      "purpose": "Record fallback Greasy Fork/Discord announcement state when primary release completion is absent.",
       "credential": "github.token",
       "actor": "github-actions[bot]",
       "writes": [
@@ -25,16 +25,6 @@
       "migrationTarget": "release-state branch or immutable release asset"
     },
     {
-      "workflow": ".github/workflows/reconcile-release-announcement-state.yml",
-      "purpose": "Synchronize the fallback announcement tracker after a verified release.",
-      "credential": "github.token",
-      "actor": "github-actions[bot]",
-      "writes": [
-        ".github/greasyfork-version.txt"
-      ],
-      "migrationTarget": "release-state branch"
-    },
-    {
       "workflow": ".github/workflows/release-recovery.yml",
       "purpose": "Record controlled Greasy Fork, private-backup, Discord and dashboard recovery state.",
       "credential": "github.token",
@@ -48,7 +38,7 @@
     },
     {
       "workflow": ".github/workflows/release-toolkit.yml",
-      "purpose": "Publish stable dist and Greasy Fork root mirrors, then record final verified release state.",
+      "purpose": "Publish stable distribution, record verified release state and update the announcement tracker atomically.",
       "credential": "github.token",
       "actor": "github-actions[bot]",
       "writes": [
@@ -56,7 +46,8 @@
         "MissionChief_Map_Command_Toolkit.user.js",
         "MissionChief_Map_Command_Toolkit.txt",
         "status/release-dashboard.json",
-        "status/README.md"
+        "status/README.md",
+        ".github/greasyfork-version.txt"
       ],
       "helperScripts": [
         ".github/scripts/sync_greasyfork_root_mirror.sh"
@@ -132,12 +123,21 @@
         "live userscript",
         "parity.log"
       ]
+    },
+    {
+      "workflow": ".github/workflows/reconcile-release-announcement-state.yml",
+      "purpose": "Verify dashboard and announcement tracker consistency without changing repository state.",
+      "permission": "contents: read",
+      "artifact": "missionchief-release-announcement-state-<commit>",
+      "evidence": [
+        "release-announcement-state.json",
+        "release-announcement-state.md"
+      ]
     }
   ],
   "directMainPushSources": [
     ".github/workflows/greasyfork-release-monitor.yml",
     ".github/workflows/publish-update-manifest.yml",
-    ".github/workflows/reconcile-release-announcement-state.yml",
     ".github/workflows/release-recovery.yml",
     ".github/workflows/release-toolkit.yml",
     ".github/scripts/sync_greasyfork_root_mirror.sh"
@@ -166,7 +166,6 @@
     ".github/workflows/greasyfork-release-monitor.yml",
     ".github/workflows/owner-release-command.yml",
     ".github/workflows/publish-update-manifest.yml",
-    ".github/workflows/reconcile-release-announcement-state.yml",
     ".github/workflows/release-recovery.yml",
     ".github/workflows/release-toolkit.yml"
   ]

--- a/.github/scripts/test_branch_write_inventory.py
+++ b/.github/scripts/test_branch_write_inventory.py
@@ -92,8 +92,8 @@ def main() -> int:
         fail("A workflow cannot be both a direct main writer and an orchestrator")
     if artifact_workflows & classified_contents:
         fail("Artifact-only workflows cannot retain contents-write classification")
-    if len(direct_workflows) != 5:
-        fail(f"Expected five reviewed direct public-main writers, found {len(direct_workflows)}")
+    if len(direct_workflows) != 4:
+        fail(f"Expected four reviewed direct public-main writers, found {len(direct_workflows)}")
     if len(orchestrator_workflows) != 2:
         fail(f"Expected two reviewed release orchestrators, found {len(orchestrator_workflows)}")
     expected_artifacts = {
@@ -102,6 +102,7 @@ def main() -> int:
         ".github/workflows/repository-audit.yml",
         ".github/workflows/update-release-dashboard.yml",
         ".github/workflows/import-canonical-userscript.yml",
+        ".github/workflows/reconcile-release-announcement-state.yml",
     }
     if artifact_workflows != expected_artifacts:
         fail(f"Unexpected artifact-only workflow inventory: {sorted(artifact_workflows)}")
@@ -258,6 +259,22 @@ def main() -> int:
         '"liveAheadRequiresOwnerReview": True',
     ], "Greasy Fork parity auditor")
 
+    announcement_workflow = (ROOT / ".github/workflows/reconcile-release-announcement-state.yml").read_text(encoding="utf-8")
+    require_markers(announcement_workflow, [
+        "name: Verify Release Announcement State",
+        "permissions:\n  contents: read",
+        "persist-credentials: false",
+        "Verify dashboard and announcement tracker",
+        "announcementTrackerChanged: false",
+        "Upload immutable announcement-state evidence",
+        "missionchief-release-announcement-state-${{ github.sha }}",
+        "No automatic mutation was attempted.",
+    ], "Artifact-only announcement-state workflow")
+    forbid_markers(announcement_workflow, [
+        "contents: write", "git commit", "git push", "git pull --rebase",
+        "github-actions[bot]", "git reset --hard",
+    ], "Artifact-only announcement-state workflow")
+
     for entry in external_entries:
         path = ROOT / str(entry["path"])
         repository = str(entry["repository"])
@@ -282,8 +299,8 @@ def main() -> int:
 
     for claim in [
         "Strict pull-request-only protection is **not yet safe to enable**",
-        "five workflows that can commit directly to public `main`",
-        "Canonical validation, release dry runs, repository audits, dashboard projection and Greasy Fork parity are now artifact-only",
+        "four workflows that can commit directly to public `main`",
+        "Canonical validation, release dry runs, repository audits, dashboard projection, Greasy Fork parity and announcement-state verification are now artifact-only",
     ]:
         if claim not in document:
             fail(f"Human inventory is missing migration claim: {claim}")

--- a/.github/scripts/test_release_announcement_state_pipeline.py
+++ b/.github/scripts/test_release_announcement_state_pipeline.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Contracts for atomic release announcement state and read-only verification."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+RELEASE = ROOT / ".github" / "workflows" / "release-toolkit.yml"
+VERIFY = ROOT / ".github" / "workflows" / "reconcile-release-announcement-state.yml"
+DASHBOARD = ROOT / "status" / "release-dashboard.json"
+TRACKER = ROOT / ".github" / "greasyfork-version.txt"
+
+
+def require(text: str, markers: list[str], label: str) -> None:
+    for marker in markers:
+        if marker not in text:
+            raise AssertionError(f"{label} is missing required marker: {marker}")
+
+
+def forbid(text: str, markers: list[str], label: str) -> None:
+    for marker in markers:
+        if marker in text:
+            raise AssertionError(f"{label} contains forbidden marker: {marker}")
+
+
+def main() -> int:
+    release = RELEASE.read_text(encoding="utf-8")
+    verify = VERIFY.read_text(encoding="utf-8")
+    dashboard = json.loads(DASHBOARD.read_text(encoding="utf-8"))
+    tracker = TRACKER.read_text(encoding="utf-8").strip()
+
+    require(release, [
+        "Post verified release to Discord",
+        "Record successful release and announcement state",
+        "printf '%s\\n' \"$RELEASE_VERSION\" > .github/greasyfork-version.txt",
+        "git add status/release-dashboard.json status/README.md .github/greasyfork-version.txt",
+        "Release dashboard and announcement tracker updated atomically",
+    ], "Production release workflow")
+    discord_index = release.index("      - name: Post verified release to Discord")
+    state_index = release.index("      - name: Record successful release and announcement state")
+    publish_index = release.index("      - name: Publish update channels in parallel")
+    if not discord_index < state_index < publish_index:
+        raise AssertionError("Announcement state must be recorded after Discord and before update-channel publication")
+
+    require(verify, [
+        "name: Verify Release Announcement State",
+        "permissions:\n  contents: read",
+        "persist-credentials: false",
+        "Verify dashboard and announcement tracker",
+        "announcementTrackerChanged: false",
+        "Upload immutable announcement-state evidence",
+        "missionchief-release-announcement-state-${{ github.sha }}",
+        "No automatic mutation was attempted.",
+    ], "Announcement-state verification workflow")
+    forbid(verify, [
+        "contents: write",
+        "git commit",
+        "git push",
+        "git pull --rebase",
+        "github-actions[bot]",
+        "git reset --hard",
+    ], "Announcement-state verification workflow")
+
+    latest = dashboard.get("latestRelease") or {}
+    if str(latest.get("version") or "") != tracker:
+        raise AssertionError("Committed announcement tracker does not match latest verified release")
+    if latest.get("greasyForkVerified") is not True:
+        raise AssertionError("Latest verified release is not marked Greasy Fork verified")
+    if latest.get("discordPosted") is not True:
+        raise AssertionError("Latest verified release is not marked Discord posted")
+
+    print("Release announcement state passed: atomic release commit and read-only verification.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_validation_candidate_pipeline.py
+++ b/.github/scripts/test_validation_candidate_pipeline.py
@@ -96,7 +96,7 @@ def main() -> int:
     ], "Stable distribution publication helper")
     require(release, [
         "run: bash .github/scripts/sync_greasyfork_root_mirror.sh",
-        "Record successful release in dashboard",
+        "Record successful release and announcement state",
     ], "Production release workflow")
 
     if "distributionCandidate" in dashboard or "releaseDryRun" in dashboard:

--- a/.github/scripts/test_version_status_contract.py
+++ b/.github/scripts/test_version_status_contract.py
@@ -114,9 +114,9 @@ def main() -> int:
         "MANIFEST_RUN_ID: ${{ steps.channels.outputs.manifest_run_id }}",
     ]:
         assert marker in release_workflow, f"release workflow parallel publication marker missing: {marker}"
-    dashboard_index = release_workflow.index("- name: Record successful release in dashboard")
+    dashboard_index = release_workflow.index("- name: Record successful release and announcement state")
     publish_index = release_workflow.index("- name: Publish update channels in parallel")
-    assert dashboard_index < publish_index, "parallel update channels must start after dashboard reconciliation"
+    assert dashboard_index < publish_index, "parallel update channels must start after atomic release-state reconciliation"
 
     result = subprocess.run(["node", str(RUNTIME)], cwd=ROOT)
     assert result.returncode == 0, "version status runtime fixtures failed"

--- a/.github/workflows/reconcile-release-announcement-state.yml
+++ b/.github/workflows/reconcile-release-announcement-state.yml
@@ -1,4 +1,4 @@
-name: Reconcile Release Announcement State
+name: Verify Release Announcement State
 
 on:
   workflow_run:
@@ -7,82 +7,124 @@ on:
     types:
       - completed
   workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/release-toolkit.yml"
+      - ".github/workflows/reconcile-release-announcement-state.yml"
+      - ".github/greasyfork-version.txt"
+      - "status/release-dashboard.json"
+      - ".github/actions-security-policy.json"
+      - ".github/branch-write-inventory.json"
+      - "docs/BRANCH_PROTECTION_MIGRATION.md"
+      - "docs/BRANCH_WRITE_INVENTORY.md"
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
-  group: toolkit-production-release
-  cancel-in-progress: false
+  group: verify-release-announcement-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  reconcile:
-    name: Synchronize release announcement tracker
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+  verify:
+    name: Verify release announcement tracker
+    if: >-
+      github.event_name == 'pull_request' ||
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:
-      - name: Check out latest main
+      - name: Check out exact verified state
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
-          ref: main
-          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_run' && 'main' || github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+          show-progress: false
 
-      - name: Verify completed release state
-        id: release
+      - name: Verify dashboard and announcement tracker
+        id: state
+        continue-on-error: true
         shell: bash
         run: |
           set -euo pipefail
-          DASHBOARD_FILE="status/release-dashboard.json"
-          VERSION="$(jq -r '.latestRelease.version // empty' "$DASHBOARD_FILE")"
-          GREASYFORK_VERIFIED="$(jq -r '.latestRelease.greasyForkVerified // false' "$DASHBOARD_FILE")"
-          DISCORD_POSTED="$(jq -r '.latestRelease.discordPosted // false' "$DASHBOARD_FILE")"
+          mkdir -p announcement-state
 
-          [[ -n "$VERSION" ]] || { echo "::error::The release dashboard has no latest release version."; exit 1; }
-          [[ "$GREASYFORK_VERIFIED" == "true" ]] || { echo "::error::The latest release is not verified on Greasy Fork."; exit 1; }
-          [[ "$DISCORD_POSTED" == "true" ]] || { echo "::error::The latest release is not recorded as announced to Discord."; exit 1; }
+          DASHBOARD="status/release-dashboard.json"
+          TRACKER=".github/greasyfork-version.txt"
+          DASHBOARD_VERSION="$(jq -r '.latestRelease.version // empty' "$DASHBOARD")"
+          GREASYFORK_VERIFIED="$(jq -r '.latestRelease.greasyForkVerified // false' "$DASHBOARD")"
+          DISCORD_POSTED="$(jq -r '.latestRelease.discordPosted // false' "$DASHBOARD")"
+          TRACKER_VERSION="$(tr -d '\r\n ' < "$TRACKER" 2>/dev/null || true)"
 
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          ACCEPTABLE=false
+          STATE="inconsistent"
+          if [[ -n "$DASHBOARD_VERSION" &&
+                "$TRACKER_VERSION" == "$DASHBOARD_VERSION" &&
+                "$GREASYFORK_VERIFIED" == "true" &&
+                "$DISCORD_POSTED" == "true" ]]; then
+            ACCEPTABLE=true
+            STATE="synchronized"
+          fi
 
-      - name: Reconcile fallback announcement tracker
-        env:
-          CURRENT_VERSION: ${{ steps.release.outputs.version }}
+          jq -n \
+            --arg state "$STATE" \
+            --arg dashboardVersion "$DASHBOARD_VERSION" \
+            --arg trackerVersion "$TRACKER_VERSION" \
+            --arg sourceCommit "$GITHUB_SHA" \
+            --arg generatedAt "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+            --argjson acceptable "$ACCEPTABLE" \
+            --argjson greasyForkVerified "$GREASYFORK_VERIFIED" \
+            --argjson discordPosted "$DISCORD_POSTED" \
+            '{
+              schemaVersion: 1,
+              state: $state,
+              acceptable: $acceptable,
+              sourceCommit: $sourceCommit,
+              generatedAt: $generatedAt,
+              dashboardVersion: $dashboardVersion,
+              trackerVersion: $trackerVersion,
+              greasyForkVerified: $greasyForkVerified,
+              discordPosted: $discordPosted,
+              publicMainChanged: false,
+              releaseDashboardChanged: false,
+              announcementTrackerChanged: false
+            }' > announcement-state/release-announcement-state.json
+
+          {
+            echo "# Release announcement state"
+            echo
+            echo "- State: **${STATE}**"
+            echo "- Dashboard version: \`${DASHBOARD_VERSION:-missing}\`"
+            echo "- Tracker version: \`${TRACKER_VERSION:-missing}\`"
+            echo "- Greasy Fork verified: **${GREASYFORK_VERIFIED}**"
+            echo "- Discord posted: **${DISCORD_POSTED}**"
+            echo "- Public main changed: **no**"
+          } > announcement-state/release-announcement-state.md
+
+          [[ "$ACCEPTABLE" == "true" ]]
+
+      - name: Upload immutable announcement-state evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: missionchief-release-announcement-state-${{ github.sha }}
+          path: announcement-state/
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Publish announcement-state summary
+        if: always()
         shell: bash
         run: |
-          set -euo pipefail
-          STATE_FILE=".github/greasyfork-version.txt"
-          DASHBOARD_FILE="status/release-dashboard.json"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if [[ -f announcement-state/release-announcement-state.md ]]; then
+            cat announcement-state/release-announcement-state.md >> "$GITHUB_STEP_SUMMARY"
+          fi
 
-          for attempt in 1 2 3; do
-            git fetch origin main --prune
-            git reset --hard origin/main
-
-            REMOTE_STATE="$(tr -d '\r\n ' < "$STATE_FILE" 2>/dev/null || true)"
-            DASHBOARD_VERSION="$(jq -r '.latestRelease.version // empty' "$DASHBOARD_FILE" 2>/dev/null || true)"
-            DASHBOARD_GREASYFORK="$(jq -r '.latestRelease.greasyForkVerified // false' "$DASHBOARD_FILE" 2>/dev/null || true)"
-            DASHBOARD_DISCORD="$(jq -r '.latestRelease.discordPosted // false' "$DASHBOARD_FILE" 2>/dev/null || true)"
-
-            [[ "$REMOTE_STATE" == "$CURRENT_VERSION" ]] && {
-              echo "Fallback tracker already records Toolkit ${CURRENT_VERSION}."
-              exit 0
-            }
-
-            if [[ "$DASHBOARD_VERSION" != "$CURRENT_VERSION" ||
-                  "$DASHBOARD_GREASYFORK" != "true" ||
-                  "$DASHBOARD_DISCORD" != "true" ]]; then
-              echo "::error::The verified dashboard state changed before tracker reconciliation."
-              exit 1
-            fi
-
-            printf '%s\n' "$CURRENT_VERSION" > "$STATE_FILE"
-            git add "$STATE_FILE"
-            git commit -m "Reconcile announced Toolkit version ${CURRENT_VERSION}"
-            git push origin HEAD:main && exit 0
-            sleep 5
-          done
-
-          echo "::error::Could not reconcile the release announcement tracker after three attempts."
+      - name: Enforce announcement-state result
+        if: steps.state.outcome != 'success'
+        run: |
+          echo "Verified release dashboard and announcement tracker are inconsistent. No automatic mutation was attempted."
           exit 1

--- a/.github/workflows/release-toolkit.yml
+++ b/.github/workflows/release-toolkit.yml
@@ -200,7 +200,7 @@ jobs:
             --request POST --header "Content-Type: application/json" \
             --data @discord-release-payload.json "${DISCORD_WEBHOOK_URL}?wait=true"
 
-      - name: Record successful release in dashboard
+      - name: Record successful release and announcement state
         env:
           RELEASE_VERSION: ${{ inputs.version }}
           BACKUP_COMMIT: ${{ steps.private_backup.outputs.backup_commit }}
@@ -224,10 +224,11 @@ jobs:
              .lastUpdated=$now' \
             status/release-dashboard.json > status/release-dashboard.tmp
           mv status/release-dashboard.tmp status/release-dashboard.json
+          printf '%s\n' "$RELEASE_VERSION" > .github/greasyfork-version.txt
           python3 .github/scripts/generate_release_dashboard.py
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add status/release-dashboard.json status/README.md
+          git add status/release-dashboard.json status/README.md .github/greasyfork-version.txt
           git commit -m "Record Toolkit ${RELEASE_VERSION} verified release"
           git pull --rebase origin main
           git push origin HEAD:main
@@ -293,7 +294,7 @@ jobs:
             echo "- ✅ Greasy Fork version verified"
             echo "- ✅ Private migration backup committed: ${BACKUP_COMMIT}"
             echo "- ✅ Discord release announcement posted"
-            echo "- ✅ Release dashboard and generated control panel updated"
+            echo "- ✅ Release dashboard and announcement tracker updated atomically"
             echo "- ✅ Stable update manifest published: ${MANIFEST_RUN_ID}"
             echo "- ✅ GitHub Pages deployment completed: ${PAGES_RUN_ID}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/validate-development-package-workflow.yml
+++ b/.github/workflows/validate-development-package-workflow.yml
@@ -19,10 +19,12 @@ on:
       - ".github/scripts/verify_validation_candidate.py"
       - ".github/actions-security-policy.json"
       - ".github/branch-write-inventory.json"
+      - ".github/greasyfork-version.txt"
       - ".github/scripts/test_automation_record_hygiene.py"
       - ".github/scripts/test_branch_write_inventory.py"
       - ".github/scripts/test_development_package_workflow.py"
       - ".github/scripts/test_greasyfork_parity_pipeline.py"
+      - ".github/scripts/test_release_announcement_state_pipeline.py"
       - ".github/scripts/test_validation_candidate_pipeline.py"
       - "docs/BRANCH_PROTECTION_MIGRATION.md"
       - "docs/BRANCH_WRITE_INVENTORY.md"
@@ -58,6 +60,7 @@ jobs:
             python3 .github/scripts/test_branch_write_inventory.py
             python3 .github/scripts/test_validation_candidate_pipeline.py
             python3 .github/scripts/test_greasyfork_parity_pipeline.py
+            python3 .github/scripts/test_release_announcement_state_pipeline.py
           } 2>&1 | tee "$RUNNER_TEMP/workflow-policy.log"
 
       - name: Upload policy diagnostics

--- a/docs/BRANCH_PROTECTION_MIGRATION.md
+++ b/docs/BRANCH_PROTECTION_MIGRATION.md
@@ -1,6 +1,6 @@
 # Branch Protection Migration Plan
 
-Strict pull-request-only protection is **not yet enabled**. Controlled automation commits remain because stable distribution publication, release state, update manifests, monitoring and recovery still mutate public `main`.
+Strict pull-request-only protection is **not yet enabled**. Controlled automation commits remain because stable distribution publication, release state, the update manifest, fallback monitoring and recovery still mutate public `main`.
 
 The migration is tracked by Issue #41. Authority is maintained in:
 
@@ -8,7 +8,8 @@ The migration is tracked by Issue #41. Authority is maintained in:
 - `.github/branch-write-inventory.json`;
 - `.github/scripts/test_branch_write_inventory.py`;
 - `.github/scripts/test_validation_candidate_pipeline.py`;
-- `.github/scripts/test_greasyfork_parity_pipeline.py`.
+- `.github/scripts/test_greasyfork_parity_pipeline.py`;
+- `.github/scripts/test_release_announcement_state_pipeline.py`.
 
 ## Current safe controls
 
@@ -18,69 +19,55 @@ The migration is tracked by Issue #41. Authority is maintained in:
 - immutable Action pins and permission auditing;
 - owner-authenticated review branches for packages and rollback preparation;
 - explicit production and recovery confirmation phrases;
-- exact commit/ref/hash validation evidence for automatic releases;
-- deterministic dashboard JSON/Markdown projection checks;
-- GitHub-authoritative Greasy Fork parity evidence with no automatic import path.
+- exact commit/ref/hash validation evidence;
+- deterministic dashboard projection and Greasy Fork parity evidence;
+- atomic primary release dashboard and announcement-tracker state.
 
-## Stage 1 — write-path inventory ✅
+## Completed migration stages
 
-The 24 July 2026 baseline identified 10 direct public-main writers, two release orchestrators, two owner-token review-branch writers and one private-repository backup writer. Every `contents: write` workflow and executable main-ref mutation is classified and fail-closed in CI.
+### Write-path inventory ✅
 
-## Stage 2 — validation and generated-evidence separation ✅
+The 24 July 2026 baseline identified 10 direct public-main writers. Every `contents: write` workflow and executable main-ref mutation is now classified and fail-closed in CI.
 
-### Release dry runs ✅
+### Artifact-only validation and evidence ✅
 
-Release dry runs are read-only and artifact-only. They validate and package a candidate, retain deterministic JSON/Markdown evidence for 30 days and explicitly prove that no release or branch channel changed.
+The following workflows now have read-only repository access and retain immutable evidence instead of committing generated state:
 
-### Repository and dependency audits ✅
+- canonical userscript validation;
+- release dry runs;
+- repository/dependency audits;
+- release dashboard projection;
+- Greasy Fork canonical parity;
+- release announcement-state verification.
 
-Repository audits are read-only and artifact-only. They retain commit-scoped JSON/Markdown evidence for 90 days and never rewrite production release state.
+### Greasy Fork authority ✅
 
-### Canonical validation candidates ✅
+Automatic source importing is retired. GitHub is authoritative. Live Greasy Fork parity is checked on source changes and daily; canonical-ahead is accepted during publication, while live-ahead or equal-version content drift fails for owner review.
 
-Canonical validation no longer commits `dist/` or transient dashboard candidate fields.
+### Atomic primary announcement state ✅
 
-The workflow has read-only contents permission, checks out without persisted credentials, validates exact source/ref/version/hash evidence, and uploads `missionchief-toolkit-validation-candidate-<commit>`. Automatic release consumes the exact successful-run artifact and rejects stale commits. The owner release command performs a fresh validation of current `main`.
+Normal production releases no longer require a follow-up reconciliation commit.
 
-Stable public `dist/` paths remain current because `release-toolkit.yml` publishes `dist/` and the two root Greasy Fork mirrors together after readiness passes and production release begins.
+After Greasy Fork verification, private backup and Discord publication, `release-toolkit.yml` commits these together:
 
-### Dashboard projection ✅
+- `status/release-dashboard.json`;
+- `status/README.md`;
+- `.github/greasyfork-version.txt`.
 
-The standalone dashboard refresher no longer commits `status/README.md`.
+`reconcile-release-announcement-state.yml` is now read-only. It verifies the dashboard/tracker invariant and retains evidence without attempting a repair.
 
-Production release and recovery generate `status/README.md` in the same commit as `status/release-dashboard.json`. `update-release-dashboard.yml` now validates the JSON, renders to a temporary path with `--check`, compares Markdown byte-for-byte, retains evidence for 30 days and never writes.
-
-### Greasy Fork canonical parity ✅
-
-The legacy source importer is retired. GitHub remains authoritative.
-
-`import-canonical-userscript.yml` now:
-
-- has `contents: read` only;
-- runs daily, manually and when its policy changes;
-- checks out without persisted credentials;
-- downloads the live Greasy Fork userscript without copying it into canonical source;
-- validates metadata, semantic version, bytes, lines and SHA-256;
-- reports `in-sync`, `canonical-ahead`, `live-ahead` or `equal-version-content-mismatch`;
-- accepts `canonical-ahead` as an expected pre-publication state;
-- fails closed when Greasy Fork is ahead or equal-version content differs;
-- retains the live distribution, JSON/Markdown report and log for 30 days;
-- never changes source, `status/source-baseline.json`, a branch or a pull request.
-
-`status/source-baseline.json` is an immutable historical v4.11.2 bootstrap record and explicitly identifies `src/MissionChief_Map_Command_Toolkit.user.js` as current authority.
-
-Direct public-main writers are reduced from **10 to 5**.
+Direct public-main writers are reduced from **10 to 4**.
 
 ## Remaining generated state
 
-The protected branch still mixes:
+Public `main` still contains:
 
-1. canonical userscript source and policy;
-2. stable distribution and root Greasy Fork mirrors;
-3. release dashboard and announcement state;
-4. stable update-manifest state.
+1. stable `dist/` and root Greasy Fork mirrors;
+2. verified release dashboard and recovery state;
+3. stable update-manifest state;
+4. fallback announcement-monitor state.
 
-The remaining writers cannot be disabled until those data classes are moved and every release/recovery path is rehearsed.
+These responsibilities must move before strict protection is safe.
 
 ## Target architecture
 
@@ -90,15 +77,15 @@ Reviewed source, workflows, tests, policy, documentation and stable configuratio
 
 ### Distribution branch
 
-Stable `dist/` and root userscript mirrors required by Greasy Fork, written only by a narrowly scoped release GitHub App.
+Stable `dist/` and root userscript mirrors required by Greasy Fork, written by a narrowly scoped release GitHub App.
 
 ### Release-state branch
 
-Mutable dashboard, announcement, manifest and recovery state. It is operational evidence, never a competing source for product code.
+Mutable dashboard, announcement, manifest, fallback-monitor and recovery state. It is operational evidence, never product source.
 
 ### Immutable evidence
 
-Validation candidates, parity audits, dashboard projections, release bundles, checksums, audits, dry runs, changelog extracts and handovers remain GitHub Release assets or Actions artifacts.
+Validation candidates, parity audits, announcement checks, dashboard projections, release bundles, checksums, audits, dry runs and handovers remain GitHub Release assets or Actions artifacts.
 
 ## Access and speed requirements
 
@@ -107,22 +94,22 @@ The final protection design must retain fast owner operation:
 - `Conroy1988` remains repository administrator and recovery authority;
 - normal changes use owner-created branches and fast parallel CI;
 - no mandatory external reviewer is introduced;
-- admin bypass, where configured, is limited to pull-request operation rather than routine direct pushes;
-- auto-merge should be enabled after the workflow and settings rehearsal;
-- distribution and release-state branches retain explicit administrator recovery access;
-- strict enforcement is not enabled until branch creation, PR update, merge, release, recovery and ruleset rollback access are all proven;
-- `Verify release-dashboard projection` is designated as a required status check when the ledger, renderer or projection workflow changes;
-- `Verify Greasy Fork Canonical Parity` is designated as a required status check when parity policy or the retired-importer workflow changes.
+- administrator bypass is PR-only rather than routine direct push;
+- auto-merge is enabled after rehearsal;
+- distribution and release-state branches retain administrator recovery access;
+- strict enforcement is not enabled until branch creation, PR update, merge, release, recovery and ruleset rollback access are proven;
+- dashboard projection, Greasy Fork parity and announcement-state verification become required checks only for their relevant paths.
 
 ## Remaining migration stages
 
 1. ✅ Inventory every workflow and script capable of updating public `main`.
-2. ✅ Separate validation, dry-run, audit, dashboard-projection and Greasy Fork parity evidence from public `main`.
-3. Move dashboard, announcement and manifest state to a release-state branch or immutable assets.
-4. Move stable `dist/` and Greasy Fork mirrors to a distribution branch.
-5. Introduce a narrowly scoped GitHub App identity.
-6. Remove unnecessary `contents: write` from orchestration-only workflows.
-7. Rehearse without public-main mutation:
+2. ✅ Separate validation, audit and verification evidence from public `main`.
+3. ✅ Make primary dashboard and announcement state atomic; retire the reconciliation writer.
+4. Move dashboard, manifest, fallback-monitor and recovery state to a release-state branch.
+5. Move stable `dist/` and Greasy Fork mirrors to a distribution branch.
+6. Introduce a narrowly scoped GitHub App identity.
+7. Remove unnecessary `contents: write` from orchestration-only workflows.
+8. Rehearse without public-main mutation:
    - normal Release Readiness;
    - full production publication;
    - Greasy Fork-only retry;
@@ -131,15 +118,15 @@ The final protection design must retain fast owner operation:
    - dashboard reconstruction;
    - stable release-asset repair;
    - emergency rollback-candidate preparation.
-8. Rehearse owner/admin access:
+9. Rehearse owner/admin access:
    - create and update an owner branch;
    - open and update a pull request;
    - auto-merge after green checks;
    - use PR-only administrator bypass where required;
    - repair distribution and release-state branches;
    - disable or amend the ruleset.
-9. Require pull requests, approved checks, current branches and resolved conversations.
-10. Block routine direct human pushes and enable strict protection only after complete rehearsal.
+10. Require pull requests, approved checks, current branches and resolved conversations.
+11. Block routine direct human pushes and enable strict protection only after complete rehearsal.
 
 ## Exit criteria
 

--- a/docs/BRANCH_WRITE_INVENTORY.md
+++ b/docs/BRANCH_WRITE_INVENTORY.md
@@ -1,119 +1,117 @@
 # Protected-branch write inventory
 
 **Reviewed:** 24 July 2026  
-**Reviewed `main`:** `fc2fcb206df00d28a1b4752409d9352728585c9e`  
+**Reviewed `main`:** `0b43be27b5857206adb55de85777425be9160816`  
 **Issue:** #41 — Migrate release state for strict main-branch protection
 
 ## Current conclusion
 
 Strict pull-request-only protection is **not yet safe to enable**.
 
-The repository now has five workflows that can commit directly to public `main`. Two release orchestrators invoke the reusable production writer but contain no direct public-main push. The remaining writes are limited to stable distribution publication, release state, announcement state and the update manifest.
+The repository now has four workflows that can commit directly to public `main`. Two release orchestrators invoke the reusable production writer but contain no direct public-main push. The remaining writes are limited to fallback monitoring, stable update-manifest publication, release recovery and guarded production publication.
 
-Canonical validation, release dry runs, repository audits, dashboard projection and Greasy Fork parity are now artifact-only. All five use read-only contents permission, disable persisted checkout credentials where checkout is required, and retain deterministic evidence without mutating public `main`.
+Canonical validation, release dry runs, repository audits, dashboard projection, Greasy Fork parity and announcement-state verification are now artifact-only. All six use read-only contents permission and retain deterministic evidence without mutating public `main`.
 
-`.github/branch-write-inventory.json` is the machine-readable authority. `.github/scripts/test_branch_write_inventory.py`, `.github/scripts/test_validation_candidate_pipeline.py` and `.github/scripts/test_greasyfork_parity_pipeline.py` fail closed when a writer, permission, authority or evidence boundary changes.
+`.github/branch-write-inventory.json` is the machine-readable authority. Permanent contracts fail closed when a writer, permission, authority or release-state boundary changes.
 
 ## Direct public `main` writers
 
 | Workflow | Current mutation | Required migration |
 |---|---|---|
-| `greasyfork-release-monitor.yml` | `.github/greasyfork-version.txt` | Move announcement state to a release-state branch. |
+| `greasyfork-release-monitor.yml` | fallback `.github/greasyfork-version.txt` state | Move fallback announcement state to a release-state branch. |
 | `publish-update-manifest.yml` | `status/update-manifest.json` | Publish from a release-state branch or immutable release asset. |
-| `reconcile-release-announcement-state.yml` | `.github/greasyfork-version.txt` | Move announcement state to a release-state branch. |
-| `release-recovery.yml` | dashboard JSON/Markdown and announcement tracker | Keep release-object repair in the API; move mutable state to the release-state branch. |
-| `release-toolkit.yml` | stable `dist/`, root Greasy Fork mirrors and final release dashboard | Move distribution output to a dedicated branch and state to a release-state branch under a scoped GitHub App. |
+| `release-recovery.yml` | dashboard JSON/Markdown and announcement tracker | Move mutable recovery state to the release-state branch. |
+| `release-toolkit.yml` | stable distribution, verified dashboard and announcement tracker | Move distribution and state to dedicated branches under a scoped GitHub App. |
 
-The executable public-main push helper `.github/scripts/sync_greasyfork_root_mirror.sh` is owned by `release-toolkit.yml`. It publishes `dist/` and the two stable root mirrors together only after release readiness has passed and the guarded production release has started.
+The executable public-main push helper `.github/scripts/sync_greasyfork_root_mirror.sh` is owned by `release-toolkit.yml`.
 
 ## Artifact-only evidence workflows
 
-| Workflow | Permission | Retained evidence | Branch effect |
+| Workflow | Permission | Evidence | Branch effect |
 |---|---|---|---|
-| `validate-userscript.yml` | `contents: read` | exact commit/ref candidate JSON, userscript, text copy, checksums and release manifest | No branch or dashboard change. |
-| `release-toolkit-dry-run.yml` | `contents: read` | release bundle plus versioned JSON/Markdown dry-run report | No branch or publication-channel change. |
-| `repository-audit.yml` | `contents: read` | repository audit JSON/Markdown | No branch or release-dashboard change. |
-| `update-release-dashboard.yml` | `contents: read` | generated control-panel Markdown, comparison result and projection log | No branch change; fails when JSON and Markdown diverge. |
-| `import-canonical-userscript.yml` | `contents: read` | live userscript plus canonical-parity JSON/Markdown/log | No source, baseline, branch or PR change. |
+| `validate-userscript.yml` | `contents: read` | exact candidate source/ref/hash bundle | No branch or dashboard change. |
+| `release-toolkit-dry-run.yml` | `contents: read` | release bundle plus dry-run report | No publication-channel change. |
+| `repository-audit.yml` | `contents: read` | repository audit JSON/Markdown | No branch or dashboard change. |
+| `update-release-dashboard.yml` | `contents: read` | rendered dashboard, diff and log | No branch change. |
+| `import-canonical-userscript.yml` | `contents: read` | live Greasy Fork parity evidence | No source, baseline, branch or PR change. |
+| `reconcile-release-announcement-state.yml` | `contents: read` | dashboard/tracker consistency JSON/Markdown | No dashboard or tracker change. |
 
-### Greasy Fork authority boundary
+## Atomic announcement state
 
-The former automatic importer is retired. GitHub is the canonical source of truth.
+Primary release no longer requires a follow-up reconciliation commit.
 
-The read-only parity audit:
+After Greasy Fork verification, private backup and Discord publication, `release-toolkit.yml` now writes the following together in one commit:
 
-- downloads the live Greasy Fork userscript;
-- validates metadata and semantic versions;
-- compares version, bytes, lines and SHA-256 with `src/MissionChief_Map_Command_Toolkit.user.js`;
-- treats `canonical-ahead` as an expected pre-publication state;
-- fails on `live-ahead` or equal-version content mismatch;
-- retains the live userscript and audit evidence for 30 days;
-- never changes canonical source, the historical bootstrap baseline, a branch or a pull request.
+- `status/release-dashboard.json`;
+- `status/README.md`;
+- `.github/greasyfork-version.txt`.
 
-`status/source-baseline.json` is now an immutable historical v4.11.2 bootstrap record. It is not refreshed from Greasy Fork and does not compete with current source authority.
+This guarantees that the verified release ledger and announcement tracker cannot diverge during normal publication. `reconcile-release-announcement-state.yml` now only verifies that:
 
-### Other retired writers
+- the dashboard has a latest release version;
+- Greasy Fork is verified;
+- Discord is recorded as posted;
+- the tracker exactly matches the dashboard version.
 
-The former committed dry-run record was stale at v4.10.4 while production was v5.0.7. The former committed repository audit described v4.13.1 and wrote a fixed dashboard timestamp. The former validation workflow committed transient candidate output before publication. The former dashboard refresher created an additional automation commit for data already generated by release/recovery. All five removed direct-write paths are permanently forbidden by CI.
+It retains 30-day evidence and fails without attempting a repair. Recovery workflows retain their existing guarded ability to reconstruct state until the release-state branch migration is complete.
 
-## Production release write sequence
+## Greasy Fork authority boundary
 
-1. `validate-userscript.yml` validates the exact `main` commit and uploads immutable candidate evidence.
-2. `auto-release-after-validation.yml` downloads the artifact from that exact run, verifies it and rejects a stale commit.
-3. Release Readiness independently rebuilds and validates `dist/` from canonical source.
-4. `release-toolkit.yml` publishes stable `dist/` and root mirrors.
-5. `release-toolkit.yml` publishes GitHub Release, verifies Greasy Fork, backs up privately and posts Discord.
-6. `release-toolkit.yml` commits verified release dashboard JSON and Markdown together.
-7. `publish-update-manifest.yml` commits the stable update manifest.
-8. Announcement reconciliation may create further generated-state commits.
-9. Dashboard projection and Greasy Fork parity only verify; neither writes.
+The former automatic importer is retired. GitHub is canonical. The read-only parity audit accepts an expected `canonical-ahead` state and fails on live-ahead or equal-version content drift. `status/source-baseline.json` is an immutable historical v4.11.2 bootstrap record.
 
-The owner command freshly validates current `main`, verifies the requested version and hash, refuses an existing release, then starts the same readiness and production workflows.
+## Production release sequence
+
+1. Canonical validation uploads exact immutable candidate evidence.
+2. Automatic release verifies that exact run and rejects stale commits.
+3. Release Readiness independently rebuilds and validates distribution.
+4. Production publishes stable distribution and root mirrors.
+5. GitHub Release is published and Greasy Fork is verified.
+6. The release is backed up privately and announced to Discord.
+7. Dashboard JSON, rendered Markdown and announcement tracker are committed atomically.
+8. Stable update manifest and Pages are dispatched in parallel.
+9. Dashboard projection, Greasy Fork parity and announcement-state workflows verify only.
+
+The owner command freshly validates current `main` and starts the same readiness and production workflows.
 
 ## Indirect release orchestrators
 
 | Workflow | Delegated writer | Role |
 |---|---|---|
-| `auto-release-after-validation.yml` | `release-toolkit.yml` | Consumes exact immutable validation evidence and starts the guarded release. |
-| `owner-release-command.yml` | `release-toolkit.yml` | Performs owner authorization plus fresh validation, then starts the guarded release. |
+| `auto-release-after-validation.yml` | `release-toolkit.yml` | Consumes exact validation evidence and starts guarded release. |
+| `owner-release-command.yml` | `release-toolkit.yml` | Performs owner authorization and fresh validation. |
 
-Their write authority remains only because the reusable production workflow still writes distribution and release state.
+Their write authority remains only because the reusable production job still writes distribution and release state.
 
 ## Explicit non-public-main writers
 
 | Automation | Target | Credential | Protection posture |
 |---|---|---|---|
-| `apply-development-package.yml` | Existing owner-created PR branch | `DEVELOPMENT_PR_TOKEN` | Review branch only. |
-| `prepare-release-rollback.yml` | New recovery branch and PR | `DEVELOPMENT_PR_TOKEN` | Review branch only. |
-| `backup_release_to_private_repo.sh` | private recovery repository `main` | `MIGRATION_REPO_TOKEN` | Separate repository; not a public-main bypass. |
+| `apply-development-package.yml` | Existing owner PR branch | `DEVELOPMENT_PR_TOKEN` | Review branch only. |
+| `prepare-release-rollback.yml` | Recovery branch and PR | `DEVELOPMENT_PR_TOKEN` | Review branch only. |
+| `backup_release_to_private_repo.sh` | private recovery repository `main` | `MIGRATION_REPO_TOKEN` | Separate repository. |
 
 ## Target architecture
 
-- **Public `main`:** reviewed source, workflows, tests, policy, documentation and stable configuration only.
-- **Distribution branch:** stable `dist/` and root Greasy Fork mirrors, written only by the release GitHub App.
-- **Release-state branch:** dashboard, manifest, announcement and recovery state; never product source.
-- **Immutable evidence:** validation candidates, parity audits, dashboard projections, bundles, checksums, audits, dry-runs and handovers.
+- **Public `main`:** reviewed source, workflows, tests, policy and documentation.
+- **Distribution branch:** stable `dist/` and root mirrors, written by a scoped release App.
+- **Release-state branch:** dashboard, manifest, announcement and recovery state.
+- **Immutable evidence:** validation, parity, projections, bundles, audits and handovers.
 
 ## Migration order
 
-1. ✅ Inventory every public-main writer and enforce it in CI.
-2. ✅ Convert release dry runs to artifact-only evidence.
-3. ✅ Convert repository audits to artifact-only evidence.
-4. ✅ Convert canonical validation candidates to artifact-only evidence.
-5. ✅ Convert standalone dashboard refreshes to read-only projection verification.
-6. ✅ Retire automatic Greasy Fork importing and replace it with read-only parity evidence.
-7. Separate release dashboard, manifest and announcement state from canonical source.
-8. Move stable distribution output to a dedicated branch.
-9. Introduce a narrowly scoped GitHub App for distribution and release-state writes.
-10. Rehearse every release, recovery and administrator-access path.
-11. Enable strict protection only after all rehearsals pass.
+1. ✅ Inventory and enforce every public-main writer.
+2. ✅ Convert dry runs, audits and validation to immutable evidence.
+3. ✅ Convert dashboard refresh to read-only projection.
+4. ✅ Retire automatic Greasy Fork importing.
+5. ✅ Make primary announcement state atomic and reconciliation read-only.
+6. Move dashboard, manifest, fallback monitor and recovery state to a release-state branch.
+7. Move stable distribution to a dedicated branch.
+8. Introduce a scoped GitHub App.
+9. Rehearse release, recovery and administrator access.
+10. Enable strict protection only after all rehearsals pass.
 
 ## Current migration evidence
 
-- PR #498: initial inventory and fail-closed enforcement.
-- PR #499: dry-run writer removed.
-- PR #500: repository-audit writer removed.
-- PR #501: canonical validation writer removed and release authorization rewired.
-- PR #502: standalone dashboard writer removed.
-- Current change: legacy Greasy Fork importer retired.
-- Direct public-main writers reduced from **10 to 5**.
+- PRs #498–#503 completed the inventory and first five writer removals.
+- Current change removes the separate announcement reconciliation writer.
+- Direct public-main writers reduced from **10 to 4**.


### PR DESCRIPTION
## Purpose

Advance Issue #41 by removing the separate announcement reconciliation workflow as the sixth direct automation writer to public `main`, while reducing release latency and commit noise.

## Problem

After a successful production release, `release-toolkit.yml` committed the verified dashboard and a second workflow later committed `.github/greasyfork-version.txt`. That split normal release state across two bot commits and created an avoidable consistency window.

## Changes

- Update `release-toolkit.yml` to write dashboard JSON, rendered Markdown and the announcement tracker in the same guarded commit after Discord publication.
- Preserve existing release ordering: Greasy Fork verification → private backup → Discord → atomic state commit → update manifest and Pages.
- Convert `reconcile-release-announcement-state.yml` to `contents: read`.
- Verify dashboard version, Greasy Fork verification, Discord state and tracker version without attempting a repair.
- Retain JSON/Markdown verification evidence for 30 days.
- Remove the verifier from the Actions write-permission allowlist.
- Add permanent atomic-state and branch-write contracts.
- Reclassify the workflow as artifact-only and reduce direct public-main writers from 5 to 4.

## Speed impact

- Removes one follow-up bot commit from every normal release.
- Removes the reconciliation retry loop from the critical publication sequence.
- Makes primary release state immediately consistent when the release commit lands.
- Leaves recovery operations available until the release-state branch migration is complete.

## Safety

- No userscript, distribution or production version change.
- No release is published by this PR.
- Recovery workflows retain their guarded state-reconstruction logic.
- The documentation-only hero refresh that landed during review is preserved; the PR remains mergeable against the current `main` view.
- No branch-protection setting is enabled.

## Validation

All six checks pass on exact head `c64bbc0363d8e94526cfb6d7a0e4f98c52eae0aa`:

- Verify Release Announcement State
- Verify Greasy Fork Canonical Parity
- Validate Canonical Userscript
- Development and Automation Workflow Policy
- Actions security
- Development status

The retained announcement evidence reports:

- state: `synchronized`
- dashboard version: `5.0.7`
- tracker version: `5.0.7`
- Greasy Fork verified: `true`
- Discord posted: `true`
- public `main` changed: `false`
- release dashboard changed: `false`
- announcement tracker changed: `false`

Retained evidence: `missionchief-release-announcement-state-efc1a11139e80c0fe09423f2a28260febac2f7a0`, retained for 30 days.

Advances #41