### PR TITLE
Make stable update manifest publication atomic

### DIFF
--- a/.github/actions-security-policy.json
+++ b/.github/actions-security-policy.json
@@ -37,9 +37,6 @@
     ".github/workflows/pages-production-monitor.yml": [
       "issues"
     ],
-    ".github/workflows/publish-update-manifest.yml": [
-      "contents"
-    ],
     ".github/workflows/release-recovery.yml": [
       "contents"
     ],

--- a/.github/branch-write-inventory.json
+++ b/.github/branch-write-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "reviewedAt": "2026-07-24",
-  "reviewedMainCommit": "4da0da71c8579ed6efc8ac8143f5c0354f2c0f39",
+  "reviewedMainCommit": "092c20afcd05eb0f159c4e7e2da8bd2a0bb52c59",
   "strictProtectionEnabled": false,
   "directMainWriters": [
     {
@@ -13,16 +13,6 @@
         ".github/greasyfork-version.txt"
       ],
       "migrationTarget": "release-state branch"
-    },
-    {
-      "workflow": ".github/workflows/publish-update-manifest.yml",
-      "purpose": "Publish the stable update manifest after all release channels are verified.",
-      "credential": "github.token",
-      "actor": "github-actions[bot]",
-      "writes": [
-        "status/update-manifest.json"
-      ],
-      "migrationTarget": "release-state branch or immutable release asset"
     },
     {
       "workflow": ".github/workflows/release-recovery.yml",
@@ -38,7 +28,7 @@
     },
     {
       "workflow": ".github/workflows/release-toolkit.yml",
-      "purpose": "Publish stable distribution, record verified release state and update the announcement tracker atomically.",
+      "purpose": "Publish stable distribution and record verified dashboard, update-manifest and announcement state atomically.",
       "credential": "github.token",
       "actor": "github-actions[bot]",
       "writes": [
@@ -47,10 +37,12 @@
         "MissionChief_Map_Command_Toolkit.txt",
         "status/release-dashboard.json",
         "status/README.md",
+        "status/update-manifest.json",
         ".github/greasyfork-version.txt"
       ],
       "helperScripts": [
-        ".github/scripts/sync_greasyfork_root_mirror.sh"
+        ".github/scripts/sync_greasyfork_root_mirror.sh",
+        ".github/scripts/build_stable_update_manifest.py"
       ],
       "migrationTarget": "dedicated distribution branch plus release-state branch, written by a scoped GitHub App"
     }
@@ -133,11 +125,21 @@
         "release-announcement-state.json",
         "release-announcement-state.md"
       ]
+    },
+    {
+      "workflow": ".github/workflows/publish-update-manifest.yml",
+      "purpose": "Verify the committed stable update manifest against the verified release ledger without changing repository state.",
+      "permission": "contents: read",
+      "artifact": "missionchief-update-manifest-verification-<commit>",
+      "evidence": [
+        "update-manifest-verification.json",
+        "update-manifest-verification.md",
+        "update-manifest-verification.log"
+      ]
     }
   ],
   "directMainPushSources": [
     ".github/workflows/greasyfork-release-monitor.yml",
-    ".github/workflows/publish-update-manifest.yml",
     ".github/workflows/release-recovery.yml",
     ".github/workflows/release-toolkit.yml",
     ".github/scripts/sync_greasyfork_root_mirror.sh"
@@ -182,7 +184,6 @@
     ".github/workflows/auto-release-after-validation.yml",
     ".github/workflows/greasyfork-release-monitor.yml",
     ".github/workflows/owner-release-command.yml",
-    ".github/workflows/publish-update-manifest.yml",
     ".github/workflows/release-recovery.yml",
     ".github/workflows/release-toolkit.yml"
   ]

--- a/.github/scripts/build_stable_update_manifest.py
+++ b/.github/scripts/build_stable_update_manifest.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Build or verify the stable Toolkit update manifest.
+
+The stable manifest is derived only from the verified release dashboard and
+reviewed release settings. The same implementation is used by production and
+read-only verification so the public compatibility URL cannot drift.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlparse
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_DASHBOARD = ROOT / "status" / "release-dashboard.json"
+DEFAULT_SETTINGS = ROOT / ".github" / "release-settings.json"
+DEFAULT_OUTPUT = ROOT / "status" / "update-manifest.json"
+SEMVER = re.compile(r"^\d+\.\d+\.\d+$")
+SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+
+class ManifestError(RuntimeError):
+    """Fail-closed manifest validation error."""
+
+
+@dataclass(frozen=True)
+class BuildResult:
+    manifest: dict[str, object]
+    rendered: str
+    changed: bool
+
+
+def load_object(path: Path, label: str) -> dict:
+    if not path.is_file() or path.is_symlink():
+        raise ManifestError(f"{label} is missing or unsafe: {path}")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ManifestError(f"{label} is not valid JSON: {path}") from error
+    if not isinstance(value, dict):
+        raise ManifestError(f"{label} must be a JSON object: {path}")
+    return value
+
+
+def canonical_release_url(version: str, value: object) -> str:
+    url = str(value or "").strip()
+    parts = urlparse(url)
+    expected_path = f"/Conroy1988/missionchief-toolkit-assets/releases/tag/v{version}"
+    if parts.scheme != "https" or parts.netloc != "github.com" or parts.path != expected_path:
+        raise ManifestError("GitHub release URL is not canonical")
+    if parts.params or parts.query or parts.fragment:
+        raise ManifestError("GitHub release URL must not contain params, query or fragment")
+    return url
+
+
+def canonical_update_url(value: object) -> str:
+    url = str(value or "").strip()
+    parts = urlparse(url)
+    if parts.scheme != "https" or parts.netloc != "update.greasyfork.org":
+        raise ManifestError("Greasy Fork update URL is not canonical")
+    if not parts.path.startswith("/scripts/586018/"):
+        raise ManifestError("Greasy Fork update URL does not target Toolkit script 586018")
+    if parts.params or parts.query or parts.fragment:
+        raise ManifestError("Greasy Fork update URL must not contain params, query or fragment")
+    return url
+
+
+def build_manifest(dashboard: dict, settings: dict) -> dict[str, object]:
+    status = dashboard.get("status")
+    latest = dashboard.get("latestRelease")
+    if not isinstance(status, dict) or not isinstance(latest, dict):
+        raise ManifestError("Release dashboard is missing status or latestRelease objects")
+
+    required_status = {
+        "validation": "passed",
+        "githubRelease": "published",
+        "greasyForkSync": "verified",
+        "backup": "private-repository-verified",
+        "discordRelease": "posted",
+        "assetAudit": "passed",
+        "releaseReadiness": "passed",
+    }
+    for key, expected in required_status.items():
+        actual = status.get(key)
+        if actual != expected:
+            raise ManifestError(f"Refusing stable manifest: {key}={actual!r}, expected {expected!r}")
+
+    version = str(latest.get("version") or "").strip()
+    if not SEMVER.fullmatch(version):
+        raise ManifestError(f"Stable semantic version required, found {version!r}")
+    if str(dashboard.get("currentVersion") or "").strip() != version:
+        raise ManifestError("Dashboard currentVersion is not the verified latest release")
+    if latest.get("greasyForkVerified") is not True:
+        raise ManifestError("Greasy Fork is not verified")
+    if latest.get("discordPosted") is not True:
+        raise ManifestError("Discord release is not recorded")
+    if not str(latest.get("privateBackupCommit") or "").strip():
+        raise ManifestError("Private backup commit is absent")
+
+    sha256 = str(latest.get("sha256") or "").strip()
+    if not SHA256.fullmatch(sha256):
+        raise ManifestError("Verified release SHA-256 is invalid")
+
+    published_at = str(latest.get("completedAt") or "").strip()
+    if not published_at:
+        raise ManifestError("Verified release completion time is absent")
+
+    greasy_fork = settings.get("greasyFork")
+    if not isinstance(greasy_fork, dict):
+        raise ManifestError("Release settings are missing greasyFork configuration")
+
+    return {
+        "schemaVersion": 1,
+        "channel": "stable",
+        "version": version,
+        "releaseNotesUrl": canonical_release_url(version, latest.get("githubRelease")),
+        "updateUrl": canonical_update_url(greasy_fork.get("installUrl")),
+        "publishedAt": published_at,
+        "sha256": sha256,
+    }
+
+
+def render_manifest(manifest: dict[str, object]) -> str:
+    return json.dumps(manifest, indent=2, ensure_ascii=False) + "\n"
+
+
+def sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def build(dashboard_path: Path, settings_path: Path, output_path: Path, check: bool) -> BuildResult:
+    manifest = build_manifest(
+        load_object(dashboard_path, "Release dashboard"),
+        load_object(settings_path, "Release settings"),
+    )
+    rendered = render_manifest(manifest)
+    existing = output_path.read_text(encoding="utf-8") if output_path.is_file() else None
+    changed = existing != rendered
+
+    if check:
+        if existing is None:
+            raise ManifestError(f"Committed stable manifest is missing: {output_path}")
+        if changed:
+            raise ManifestError("Committed stable update manifest differs from the verified release projection")
+    else:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(rendered, encoding="utf-8")
+
+    return BuildResult(manifest=manifest, rendered=rendered, changed=changed)
+
+
+def evidence(result: BuildResult, *, check: bool, dashboard_path: Path, output_path: Path) -> dict[str, object]:
+    return {
+        "schemaVersion": 1,
+        "state": "synchronized" if check else "prepared",
+        "mode": "check" if check else "write",
+        "version": result.manifest["version"],
+        "sha256": result.manifest["sha256"],
+        "manifestSha256": sha256_text(result.rendered),
+        "dashboardPath": dashboard_path.relative_to(ROOT).as_posix() if dashboard_path.is_relative_to(ROOT) else str(dashboard_path),
+        "outputPath": output_path.relative_to(ROOT).as_posix() if output_path.is_relative_to(ROOT) else str(output_path),
+        "manifestChanged": result.changed,
+        "publicMainChanged": False,
+        "releaseDashboardChanged": False,
+        "liveConsumersChanged": False,
+    }
+
+
+def render_evidence_markdown(report: dict[str, object]) -> str:
+    return "\n".join(
+        [
+            "# Toolkit stable update-manifest verification",
+            "",
+            f"- State: **{report['state']}**",
+            f"- Mode: `{report['mode']}`",
+            f"- Version: `v{report['version']}`",
+            f"- Release SHA-256: `{report['sha256']}`",
+            f"- Manifest SHA-256: `{report['manifestSha256']}`",
+            f"- Manifest changed: **{'yes' if report['manifestChanged'] else 'no'}**",
+            "- Public `main` changed by verification: **no**",
+            "- Release dashboard changed: **no**",
+            "- Live consumers changed: **no**",
+            "",
+        ]
+    )
+
+
+def self_test() -> None:
+    dashboard = {
+        "currentVersion": "1.2.3",
+        "status": {
+            "validation": "passed",
+            "githubRelease": "published",
+            "greasyForkSync": "verified",
+            "backup": "private-repository-verified",
+            "discordRelease": "posted",
+            "assetAudit": "passed",
+            "releaseReadiness": "passed",
+        },
+        "latestRelease": {
+            "version": "1.2.3",
+            "sha256": "a" * 64,
+            "githubRelease": "https://github.com/Conroy1988/missionchief-toolkit-assets/releases/tag/v1.2.3",
+            "greasyForkVerified": True,
+            "privateBackupCommit": "b" * 40,
+            "discordPosted": True,
+            "completedAt": "2026-07-24T12:00:00Z",
+        },
+    }
+    settings = {
+        "greasyFork": {
+            "installUrl": "https://update.greasyfork.org/scripts/586018/MissionChief%20Map%20Command%20Toolkit.user.js"
+        }
+    }
+    expected = build_manifest(dashboard, settings)
+    assert expected["version"] == "1.2.3"
+    assert expected["sha256"] == "a" * 64
+
+    broken = json.loads(json.dumps(dashboard))
+    broken["status"]["discordRelease"] = "pending"
+    try:
+        build_manifest(broken, settings)
+    except ManifestError:
+        pass
+    else:
+        raise AssertionError("Incomplete release status was accepted")
+
+    with tempfile.TemporaryDirectory(prefix="manifest-self-test-") as directory:
+        root = Path(directory)
+        dashboard_path = root / "dashboard.json"
+        settings_path = root / "settings.json"
+        output_path = root / "manifest.json"
+        dashboard_path.write_text(json.dumps(dashboard), encoding="utf-8")
+        settings_path.write_text(json.dumps(settings), encoding="utf-8")
+        first = build(dashboard_path, settings_path, output_path, check=False)
+        assert first.changed is True
+        second = build(dashboard_path, settings_path, output_path, check=True)
+        assert second.changed is False
+        output_path.write_text("{}\n", encoding="utf-8")
+        try:
+            build(dashboard_path, settings_path, output_path, check=True)
+        except ManifestError:
+            pass
+        else:
+            raise AssertionError("Manifest drift was not rejected")
+
+    print("Stable update manifest self-tests passed.")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dashboard", type=Path, default=DEFAULT_DASHBOARD)
+    parser.add_argument("--settings", type=Path, default=DEFAULT_SETTINGS)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--check", action="store_true")
+    parser.add_argument("--evidence-json", type=Path)
+    parser.add_argument("--evidence-markdown", type=Path)
+    parser.add_argument("--self-test", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.self_test:
+        self_test()
+        return 0
+
+    result = build(args.dashboard, args.settings, args.output, args.check)
+    report = evidence(result, check=args.check, dashboard_path=args.dashboard, output_path=args.output)
+    if args.evidence_json:
+        args.evidence_json.parent.mkdir(parents=True, exist_ok=True)
+        args.evidence_json.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    if args.evidence_markdown:
+        args.evidence_markdown.parent.mkdir(parents=True, exist_ok=True)
+        args.evidence_markdown.write_text(render_evidence_markdown(report), encoding="utf-8")
+    print(f"Stable update manifest {report['state']} for Toolkit v{report['version']}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ManifestError as error:
+        print(f"stable update manifest refused: {error}", file=__import__("sys").stderr)
+        raise SystemExit(1)

--- a/.github/scripts/test_branch_write_inventory.py
+++ b/.github/scripts/test_branch_write_inventory.py
@@ -92,8 +92,8 @@ def main() -> int:
         fail("A workflow cannot be both a direct main writer and an orchestrator")
     if artifact_workflows & classified_contents:
         fail("Artifact-only workflows cannot retain contents-write classification")
-    if len(direct_workflows) != 4:
-        fail(f"Expected four reviewed direct public-main writers, found {len(direct_workflows)}")
+    if len(direct_workflows) != 3:
+        fail(f"Expected three reviewed direct public-main writers, found {len(direct_workflows)}")
     if len(orchestrator_workflows) != 2:
         fail(f"Expected two reviewed release orchestrators, found {len(orchestrator_workflows)}")
     expected_artifacts = {
@@ -103,6 +103,7 @@ def main() -> int:
         ".github/workflows/update-release-dashboard.yml",
         ".github/workflows/import-canonical-userscript.yml",
         ".github/workflows/reconcile-release-announcement-state.yml",
+        ".github/workflows/publish-update-manifest.yml",
     }
     if artifact_workflows != expected_artifacts:
         fail(f"Unexpected artifact-only workflow inventory: {sorted(artifact_workflows)}")
@@ -275,6 +276,28 @@ def main() -> int:
         "github-actions[bot]", "git reset --hard",
     ], "Artifact-only announcement-state workflow")
 
+    manifest_workflow = (ROOT / ".github/workflows/publish-update-manifest.yml").read_text(encoding="utf-8")
+    manifest_builder = (ROOT / ".github/scripts/build_stable_update_manifest.py").read_text(encoding="utf-8")
+    require_markers(manifest_workflow, [
+        "name: Verify Toolkit Update Manifest",
+        "permissions:\n  contents: read",
+        "persist-credentials: false",
+        "Verify committed manifest against release ledger",
+        "--check",
+        "Upload immutable update-manifest evidence",
+        "missionchief-update-manifest-verification-${{ github.sha }}",
+        "No repository mutation was attempted.",
+    ], "Artifact-only update-manifest workflow")
+    forbid_markers(manifest_workflow, [
+        "contents: write", "git commit", "git push", "git pull --rebase", "github-actions[bot]",
+    ], "Artifact-only update-manifest workflow")
+    require_markers(manifest_builder, [
+        "def build_manifest(dashboard: dict, settings: dict)",
+        '"publicMainChanged": False',
+        '"releaseDashboardChanged": False',
+        "Stable update manifest self-tests passed.",
+    ], "Stable update-manifest builder")
+
     for entry in external_entries:
         path = ROOT / str(entry["path"])
         repository = str(entry["repository"])
@@ -299,8 +322,8 @@ def main() -> int:
 
     for claim in [
         "Strict pull-request-only protection is **not yet safe to enable**",
-        "four workflows that can commit directly to public `main`",
-        "Canonical validation, release dry runs, repository audits, dashboard projection, Greasy Fork parity and announcement-state verification are now artifact-only",
+        "three workflows that can commit directly to public `main`",
+        "Canonical validation, release dry runs, repository audits, dashboard projection, Greasy Fork parity, announcement-state verification and stable update-manifest verification are now artifact-only",
     ]:
         if claim not in document:
             fail(f"Human inventory is missing migration claim: {claim}")

--- a/.github/scripts/test_pages_release_deploy_contract.py
+++ b/.github/scripts/test_pages_release_deploy_contract.py
@@ -44,25 +44,31 @@ def main() -> int:
     release = RELEASE_WORKFLOW.read_text(encoding="utf-8")
     release_required = [
         "permissions:\n  contents: write\n  actions: write",
-        "Record successful release in dashboard",
-        "Publish update channels in parallel",
+        "Record successful release, manifest and announcement state",
+        "Publish GitHub Pages",
         "gh workflow run github-pages.yml --ref main",
-        "gh run list --workflow \"$workflow\" --event workflow_dispatch --branch main",
+        "gh run list --workflow github-pages.yml --event workflow_dispatch --branch main",
         "The dispatched GitHub Pages run was not found",
         'gh run watch "$PAGES_RUN_ID" --exit-status',
-        "steps.channels.outputs.pages_run_id",
+        "steps.pages.outputs.pages_run_id",
     ]
     release_missing = [fragment for fragment in release_required if fragment not in release]
     assert not release_missing, (
         "Production release-to-Pages dispatch contract fragments missing: "
         f"{release_missing}"
     )
+    for retired in [
+        "Publish update channels in parallel",
+        "gh workflow run publish-update-manifest.yml",
+        "steps.channels.outputs.pages_run_id",
+    ]:
+        assert retired not in release, f"Retired parallel-channel marker returned: {retired}"
 
-    dashboard_index = release.index("Record successful release in dashboard")
-    pages_dispatch_index = release.index("Publish update channels in parallel")
+    state_index = release.index("Record successful release, manifest and announcement state")
+    pages_dispatch_index = release.index("Publish GitHub Pages")
     summary_index = release.index("Write release summary")
-    assert dashboard_index < pages_dispatch_index < summary_index, (
-        "The release must record verified state, await the Pages deployment, then write its final summary"
+    assert state_index < pages_dispatch_index < summary_index, (
+        "The release must record verified atomic state, await Pages, then write its final summary"
     )
 
     print(

--- a/.github/scripts/test_release_announcement_state_pipeline.py
+++ b/.github/scripts/test_release_announcement_state_pipeline.py
@@ -33,16 +33,17 @@ def main() -> int:
 
     require(release, [
         "Post verified release to Discord",
-        "Record successful release and announcement state",
+        "Record successful release, manifest and announcement state",
         "printf '%s\\n' \"$RELEASE_VERSION\" > .github/greasyfork-version.txt",
-        "git add status/release-dashboard.json status/README.md .github/greasyfork-version.txt",
-        "Release dashboard and announcement tracker updated atomically",
+        "python3 .github/scripts/build_stable_update_manifest.py",
+        "status/update-manifest.json",
+        "Dashboard, stable update manifest and announcement tracker updated atomically",
     ], "Production release workflow")
     discord_index = release.index("      - name: Post verified release to Discord")
-    state_index = release.index("      - name: Record successful release and announcement state")
-    publish_index = release.index("      - name: Publish update channels in parallel")
-    if not discord_index < state_index < publish_index:
-        raise AssertionError("Announcement state must be recorded after Discord and before update-channel publication")
+    state_index = release.index("      - name: Record successful release, manifest and announcement state")
+    pages_index = release.index("      - name: Publish GitHub Pages")
+    if not discord_index < state_index < pages_index:
+        raise AssertionError("Announcement state must be recorded after Discord and before Pages publication")
 
     require(verify, [
         "name: Verify Release Announcement State",

--- a/.github/scripts/test_update_manifest_pipeline.py
+++ b/.github/scripts/test_update_manifest_pipeline.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Contracts for Issue #41 atomic stable update-manifest publication."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+BUILDER = ROOT / ".github" / "scripts" / "build_stable_update_manifest.py"
+WORKFLOW = ROOT / ".github" / "workflows" / "publish-update-manifest.yml"
+RELEASE = ROOT / ".github" / "workflows" / "release-toolkit.yml"
+SOURCE = ROOT / "src" / "MissionChief_Map_Command_Toolkit.user.js"
+MANIFEST = ROOT / "status" / "update-manifest.json"
+DASHBOARD = ROOT / "status" / "release-dashboard.json"
+
+
+def require(text: str, markers: list[str], label: str) -> None:
+    for marker in markers:
+        if marker not in text:
+            raise AssertionError(f"{label} is missing required marker: {marker}")
+
+
+def forbid(text: str, markers: list[str], label: str) -> None:
+    for marker in markers:
+        if marker in text:
+            raise AssertionError(f"{label} contains forbidden marker: {marker}")
+
+
+def main() -> int:
+    builder = BUILDER.read_text(encoding="utf-8")
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    release = RELEASE.read_text(encoding="utf-8")
+    source = SOURCE.read_text(encoding="utf-8")
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    dashboard = json.loads(DASHBOARD.read_text(encoding="utf-8"))
+
+    require(
+        builder,
+        [
+            "def build_manifest(dashboard: dict, settings: dict)",
+            "def render_manifest(manifest: dict[str, object])",
+            '"publicMainChanged": False',
+            '"releaseDashboardChanged": False',
+            '"liveConsumersChanged": False',
+            "Committed stable update manifest differs from the verified release projection",
+            "Stable update manifest self-tests passed.",
+        ],
+        "Stable manifest builder",
+    )
+
+    require(
+        workflow,
+        [
+            "name: Verify Toolkit Update Manifest",
+            "permissions:\n  contents: read",
+            "persist-credentials: false",
+            "Validate stable manifest builder self-tests",
+            "Verify committed manifest against release ledger",
+            "--check",
+            "Upload immutable update-manifest evidence",
+            "missionchief-update-manifest-verification-${{ github.sha }}",
+            "retention-days: 30",
+            "No repository mutation was attempted.",
+        ],
+        "Read-only update-manifest workflow",
+    )
+    forbid(
+        workflow,
+        [
+            "contents: write",
+            "git commit",
+            "git push",
+            "git pull --rebase",
+            "github-actions[bot]",
+            "DEVELOPMENT_PR_TOKEN",
+        ],
+        "Read-only update-manifest workflow",
+    )
+
+    require(
+        release,
+        [
+            "Record successful release, manifest and announcement state",
+            "python3 .github/scripts/build_stable_update_manifest.py",
+            "status/update-manifest.json",
+            'git commit -m "Record Toolkit ${RELEASE_VERSION} verified release state"',
+            "- name: Publish GitHub Pages",
+            "gh workflow run github-pages.yml --ref main",
+            'gh run watch "$PAGES_RUN_ID" --exit-status',
+            "Dashboard, stable update manifest and announcement tracker updated atomically",
+        ],
+        "Production release workflow",
+    )
+    forbid(
+        release,
+        [
+            "gh workflow run publish-update-manifest.yml",
+            "MANIFEST_RUN_ID",
+            "manifest_run_id",
+            "Update-manifest publication failed",
+        ],
+        "Production release workflow",
+    )
+
+    state_index = release.index("Record successful release, manifest and announcement state")
+    builder_index = release.index("python3 .github/scripts/build_stable_update_manifest.py", state_index)
+    add_index = release.index("git add", builder_index)
+    push_index = release.index("git push origin HEAD:main", add_index)
+    pages_index = release.index("- name: Publish GitHub Pages", push_index)
+    assert state_index < builder_index < add_index < push_index < pages_index
+
+    public_url = "raw.githubusercontent.com/Conroy1988/missionchief-toolkit-assets/main/status/update-manifest.json"
+    assert public_url in source, "Existing v5.0.7 manifest consumer URL changed"
+    assert manifest["version"] == dashboard["latestRelease"]["version"]
+    assert manifest["sha256"] == dashboard["latestRelease"]["sha256"]
+
+    for command in [
+        ["python3", str(BUILDER), "--self-test"],
+        ["python3", str(BUILDER), "--check"],
+    ]:
+        result = subprocess.run(command, cwd=ROOT)
+        if result.returncode != 0:
+            raise AssertionError(f"Stable update-manifest command failed: {' '.join(command)}")
+
+    print("Atomic update-manifest pipeline passed: one release-state commit, read-only verification and unchanged public URL.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_validation_candidate_pipeline.py
+++ b/.github/scripts/test_validation_candidate_pipeline.py
@@ -96,7 +96,8 @@ def main() -> int:
     ], "Stable distribution publication helper")
     require(release, [
         "run: bash .github/scripts/sync_greasyfork_root_mirror.sh",
-        "Record successful release and announcement state",
+        "Record successful release, manifest and announcement state",
+        "python3 .github/scripts/build_stable_update_manifest.py",
     ], "Production release workflow")
 
     if "distributionCandidate" in dashboard or "releaseDryRun" in dashboard:

--- a/.github/scripts/test_version_status_contract.py
+++ b/.github/scripts/test_version_status_contract.py
@@ -11,6 +11,7 @@ SOURCE = ROOT / "src" / "MissionChief_Map_Command_Toolkit.user.js"
 RUNTIME = ROOT / ".github" / "scripts" / "test_version_status_runtime.js"
 WORKFLOW = ROOT / ".github" / "workflows" / "publish-update-manifest.yml"
 RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release-toolkit.yml"
+BUILDER = ROOT / ".github" / "scripts" / "build_stable_update_manifest.py"
 MANIFEST = ROOT / "status" / "update-manifest.json"
 DASHBOARD = ROOT / "status" / "release-dashboard.json"
 
@@ -25,6 +26,7 @@ def main() -> int:
     source = SOURCE.read_text(encoding="utf-8")
     workflow = WORKFLOW.read_text(encoding="utf-8")
     release_workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    builder = BUILDER.read_text(encoding="utf-8")
     manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
     dashboard = json.loads(DASHBOARD.read_text(encoding="utf-8"))
     start = source.index("    // Issue #153: stable live Toolkit version-status control.")
@@ -88,35 +90,48 @@ def main() -> int:
     assert manifest["updateUrl"].startswith("https://update.greasyfork.org/scripts/586018/")
 
     for marker in [
+        "name: Verify Toolkit Update Manifest",
         "workflow_dispatch:",
-        "Build manifest from verified release ledger",
-        "status/update-manifest.json",
-        "'githubRelease': 'published'",
-        "'greasyForkSync': 'verified'",
-        "'backup': 'private-repository-verified'",
-        "'discordRelease': 'posted'",
-        "git push origin HEAD:main",
+        "permissions:\n  contents: read",
+        "persist-credentials: false",
+        "Validate stable manifest builder self-tests",
+        "Verify committed manifest against release ledger",
+        "--check",
+        "missionchief-update-manifest-verification-${{ github.sha }}",
     ]:
         assert marker in workflow, f"verified manifest workflow marker missing: {marker}"
-    assert "workflow_run:" not in workflow, "manifest publication must not duplicate the explicit release dispatch"
-    dispatch_index = workflow.index("workflow_dispatch:")
-    build_index = workflow.index("Build manifest from verified release ledger")
-    push_index = workflow.index("git push origin HEAD:main")
-    assert dispatch_index < build_index < push_index, "manifest dispatch must precede verified publication"
+    for forbidden in ["contents: write", "git push", "git commit", "git pull --rebase"]:
+        assert forbidden not in workflow, f"read-only manifest verifier contains mutation marker: {forbidden}"
 
     for marker in [
-        "- name: Publish update channels in parallel",
-        "gh workflow run publish-update-manifest.yml --ref main",
-        "gh workflow run github-pages.yml --ref main",
-        'gh run list --workflow "$workflow" --event workflow_dispatch --branch main',
-        'gh run watch "$MANIFEST_RUN_ID" --exit-status',
-        'gh run watch "$PAGES_RUN_ID" --exit-status',
-        "MANIFEST_RUN_ID: ${{ steps.channels.outputs.manifest_run_id }}",
+        "def build_manifest(dashboard: dict, settings: dict)",
+        "Stable update manifest self-tests passed.",
+        '"publicMainChanged": False',
     ]:
-        assert marker in release_workflow, f"release workflow parallel publication marker missing: {marker}"
-    dashboard_index = release_workflow.index("- name: Record successful release and announcement state")
-    publish_index = release_workflow.index("- name: Publish update channels in parallel")
-    assert dashboard_index < publish_index, "parallel update channels must start after atomic release-state reconciliation"
+        assert marker in builder, f"stable manifest builder marker missing: {marker}"
+
+    for marker in [
+        "- name: Record successful release, manifest and announcement state",
+        "python3 .github/scripts/build_stable_update_manifest.py",
+        "status/update-manifest.json",
+        "- name: Publish GitHub Pages",
+        "gh workflow run github-pages.yml --ref main",
+        'gh run watch "$PAGES_RUN_ID" --exit-status',
+        "PAGES_RUN_ID: ${{ steps.pages.outputs.pages_run_id }}",
+    ]:
+        assert marker in release_workflow, f"release workflow atomic manifest marker missing: {marker}"
+    for forbidden in [
+        "gh workflow run publish-update-manifest.yml",
+        "MANIFEST_RUN_ID",
+        "manifest_run_id",
+    ]:
+        assert forbidden not in release_workflow, f"retired manifest dispatch marker returned: {forbidden}"
+
+    dashboard_index = release_workflow.index("- name: Record successful release, manifest and announcement state")
+    build_index = release_workflow.index("python3 .github/scripts/build_stable_update_manifest.py", dashboard_index)
+    push_index = release_workflow.index("git push origin HEAD:main", build_index)
+    pages_index = release_workflow.index("- name: Publish GitHub Pages", push_index)
+    assert dashboard_index < build_index < push_index < pages_index
 
     result = subprocess.run(["node", str(RUNTIME)], cwd=ROOT)
     assert result.returncode == 0, "version status runtime fixtures failed"

--- a/.github/workflows/publish-update-manifest.yml
+++ b/.github/workflows/publish-update-manifest.yml
@@ -1,115 +1,76 @@
-name: Publish Toolkit Update Manifest
+name: Verify Toolkit Update Manifest
 
 on:
+  schedule:
+    - cron: "17 6 * * *"
   workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/publish-update-manifest.yml"
+      - ".github/workflows/release-toolkit.yml"
+      - ".github/scripts/build_stable_update_manifest.py"
+      - ".github/scripts/test_update_manifest_pipeline.py"
+      - ".github/scripts/test_version_status_contract.py"
+      - ".github/release-settings.json"
+      - "status/release-dashboard.json"
+      - "status/update-manifest.json"
+      - "src/MissionChief_Map_Command_Toolkit.user.js"
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
-  group: toolkit-update-manifest
-  cancel-in-progress: false
+  group: toolkit-update-manifest-verification-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  publish:
+  verify:
+    name: Verify committed stable manifest projection
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 8
 
     steps:
-      - name: Check out reconciled main
+      - name: Check out exact repository state
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
-          ref: main
-          fetch-depth: 0
+          persist-credentials: false
+          show-progress: false
 
-      - name: Build manifest from verified release ledger
+      - name: Validate stable manifest builder self-tests
+        run: python3 .github/scripts/build_stable_update_manifest.py --self-test
+
+      - name: Verify committed manifest against release ledger
+        id: verify
+        continue-on-error: true
         shell: bash
         run: |
-          set -euo pipefail
-          python3 - <<'PY'
-          from __future__ import annotations
+          set -o pipefail
+          mkdir -p update-manifest-evidence
+          python3 .github/scripts/build_stable_update_manifest.py \
+            --check \
+            --evidence-json update-manifest-evidence/update-manifest-verification.json \
+            --evidence-markdown update-manifest-evidence/update-manifest-verification.md \
+            2>&1 | tee update-manifest-evidence/update-manifest-verification.log
 
-          import json
-          import re
-          from pathlib import Path
-          from urllib.parse import urlparse
+      - name: Upload immutable update-manifest evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: missionchief-update-manifest-verification-${{ github.sha }}
+          path: update-manifest-evidence/
+          if-no-files-found: error
+          retention-days: 30
 
-          dashboard_path = Path('status/release-dashboard.json')
-          settings_path = Path('.github/release-settings.json')
-          manifest_path = Path('status/update-manifest.json')
-
-          dashboard = json.loads(dashboard_path.read_text(encoding='utf-8'))
-          settings = json.loads(settings_path.read_text(encoding='utf-8'))
-          latest = dashboard.get('latestRelease') or {}
-          status = dashboard.get('status') or {}
-
-          required_status = {
-              'validation': 'passed',
-              'githubRelease': 'published',
-              'greasyForkSync': 'verified',
-              'backup': 'private-repository-verified',
-              'discordRelease': 'posted',
-              'assetAudit': 'passed',
-              'releaseReadiness': 'passed',
-          }
-          for key, expected in required_status.items():
-              actual = status.get(key)
-              if actual != expected:
-                  raise SystemExit(f'Refusing manifest publication: {key}={actual!r}, expected {expected!r}.')
-
-          version = str(latest.get('version') or '').strip()
-          if not re.fullmatch(r'\d+\.\d+\.\d+', version):
-              raise SystemExit(f'Refusing manifest publication: invalid stable version {version!r}.')
-          if str(dashboard.get('currentVersion') or '') != version:
-              raise SystemExit('Refusing manifest publication: dashboard currentVersion is not the verified latest release.')
-          if latest.get('greasyForkVerified') is not True:
-              raise SystemExit('Refusing manifest publication: Greasy Fork is not verified.')
-          if latest.get('discordPosted') is not True:
-              raise SystemExit('Refusing manifest publication: Discord release is not recorded.')
-          if not str(latest.get('privateBackupCommit') or '').strip():
-              raise SystemExit('Refusing manifest publication: private backup commit is absent.')
-
-          release_url = str(latest.get('githubRelease') or '').strip()
-          release_parts = urlparse(release_url)
-          expected_path = f'/Conroy1988/missionchief-toolkit-assets/releases/tag/v{version}'
-          if release_parts.scheme != 'https' or release_parts.netloc != 'github.com' or release_parts.path != expected_path:
-              raise SystemExit('Refusing manifest publication: GitHub release URL is not canonical.')
-
-          update_url = str((settings.get('greasyFork') or {}).get('installUrl') or '').strip()
-          update_parts = urlparse(update_url)
-          if update_parts.scheme != 'https' or update_parts.netloc != 'update.greasyfork.org' or not update_parts.path.startswith('/scripts/586018/'):
-              raise SystemExit('Refusing manifest publication: Greasy Fork update URL is not canonical.')
-
-          published_at = str(latest.get('completedAt') or '').strip()
-          if not published_at:
-              raise SystemExit('Refusing manifest publication: verified completion time is absent.')
-
-          manifest = {
-              'schemaVersion': 1,
-              'channel': 'stable',
-              'version': version,
-              'releaseNotesUrl': release_url,
-              'updateUrl': update_url,
-              'publishedAt': published_at,
-              'sha256': str(latest.get('sha256') or '').strip(),
-          }
-          manifest_path.write_text(json.dumps(manifest, indent=2) + '\n', encoding='utf-8')
-          print(f'Prepared stable update manifest for Toolkit v{version}')
-          PY
-
-      - name: Commit verified stable manifest
+      - name: Publish update-manifest summary
+        if: always()
         shell: bash
         run: |
-          set -euo pipefail
-          if git diff --quiet -- status/update-manifest.json; then
-            echo "Stable update manifest already matches the verified release."
-            exit 0
+          if [[ -f update-manifest-evidence/update-manifest-verification.md ]]; then
+            cat update-manifest-evidence/update-manifest-verification.md >> "$GITHUB_STEP_SUMMARY"
           fi
 
-          VERSION="$(jq -r '.version' status/update-manifest.json)"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add status/update-manifest.json
-          git commit -m "Publish Toolkit ${VERSION} update manifest"
-          git pull --rebase origin main
-          git push origin HEAD:main
+      - name: Enforce update-manifest verification
+        if: steps.verify.outcome != 'success'
+        run: |
+          echo "The committed stable update manifest differs from the verified release ledger. No repository mutation was attempted."
+          exit 1

--- a/.github/workflows/release-toolkit.yml
+++ b/.github/workflows/release-toolkit.yml
@@ -200,7 +200,7 @@ jobs:
             --request POST --header "Content-Type: application/json" \
             --data @discord-release-payload.json "${DISCORD_WEBHOOK_URL}?wait=true"
 
-      - name: Record successful release and announcement state
+      - name: Record successful release, manifest and announcement state
         env:
           RELEASE_VERSION: ${{ inputs.version }}
           BACKUP_COMMIT: ${{ steps.private_backup.outputs.backup_commit }}
@@ -226,60 +226,44 @@ jobs:
           mv status/release-dashboard.tmp status/release-dashboard.json
           printf '%s\n' "$RELEASE_VERSION" > .github/greasyfork-version.txt
           python3 .github/scripts/generate_release_dashboard.py
+          python3 .github/scripts/build_stable_update_manifest.py
+          test "$(jq -r '.version' status/update-manifest.json)" = "$RELEASE_VERSION"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add status/release-dashboard.json status/README.md .github/greasyfork-version.txt
-          git commit -m "Record Toolkit ${RELEASE_VERSION} verified release"
+          git add \
+            status/release-dashboard.json \
+            status/README.md \
+            status/update-manifest.json \
+            .github/greasyfork-version.txt
+          git commit -m "Record Toolkit ${RELEASE_VERSION} verified release state"
           git pull --rebase origin main
           git push origin HEAD:main
 
-      - name: Publish update channels in parallel
-        id: channels
+      - name: Publish GitHub Pages
+        id: pages
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_VERSION: ${{ inputs.version }}
         shell: bash
         run: |
           set -euo pipefail
           STARTED_AT="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-
-          gh workflow run publish-update-manifest.yml --ref main
           gh workflow run github-pages.yml --ref main
 
-          find_run() {
-            local workflow="$1"
-            local run_id=""
-            for attempt in $(seq 1 60); do
-              run_id="$(gh run list --workflow "$workflow" --event workflow_dispatch --branch main --limit 30 --json databaseId,createdAt -q "map(select(.createdAt >= \"${STARTED_AT}\")) | sort_by(.createdAt) | reverse | .[0].databaseId // empty")"
-              [[ -n "$run_id" ]] && { printf '%s' "$run_id"; return 0; }
-              sleep 2
-            done
-            return 1
-          }
-
-          MANIFEST_RUN_ID="$(find_run publish-update-manifest.yml)" || { echo "::error::The dispatched update-manifest run was not found."; exit 1; }
-          PAGES_RUN_ID="$(find_run github-pages.yml)" || { echo "::error::The dispatched GitHub Pages run was not found."; exit 1; }
-
-          echo "manifest_run_id=$MANIFEST_RUN_ID" >> "$GITHUB_OUTPUT"
+          PAGES_RUN_ID=""
+          for attempt in $(seq 1 60); do
+            PAGES_RUN_ID="$(gh run list --workflow github-pages.yml --event workflow_dispatch --branch main --limit 30 --json databaseId,createdAt -q "map(select(.createdAt >= \"${STARTED_AT}\")) | sort_by(.createdAt) | reverse | .[0].databaseId // empty")"
+            [[ -n "$PAGES_RUN_ID" ]] && break
+            sleep 2
+          done
+          [[ -n "$PAGES_RUN_ID" ]] || { echo "::error::The dispatched GitHub Pages run was not found."; exit 1; }
           echo "pages_run_id=$PAGES_RUN_ID" >> "$GITHUB_OUTPUT"
-          echo "Waiting in parallel for update manifest ${MANIFEST_RUN_ID} and Pages ${PAGES_RUN_ID}."
-
-          set +e
-          gh run watch "$MANIFEST_RUN_ID" --exit-status & manifest_pid=$!
-          gh run watch "$PAGES_RUN_ID" --exit-status & pages_pid=$!
-          wait "$manifest_pid"; manifest_status=$?
-          wait "$pages_pid"; pages_status=$?
-          set -e
-
-          [[ "$manifest_status" -eq 0 ]] || { echo "::error::Update-manifest publication failed."; exit 1; }
-          [[ "$pages_status" -eq 0 ]] || { echo "::error::GitHub Pages deployment failed."; exit 1; }
+          gh run watch "$PAGES_RUN_ID" --exit-status
 
       - name: Write release summary
         env:
           RELEASE_VERSION: ${{ inputs.version }}
           BACKUP_COMMIT: ${{ steps.private_backup.outputs.backup_commit }}
-          MANIFEST_RUN_ID: ${{ steps.channels.outputs.manifest_run_id }}
-          PAGES_RUN_ID: ${{ steps.channels.outputs.pages_run_id }}
+          PAGES_RUN_ID: ${{ steps.pages.outputs.pages_run_id }}
         shell: bash
         run: |
           {
@@ -294,7 +278,6 @@ jobs:
             echo "- ✅ Greasy Fork version verified"
             echo "- ✅ Private migration backup committed: ${BACKUP_COMMIT}"
             echo "- ✅ Discord release announcement posted"
-            echo "- ✅ Release dashboard and announcement tracker updated atomically"
-            echo "- ✅ Stable update manifest published: ${MANIFEST_RUN_ID}"
+            echo "- ✅ Dashboard, stable update manifest and announcement tracker updated atomically"
             echo "- ✅ GitHub Pages deployment completed: ${PAGES_RUN_ID}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/validate-development-package-workflow.yml
+++ b/.github/workflows/validate-development-package-workflow.yml
@@ -13,6 +13,7 @@ on:
       - ".github/scripts/*.sh"
       - ".github/scripts/audit_greasyfork_canonical_parity.py"
       - ".github/scripts/audit_repository.py"
+      - ".github/scripts/build_stable_update_manifest.py"
       - ".github/scripts/generate_release_dashboard.py"
       - ".github/scripts/reconcile_pages_incident.sh"
       - ".github/scripts/reconcile_validation_dashboard.py"
@@ -30,7 +31,9 @@ on:
       - ".github/scripts/test_release_announcement_state_pipeline.py"
       - ".github/scripts/test_shadow_branch_parity.py"
       - ".github/scripts/test_shadow_sync_writer.py"
+      - ".github/scripts/test_update_manifest_pipeline.py"
       - ".github/scripts/test_validation_candidate_pipeline.py"
+      - ".github/scripts/test_version_status_contract.py"
       - "docs/BRANCH_PROTECTION_MIGRATION.md"
       - "docs/BRANCH_WRITE_INVENTORY.md"
       - "docs/DEVELOPMENT_PACKAGE_WORKFLOW.md"
@@ -69,6 +72,7 @@ jobs:
             python3 .github/scripts/test_release_announcement_state_pipeline.py
             python3 .github/scripts/test_shadow_branch_parity.py
             python3 .github/scripts/test_shadow_sync_writer.py
+            python3 .github/scripts/test_update_manifest_pipeline.py
           } 2>&1 | tee "$RUNNER_TEMP/workflow-policy.log"
 
       - name: Upload policy diagnostics

--- a/docs/BRANCH_PROTECTION_MIGRATION.md
+++ b/docs/BRANCH_PROTECTION_MIGRATION.md
@@ -1,6 +1,6 @@
 # Branch Protection Migration Plan
 
-Strict pull-request-only protection is **not yet enabled**. Controlled automation commits remain because stable distribution publication, the stable update manifest, consolidated release state, fallback monitoring and recovery still mutate public `main`.
+Strict pull-request-only protection is **not yet enabled**. Controlled automation commits remain because stable distribution publication, consolidated release state, fallback monitoring and recovery still mutate public `main`.
 
 The migration is tracked by Issue #41. Authority is maintained in:
 
@@ -11,6 +11,7 @@ The migration is tracked by Issue #41. Authority is maintained in:
 - `.github/scripts/test_validation_candidate_pipeline.py`;
 - `.github/scripts/test_greasyfork_parity_pipeline.py`;
 - `.github/scripts/test_release_announcement_state_pipeline.py`;
+- `.github/scripts/test_update_manifest_pipeline.py`;
 - `.github/scripts/test_shadow_branch_parity.py`;
 - `.github/scripts/test_shadow_sync_writer.py`.
 
@@ -23,10 +24,11 @@ The migration is tracked by Issue #41. Authority is maintained in:
 - owner-authenticated review branches for packages and rollback preparation;
 - explicit production, recovery and shadow-synchronization confirmation phrases;
 - exact commit/ref/hash validation evidence;
-- deterministic dashboard, Greasy Fork and announcement-state verification;
-- atomic primary release dashboard and announcement state;
+- deterministic dashboard, Greasy Fork, announcement-state and update-manifest verification;
+- atomic primary release dashboard, stable manifest and announcement state;
 - isolated non-live `release-state` and `distribution` branches;
-- a manual-only, fixed-target shadow writer with read-only workflow permission.
+- a manual-only, fixed-target shadow writer with read-only workflow permission;
+- verified administrator repair access to both operational branches.
 
 ## Completed migration stages
 
@@ -36,93 +38,72 @@ The 24 July 2026 baseline identified 10 direct public-main writers. Every `conte
 
 ### Artifact-only validation and evidence ✅
 
-Six workflows verify with read-only repository access and retained immutable evidence instead of committing generated state:
+Seven workflows verify with read-only repository access and retained immutable evidence instead of committing generated state:
 
 - canonical userscript validation;
 - release dry runs;
 - repository/dependency audits;
 - release dashboard projection;
 - Greasy Fork canonical parity;
-- release announcement-state verification.
+- release announcement-state verification;
+- stable update-manifest verification.
 
 ### GitHub source authority ✅
 
 Automatic source importing is retired. GitHub is authoritative. Live Greasy Fork parity accepts canonical-ahead during publication and fails on live-ahead or equal-version content drift.
 
-### Atomic primary announcement state ✅
+### Atomic release dashboard, manifest and announcement state ✅
 
-Normal production releases no longer require a follow-up announcement reconciliation commit.
+Normal production releases no longer require follow-up announcement or manifest commits.
 
 After Greasy Fork verification, private backup and Discord publication, `release-toolkit.yml` commits these together:
 
 - `status/release-dashboard.json`;
 - `status/README.md`;
+- `status/update-manifest.json`;
 - `.github/greasyfork-version.txt`.
 
-The stable update manifest remains a separate guarded writer. It is dispatched and awaited in parallel with GitHub Pages.
+The manifest is built by `.github/scripts/build_stable_update_manifest.py` from the verified dashboard and reviewed release settings. The former publisher is now a read-only projection verifier with 30-day retained evidence.
 
-Direct public-main writers remain reduced from **10 to 4**.
+The existing v5.0.7 runtime URL remains unchanged:
 
-### Shadow branch topology and read-only parity ✅
+`raw.githubusercontent.com/Conroy1988/missionchief-toolkit-assets/main/status/update-manifest.json`
 
-PR #506 established:
+This is a compatibility stage. A later versioned Toolkit release will move the runtime consumer to the final `release-state` endpoint, after which the `main` compatibility manifest can be frozen and removed from future mutable state.
+
+Direct public-main writers are reduced from **10 to 3**.
+
+### Shadow branch topology and access rehearsal ✅
+
+PRs #506–#507 established:
 
 - `release-state` for verified dashboard, manifest and announcement state;
-- `distribution` for stable `dist/` and root userscript paths.
+- `distribution` for stable `dist/` and root userscript paths;
+- read-only branch-role and governed-file parity verification;
+- a manual exact-SHA-bound synchronizer restricted to the two shadow refs.
 
 Both branches remain in `shadow-rehearsal` mode. `main` remains authoritative, live consumers are disabled, strict protection is disabled and administrator recovery remains mandatory.
 
-`Verify Shadow Branch Parity` has read-only contents permission. It validates role declarations and governed-file parity, retains evidence for 30 days and performs no branch mutation.
+The connected administrator identity completed:
 
-## Constrained shadow writer rehearsal 🟡
+- an exact-current-`main` read-only plan;
+- 10/10 governed-file parity;
+- same-tree fast-forward write probes on both branches;
+- post-write role and content verification;
+- no force push, history rewrite, public-main mutation or live-consumer change.
 
-The next stage introduces `.github/workflows/sync-shadow-branches.yml` and `.github/scripts/sync_shadow_branches.py` without changing live authority.
-
-### Dispatch and authorization
-
-- manual `workflow_dispatch` only;
-- repository fixed to `Conroy1988/missionchief-toolkit-assets`;
-- actor fixed to `Conroy1988`;
-- dispatch ref must be `main`;
-- checkout and `origin/main` must both equal an explicitly supplied 40-character source SHA;
-- plan mode requires `PLAN SHADOW SYNC`;
-- apply mode requires `SYNC SHADOWS`.
-
-### Target and file boundaries
-
-- allowed targets are exactly `release-state` and `distribution`;
-- `main` is rejected as a target in both workflow and script;
-- target branch roles must remain `shadow-rehearsal` and preserve main authority;
-- only branch-specific governed paths may change;
-- `.github/branch-role.json` cannot be copied or modified;
-- pushes are fast-forward commits to the two reviewed shadow refs only;
-- public `main` and live consumers remain unchanged.
-
-### Credential boundary
-
-The workflow itself retains `contents: read`. Plan mode uses no write credential. Apply mode temporarily receives the existing owner-authenticated `DEVELOPMENT_PR_TOKEN` solely for the reviewed shadow push.
-
-This is a rehearsal identity, not the final architecture. It must be replaced by a narrowly scoped GitHub App restricted to the two operational branches before consumer cutover or strict protection.
-
-### Rehearsal evidence
-
-- plan/apply JSON, Markdown and logs retained for 30 days;
-- post-operation read-only parity verification;
-- optional idempotent empty probe commits to prove branch access when governed content already matches;
-- no duplicate probe commit for the same source/target fingerprint;
-- permanent static and executable contracts reject target expansion, workflow write permission, live cutover and `main` mutation.
+The workflow-dispatch token path remains temporary and must be replaced by a narrowly scoped GitHub App before live cutover.
 
 ## Remaining generated state
 
 Public `main` still contains:
 
 1. stable `dist/` and root Greasy Fork mirrors;
-2. verified dashboard and announcement state;
-3. stable update-manifest state;
-4. fallback monitor state;
-5. guarded recovery state.
+2. verified dashboard, stable manifest and announcement state;
+3. fallback monitor state;
+4. guarded recovery state.
 
-These responsibilities must move before strict protection is safe.
+The update manifest no longer has a standalone writer, but the compatibility file remains part of the atomic production commit until the versioned consumer migration.
 
 ## Target architecture
 
@@ -136,11 +117,11 @@ Stable `dist/` and root userscript mirrors required by Greasy Fork, written by a
 
 ### Release-state branch
 
-Mutable dashboard, manifest, announcement, fallback-monitor and recovery state. It is operational evidence, never product source.
+Mutable dashboard, manifest, announcement, fallback-monitor and recovery state. It is operational state, never product source.
 
 ### Immutable evidence
 
-Validation candidates, parity audits, synchronization plans, announcement checks, dashboard projections, release bundles, checksums, audits, dry runs and handovers remain GitHub Release assets or Actions artifacts.
+Validation candidates, parity audits, synchronization plans, announcement checks, dashboard and manifest projections, release bundles, checksums, audits, dry runs and handovers remain GitHub Release assets or Actions artifacts.
 
 ## Access and speed requirements
 
@@ -159,32 +140,33 @@ The final protection design must retain fast owner operation:
 
 1. ✅ Inventory every workflow and script capable of updating public `main`.
 2. ✅ Separate validation, audit and verification evidence from public `main`.
-3. ✅ Make dashboard and announcement state atomic; retire the reconciliation writer.
-4. ⬜ Fold stable update-manifest publication into the consolidated release-state commit.
+3. ✅ Make dashboard and announcement state atomic; retire reconciliation writing.
+4. ✅ Fold stable update-manifest publication into the same atomic release-state commit.
 5. ✅ Create and verify non-live `release-state` and `distribution` branches — PR #506.
-6. 🟡 Introduce the constrained owner-token shadow writer and rehearse plan/apply synchronization.
+6. ✅ Introduce the constrained shadow writer and rehearse plan/write access — PR #507 and Issue #41 evidence.
 7. Replace the rehearsal credential with a narrowly scoped GitHub App.
-8. Move consolidated release state and recovery state to `release-state`.
-9. Move stable `dist/` and Greasy Fork mirrors to `distribution`.
-10. Remove unnecessary `contents: write` from orchestration-only workflows.
-11. Rehearse without public-main mutation:
-   - normal Release Readiness;
-   - full production publication;
-   - Greasy Fork-only retry;
-   - private-backup-only retry;
-   - Discord-only retry;
-   - dashboard reconstruction;
-   - stable release-asset repair;
-   - emergency rollback-candidate preparation.
-12. Rehearse owner/admin access:
-   - create and update an owner branch;
-   - open and update a pull request;
-   - auto-merge after green checks;
-   - use PR-only administrator bypass where required;
-   - repair distribution and release-state branches;
-   - disable or amend the ruleset.
-13. Require pull requests, approved checks, current branches and resolved conversations.
-14. Block routine direct human pushes and enable strict protection only after complete rehearsal.
+8. Publish a versioned Toolkit migration that reads the manifest from `release-state` with a reviewed compatibility fallback.
+9. Move consolidated release, fallback-monitor and recovery state to `release-state`.
+10. Move stable `dist/` and Greasy Fork mirrors to `distribution`.
+11. Remove unnecessary `contents: write` from orchestration-only workflows.
+12. Rehearse without public-main mutation:
+    - normal Release Readiness;
+    - full production publication;
+    - Greasy Fork-only retry;
+    - private-backup-only retry;
+    - Discord-only retry;
+    - dashboard reconstruction;
+    - stable release-asset repair;
+    - emergency rollback-candidate preparation.
+13. Rehearse owner/admin access:
+    - create and update an owner branch;
+    - open and update a pull request;
+    - auto-merge after green checks;
+    - use PR-only administrator bypass where required;
+    - repair distribution and release-state branches;
+    - disable or amend the ruleset.
+14. Require pull requests, approved checks, current branches and resolved conversations.
+15. Block routine direct human pushes and enable strict protection only after complete rehearsal.
 
 ## Exit criteria
 

--- a/docs/BRANCH_WRITE_INVENTORY.md
+++ b/docs/BRANCH_WRITE_INVENTORY.md
@@ -7,11 +7,11 @@
 
 Strict pull-request-only protection is **not yet safe to enable**.
 
-The repository has four workflows that can commit directly to public `main`. Two release orchestrators invoke the reusable production writer but contain no direct public-main push. The remaining writes are limited to fallback monitoring, stable update-manifest publication, release recovery and guarded production publication.
+The repository has three workflows that can commit directly to public `main`. Two release orchestrators invoke the reusable production writer but contain no direct public-main push. The remaining writes are limited to fallback monitoring, release recovery and guarded production publication.
 
-Canonical validation, release dry runs, repository audits, dashboard projection, Greasy Fork parity and announcement-state verification are now artifact-only. These six workflows use read-only repository access and retain immutable evidence instead of committing generated state.
+Canonical validation, release dry runs, repository audits, dashboard projection, Greasy Fork parity, announcement-state verification and stable update-manifest verification are now artifact-only. These seven workflows use read-only repository access and retain immutable evidence instead of committing generated state.
 
-The `release-state` and `distribution` branches are non-live shadows. Read-only parity verification is complete. A separate manually dispatched rehearsal writer is now being introduced with fixed targets and an owner-authenticated credential, but it cannot update public `main` or enable live consumers.
+The `release-state` and `distribution` branches are non-live shadows. Read-only parity, an exact-SHA plan and same-tree write-access probes are complete. The constrained writer cannot update public `main` or enable live consumers.
 
 `.github/branch-write-inventory.json` is the machine-readable write authority. `.github/shadow-branch-policy.json` governs the isolated shadow rehearsal. Permanent contracts fail closed when a writer, permission, authority, branch role or release-state boundary changes.
 
@@ -20,11 +20,10 @@ The `release-state` and `distribution` branches are non-live shadows. Read-only 
 | Workflow | Current mutation | Required migration |
 |---|---|---|
 | `greasyfork-release-monitor.yml` | fallback `.github/greasyfork-version.txt` state | Move fallback monitoring to the release-state branch. |
-| `publish-update-manifest.yml` | `status/update-manifest.json` | Fold publication into consolidated release state, then move it to the release-state branch. |
 | `release-recovery.yml` | dashboard JSON/Markdown and announcement recovery state | Move mutable recovery state to the release-state branch. |
-| `release-toolkit.yml` | stable distribution plus atomic dashboard and announcement state | Move distribution and state to dedicated branches under a scoped GitHub App. |
+| `release-toolkit.yml` | stable distribution plus atomic dashboard, update-manifest and announcement state | Move distribution and state to dedicated branches under a scoped GitHub App. |
 
-The executable public-main push helper `.github/scripts/sync_greasyfork_root_mirror.sh` is owned by `release-toolkit.yml`.
+The executable public-main push helper `.github/scripts/sync_greasyfork_root_mirror.sh` is owned by `release-toolkit.yml`. The deterministic helper `.github/scripts/build_stable_update_manifest.py` writes only the manifest projection inside that existing guarded release commit.
 
 ## Artifact-only evidence workflows
 
@@ -36,6 +35,7 @@ The executable public-main push helper `.github/scripts/sync_greasyfork_root_mir
 | `update-release-dashboard.yml` | `contents: read` | rendered dashboard, diff and log | No branch change. |
 | `import-canonical-userscript.yml` | `contents: read` | live Greasy Fork parity evidence | No source, baseline, branch or PR change. |
 | `reconcile-release-announcement-state.yml` | `contents: read` | dashboard/tracker consistency evidence | No dashboard or tracker change. |
+| `publish-update-manifest.yml` | `contents: read` | manifest projection JSON/Markdown/log | No manifest, dashboard or branch change. |
 
 ## Shadow branch topology
 
@@ -57,7 +57,7 @@ Each branch contains `.github/branch-role.json` declaring:
 
 ## Constrained shadow synchronization writer
 
-`.github/workflows/sync-shadow-branches.yml` and `.github/scripts/sync_shadow_branches.py` provide the next non-live rehearsal stage.
+`.github/workflows/sync-shadow-branches.yml` and `.github/scripts/sync_shadow_branches.py` provide the non-live rehearsal writer.
 
 The writer contract is:
 
@@ -70,32 +70,33 @@ The writer contract is:
 - apply confirmation must be `SYNC SHADOWS`;
 - workflow permission remains `contents: read`;
 - apply mode temporarily uses `DEVELOPMENT_PR_TOKEN` as the existing owner-authenticated credential;
-- the credential is required only for the apply step;
 - changed files must be a subset of each branch's governed paths;
 - `.github/branch-role.json` remains immutable;
-- pushes are fast-forward commits to `HEAD:refs/heads/release-state` or `HEAD:refs/heads/distribution` only;
-- `main` is rejected as a target inside both the workflow and the script;
-- an optional idempotent empty probe commit can prove write access when governed content already matches;
-- every plan/apply operation retains JSON/Markdown/log evidence for 30 days;
-- post-operation read-only parity verification must pass;
+- pushes are fast-forward commits to the two reviewed shadow refs only;
+- `main` is rejected as a target inside both the workflow and script;
+- an idempotent empty probe can prove write access when governed content already matches;
+- every plan/apply operation retains evidence;
 - live consumer cutover remains forbidden;
 - the temporary owner credential must be replaced by a narrowly scoped GitHub App before final cutover.
 
-This workflow is recorded under `shadowBranchWriters`, not `directMainWriters`. It cannot update public `main` and receives no workflow-level write permission.
+The connected administrator identity has completed the read-only plan and same-tree branch probes. No force push, history rewrite, public-main change or live-consumer change occurred.
 
 ## Current release state
 
-After Greasy Fork verification, private backup and Discord publication, `release-toolkit.yml` writes the following together in one commit:
+After Greasy Fork verification, private backup and Discord publication, `release-toolkit.yml` now writes the following together in one commit:
 
 - `status/release-dashboard.json`;
 - `status/README.md`;
+- `status/update-manifest.json`;
 - `.github/greasyfork-version.txt`.
 
-The stable update manifest remains a separate guarded writer. `release-toolkit.yml` dispatches `publish-update-manifest.yml` and GitHub Pages in parallel, then waits for both runs to succeed.
+The stable manifest is generated by `.github/scripts/build_stable_update_manifest.py` from the verified dashboard and reviewed release settings. `publish-update-manifest.yml` independently verifies the committed projection with read-only access.
 
-The public manifest URL remains unchanged:
+The current v5.0.7 runtime consumer remains unchanged:
 
 `raw.githubusercontent.com/Conroy1988/missionchief-toolkit-assets/main/status/update-manifest.json`
+
+This compatibility URL remains on `main` until a versioned Toolkit release moves the runtime consumer to the final `release-state` endpoint. Existing installations are therefore not stranded during migration.
 
 ## Production release sequence
 
@@ -105,10 +106,10 @@ The public manifest URL remains unchanged:
 4. Production publishes stable distribution and root mirrors.
 5. GitHub Release is published and Greasy Fork is verified.
 6. The release is backed up privately and announced to Discord.
-7. Dashboard JSON, rendered Markdown and announcement tracker are committed atomically.
-8. Stable update-manifest publication and GitHub Pages are dispatched in parallel and awaited.
-9. Dashboard, Greasy Fork and announcement workflows verify only.
-10. Shadow synchronization remains a separate non-live rehearsal until cutover.
+7. Dashboard JSON, rendered Markdown, stable update manifest and announcement tracker are committed atomically.
+8. GitHub Pages is dispatched and awaited.
+9. Dashboard, Greasy Fork, announcement and update-manifest workflows verify only.
+10. Shadow parity remains independent until the versioned consumer cutover.
 
 ## Indirect release orchestrators
 
@@ -142,11 +143,11 @@ Their write authority remains only because the reusable production job still wri
 3. ✅ Convert dashboard refresh to read-only projection.
 4. ✅ Retire automatic Greasy Fork importing.
 5. ✅ Make primary announcement state atomic and reconciliation read-only.
-6. ⬜ Fold stable update-manifest publication into the consolidated release-state commit.
+6. ✅ Fold stable update-manifest publication into the consolidated release-state commit.
 7. ✅ Create shadow `release-state` and `distribution` branches and verify read-only parity — PR #506.
-8. 🟡 Add the constrained shadow writer and rehearse plan/apply synchronization.
+8. ✅ Add the constrained shadow writer and rehearse plan/apply access — PR #507 and Issue #41 evidence.
 9. Replace the rehearsal owner token with a narrowly scoped GitHub App.
-10. Cut consolidated release state over to `release-state`.
+10. Move the versioned manifest consumer and consolidated release state to `release-state`.
 11. Cut stable distribution over to `distribution`.
 12. Rehearse release, recovery and administrator access.
 13. Enable strict protection only after all rehearsals pass.
@@ -154,7 +155,7 @@ Their write authority remains only because the reusable production job still wri
 ## Current migration evidence
 
 - PRs #498–#504 reduced direct public-main writers from **10 to 4**.
-- PR #505 was closed without merging; update-manifest publication remains a direct `main` writer.
-- PR #506 established and verified non-live shadow branches.
-- Current change introduces a separately classified, owner-confirmed shadow writer without changing live authority.
-- No live URL, source authority or protection setting has changed.
+- The current atomic update-manifest change reduces direct public-main writers from **4 to 3**.
+- PRs #506–#507 established isolated operational branches, read-only parity and constrained administrator rehearsal access.
+- Existing v5.0.7 installations retain their exact manifest URL.
+- No userscript, production version, release object, live URL or protection setting is changed by this migration step.

--- a/docs/media/readme-hero.svg
+++ b/docs/media/readme-hero.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1600" height="640" viewBox="0 0 1600 640" role="img" aria-labelledby="title desc">
-  <title id="title">MissionChief Map Command Toolkit v5.0.7 Operational Window Suite</title>
+  <title id="title">MissionChief Map Command Toolkit Operational Window Suite</title>
   <desc id="desc">A governed MissionChief operations platform presenting the Operational Window Suite, mission intelligence, fleet and map command, responsive interfaces, GitHub-authoritative delivery and private recovery.</desc>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#030812"/><stop offset="0.52" stop-color="#081a2b"/><stop offset="1" stop-color="#160b17"/></linearGradient>
@@ -16,7 +16,7 @@
     <g transform="translate(70 50)">
       <rect width="248" height="38" rx="19" fill="#0c273d" stroke="#43caff" stroke-opacity="0.55"/>
       <circle cx="20" cy="19" r="6" fill="#52d5ff"/>
-      <text x="42" y="25" fill="#c4edff" font-size="14" font-weight="800" letter-spacing="1.8">VERIFIED v5.0.7</text>
+      <text x="42" y="25" fill="#c4edff" font-size="14" font-weight="800" letter-spacing="1.8">VERIFIED DELIVERY</text>
     </g>
     <g transform="translate(334 50)">
       <rect width="326" height="38" rx="19" fill="#28151d" stroke="#ef5d69" stroke-opacity="0.52"/>


### PR DESCRIPTION
## Purpose

Advance Issue #41 by removing the standalone stable update-manifest writer while preserving the exact public URL used by existing Toolkit installations.

## Changes

- Extract deterministic manifest generation into `.github/scripts/build_stable_update_manifest.py`.
- Generate `status/update-manifest.json` from the verified release dashboard and reviewed release settings.
- Include dashboard JSON, rendered dashboard Markdown, stable update manifest and announcement tracker in one guarded production commit.
- Convert `publish-update-manifest.yml` to read-only projection verification with 30-day JSON/Markdown/log evidence.
- Remove manifest workflow dispatch, wait and follow-up bot commit from the production release path.
- Dispatch and await GitHub Pages only after the atomic state commit.
- Remove update-manifest verification from the contents-write permission allowlist.
- Reduce direct public-main writers from four to three and increase artifact-only evidence workflows from six to seven.
- Add permanent builder, version-status, release-order, Pages, announcement-state and branch-write contracts.
- Restore the required version-neutral README hero wording; layout and the unrelated README view counter remain unchanged.

## Compatibility

The v5.0.7 runtime continues to read:

`raw.githubusercontent.com/Conroy1988/missionchief-toolkit-assets/main/status/update-manifest.json`

That exact URL is preserved. A later versioned Toolkit release will migrate the runtime consumer to `release-state`; this PR does not strand existing installations.

## Speed impact

- One fewer workflow dispatch per release.
- One fewer waited Actions run.
- One fewer follow-up bot commit.
- Dashboard, manifest and announcement state become immediately consistent.

## Safety

- No userscript or production version change.
- No manifest content or release dashboard content change.
- No release is published.
- No live URL or consumer changes.
- No branch protection setting is enabled.
- Shadow branches and their roles remain unchanged.

## Validation

All ten checks pass on exact head `05aa2ca70e037f77a27c82e0de123370a1effdbc`:

- Validate Canonical Userscript
- Verify Toolkit Update Manifest
- Development and Automation Workflow Policy
- Actions security
- Verify Release Announcement State
- Verify Greasy Fork Canonical Parity
- Verify Shadow Branch Parity
- Documentation site
- Asset health
- Development status

Retained manifest evidence reports:

- state: `synchronized`;
- version: `v5.0.7`;
- release SHA-256: `97a71c7df20a9d896872e554b671f789c74069f2ec8a1dbb8f4afd7135c303da`;
- manifest SHA-256: `08b281f3a2a12f5a6ee42fe979b3a99247c340527daea2bf705fcf64982dddd9`;
- manifest changed: no;
- public `main` changed by verification: no;
- dashboard changed: no;
- live consumers changed: no.

Evidence artifact: `missionchief-update-manifest-verification-45e351353c60a2b325841d40058c465fad39f586`, retained for 30 days.

The branch is one unrelated README-only commit behind `main`, but GitHub reports it mergeable and the complete suite passed against the current synthetic merge. There are no review comments or unresolved threads.

Advances #41