### PR TITLE
Add constrained shadow synchronization rehearsal

### DIFF
--- a/.github/branch-write-inventory.json
+++ b/.github/branch-write-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "reviewedAt": "2026-07-24",
-  "reviewedMainCommit": "0b43be27b5857206adb55de85777425be9160816",
+  "reviewedMainCommit": "4da0da71c8579ed6efc8ac8143f5c0354f2c0f39",
   "strictProtectionEnabled": false,
   "directMainWriters": [
     {
@@ -159,6 +159,23 @@
       "workflow": ".github/workflows/prepare-release-rollback.yml",
       "target": "new recovery branch and owner-created pull request",
       "credential": "DEVELOPMENT_PR_TOKEN"
+    }
+  ],
+  "shadowBranchWriters": [
+    {
+      "workflow": ".github/workflows/sync-shadow-branches.yml",
+      "script": ".github/scripts/sync_shadow_branches.py",
+      "source": "main",
+      "targets": [
+        "release-state",
+        "distribution"
+      ],
+      "credential": "DEVELOPMENT_PR_TOKEN",
+      "workflowPermission": "contents: read",
+      "dispatch": "manual owner-confirmed rehearsal",
+      "mainMutationAllowed": false,
+      "liveConsumerCutoverAllowed": false,
+      "replacementIdentity": "narrowly scoped GitHub App"
     }
   ],
   "contentsWriteAuthority": [

--- a/.github/scripts/sync_shadow_branches.py
+++ b/.github/scripts/sync_shadow_branches.py
@@ -1,0 +1,512 @@
+#!/usr/bin/env python3
+"""Synchronize governed files to Issue #41 shadow branches.
+
+The synchronizer is deliberately non-live. It accepts only the reviewed
+`release-state` and `distribution` branches, preserves `main` as authority,
+requires an exact source SHA and confirmation phrase, and never updates `main`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import quote
+
+ROOT = Path(__file__).resolve().parents[2]
+POLICY_PATH = ROOT / ".github" / "shadow-branch-policy.json"
+ROLE_PATH = ".github/branch-role.json"
+FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
+
+
+class SyncError(RuntimeError):
+    """A fail-closed synchronization error."""
+
+
+def git(*args: str, cwd: Path = ROOT, check: bool = True) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+    )
+    if check and result.returncode != 0:
+        raise SyncError(result.stderr.strip() or f"git {' '.join(args)} failed")
+    return result.stdout
+
+
+def load_policy(path: Path = POLICY_PATH) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise SyncError("Shadow branch policy must be a JSON object")
+    return value
+
+
+def validate_policy(policy: dict) -> dict:
+    expected = {
+        "schemaVersion": 1,
+        "mode": "shadow-rehearsal",
+        "mainAuthorityPreserved": True,
+        "liveConsumersEnabled": False,
+        "strictProtectionEnabled": False,
+        "administratorRecoveryRequired": True,
+        "cutoverIssue": 41,
+    }
+    for key, expected_value in expected.items():
+        if policy.get(key) != expected_value:
+            raise SyncError(f"Shadow policy {key}={policy.get(key)!r}, expected {expected_value!r}")
+
+    writer = policy.get("writerRehearsal")
+    if not isinstance(writer, dict):
+        raise SyncError("writerRehearsal policy is missing")
+    writer_expected = {
+        "enabled": True,
+        "manualDispatchOnly": True,
+        "authorizedActor": "Conroy1988",
+        "sourceBranch": "main",
+        "planConfirmation": "PLAN SHADOW SYNC",
+        "applyConfirmation": "SYNC SHADOWS",
+        "credentialSecret": "DEVELOPMENT_PR_TOKEN",
+        "workflowPermission": "contents: read",
+        "allowIdempotentEmptyProbeCommit": True,
+        "liveConsumerCutoverAllowed": False,
+        "replacementIdentity": "narrowly scoped GitHub App",
+    }
+    for key, expected_value in writer_expected.items():
+        if writer.get(key) != expected_value:
+            raise SyncError(f"writerRehearsal {key}={writer.get(key)!r}, expected {expected_value!r}")
+
+    allowed_targets = writer.get("allowedTargets")
+    if allowed_targets != ["release-state", "distribution"]:
+        raise SyncError("Shadow writer target allowlist changed")
+
+    branches = policy.get("branches")
+    if not isinstance(branches, dict) or set(branches) != set(allowed_targets):
+        raise SyncError("Shadow branch definitions differ from the writer allowlist")
+    for branch, branch_policy in branches.items():
+        if branch == "main" or not isinstance(branch_policy, dict):
+            raise SyncError("Invalid shadow branch policy")
+        paths = branch_policy.get("governedPaths")
+        if not isinstance(paths, list) or not paths or any(not isinstance(path, str) for path in paths):
+            raise SyncError(f"{branch} governedPaths is invalid")
+        if ROLE_PATH in paths:
+            raise SyncError(f"{branch} role file must not be synchronized from main")
+    return writer
+
+
+def selected_targets(value: str, writer: dict) -> list[str]:
+    allowed = list(writer["allowedTargets"])
+    if value == "both":
+        return allowed
+    if value not in allowed or value == "main":
+        raise SyncError(f"Target {value!r} is not an approved shadow branch")
+    return [value]
+
+
+def validate_request(
+    *,
+    policy: dict,
+    mode: str,
+    target: str,
+    source_sha: str,
+    confirmation: str,
+    actor: str,
+    write_probe: bool,
+) -> tuple[dict, list[str]]:
+    writer = validate_policy(policy)
+    if mode not in {"plan", "apply"}:
+        raise SyncError("Mode must be plan or apply")
+    if not FULL_SHA.fullmatch(source_sha):
+        raise SyncError("source_sha must be a full lowercase 40-character SHA")
+    if actor != writer["authorizedActor"]:
+        raise SyncError("Only the reviewed repository owner may run shadow synchronization")
+    required_confirmation = writer[f"{mode}Confirmation"]
+    if confirmation != required_confirmation:
+        raise SyncError(f"Confirmation must be exactly {required_confirmation!r}")
+    if mode != "apply" and write_probe:
+        raise SyncError("A write probe is valid only in apply mode")
+    targets = selected_targets(target, writer)
+    return writer, targets
+
+
+def read_branch_json(branch: str, path: str) -> dict:
+    raw = git("show", f"refs/remotes/origin/{branch}:{path}")
+    value = json.loads(raw)
+    if not isinstance(value, dict):
+        raise SyncError(f"Expected JSON object at {branch}:{path}")
+    return value
+
+
+def validate_role(branch: str, role: dict, policy: dict) -> None:
+    expected = {
+        "schemaVersion": 1,
+        "branch": branch,
+        "mode": "shadow-rehearsal",
+        "liveConsumersEnabled": False,
+        "strictProtectionEnabled": False,
+        "administratorRecoveryRequired": True,
+        "cutoverIssue": 41,
+    }
+    for key, expected_value in expected.items():
+        if role.get(key) != expected_value:
+            raise SyncError(f"{branch} role {key}={role.get(key)!r}, expected {expected_value!r}")
+    allowed = role.get("allowedMutablePaths")
+    expected_allowed = [*policy["governedPaths"], ROLE_PATH]
+    if allowed != expected_allowed:
+        raise SyncError(f"{branch} role allowedMutablePaths differs from the reviewed allowlist")
+    if "main remains authoritative" not in str(role.get("authority") or ""):
+        raise SyncError(f"{branch} role no longer preserves main authority")
+
+
+def file_hash(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def changed_paths(worktree: Path) -> list[str]:
+    changed = set(
+        line.strip()
+        for line in git("-C", str(worktree), "diff", "--name-only").splitlines()
+        if line.strip()
+    )
+    changed.update(
+        line.strip()
+        for line in git("-C", str(worktree), "ls-files", "--others", "--exclude-standard").splitlines()
+        if line.strip()
+    )
+    return sorted(changed)
+
+
+def authenticated_url(repository: str, token: str) -> str:
+    if not token:
+        raise SyncError("DEVELOPMENT_PR_TOKEN is required for apply mode")
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository):
+        raise SyncError("GITHUB_REPOSITORY is invalid")
+    return f"https://x-access-token:{quote(token, safe='')}@github.com/{repository}.git"
+
+
+def push_branch(*, worktree: Path, branch: str, repository: str, token: str) -> None:
+    url = authenticated_url(repository, token)
+    result = subprocess.run(
+        ["git", "-C", str(worktree), "push", url, f"HEAD:refs/heads/{branch}"],
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        raise SyncError(f"Owner-authenticated push to {branch} failed")
+
+
+def sync_branch(
+    *,
+    branch: str,
+    branch_policy: dict,
+    source_sha: str,
+    mode: str,
+    write_probe: bool,
+    repository: str,
+    token: str,
+) -> dict:
+    if branch == "main" or branch not in {"release-state", "distribution"}:
+        raise SyncError("Refusing non-shadow target")
+
+    remote_ref = f"refs/remotes/origin/{branch}"
+    before_sha = git("rev-parse", remote_ref).strip()
+    role = read_branch_json(branch, ROLE_PATH)
+    validate_role(branch, role, branch_policy)
+    paths = list(branch_policy["governedPaths"])
+    fingerprint = hashlib.sha256(
+        (source_sha + "\0" + branch + "\0" + "\0".join(paths)).encode("utf-8")
+    ).hexdigest()[:16]
+    marker = f"[shadow-sync:{fingerprint}]"
+
+    files: list[dict[str, object]] = []
+    for path in paths:
+        source = ROOT / path
+        if not source.is_file() or source.is_symlink():
+            raise SyncError(f"Source governed path is missing or unsafe: {path}")
+        try:
+            branch_bytes = subprocess.run(
+                ["git", "show", f"{remote_ref}:{path}"],
+                cwd=ROOT,
+                check=True,
+                capture_output=True,
+            ).stdout
+        except subprocess.CalledProcessError as exc:
+            raise SyncError(f"{branch} is missing governed path {path}") from exc
+        files.append(
+            {
+                "path": path,
+                "equalBefore": source.read_bytes() == branch_bytes,
+                "sourceSha256": file_hash(source),
+            }
+        )
+
+    with tempfile.TemporaryDirectory(prefix=f"shadow-sync-{branch}-") as temporary:
+        worktree = Path(temporary) / "worktree"
+        git("worktree", "add", "--detach", str(worktree), remote_ref)
+        try:
+            for path in paths:
+                source = ROOT / path
+                destination = worktree / path
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copyfile(source, destination)
+
+            changed = changed_paths(worktree)
+            unexpected = sorted(set(changed) - set(paths))
+            if unexpected:
+                raise SyncError(f"{branch} synchronization changed non-governed paths: {unexpected}")
+            if ROLE_PATH in changed:
+                raise SyncError(f"{branch} role declaration must remain immutable during sync")
+
+            latest_message = git("-C", str(worktree), "log", "-1", "--format=%B")
+            probe_already_recorded = marker in latest_message
+            should_commit = bool(changed) or (mode == "apply" and write_probe and not probe_already_recorded)
+            pushed = False
+            empty_probe = False
+            after_sha = before_sha
+
+            if mode == "apply" and should_commit:
+                git("-C", str(worktree), "config", "user.name", "Conroy1988 shadow rehearsal")
+                git(
+                    "-C",
+                    str(worktree),
+                    "config",
+                    "user.email",
+                    "27301455+Conroy1988@users.noreply.github.com",
+                )
+                if changed:
+                    git("-C", str(worktree), "add", "--", *paths)
+                    git(
+                        "-C",
+                        str(worktree),
+                        "commit",
+                        "-m",
+                        f"Rehearse {branch} shadow sync from {source_sha[:12]} {marker}",
+                    )
+                else:
+                    empty_probe = True
+                    git(
+                        "-C",
+                        str(worktree),
+                        "commit",
+                        "--allow-empty",
+                        "-m",
+                        f"Rehearse {branch} shadow writer access from {source_sha[:12]} {marker}",
+                    )
+                after_sha = git("-C", str(worktree), "rev-parse", "HEAD").strip()
+                push_branch(
+                    worktree=worktree,
+                    branch=branch,
+                    repository=repository,
+                    token=token,
+                )
+                pushed = True
+
+            return {
+                "branch": branch,
+                "beforeCommit": before_sha,
+                "afterCommit": after_sha,
+                "changedPaths": changed,
+                "contentChanged": bool(changed),
+                "emptyProbeCommit": empty_probe,
+                "probeAlreadyRecorded": probe_already_recorded,
+                "pushed": pushed,
+                "files": files,
+                "acceptable": True,
+            }
+        finally:
+            git("worktree", "remove", "--force", str(worktree), check=False)
+
+
+def render_markdown(report: dict) -> str:
+    lines = [
+        "# Issue #41 shadow synchronization rehearsal",
+        "",
+        f"- State: **{report['state']}**",
+        f"- Mode: `{report['mode']}`",
+        f"- Source commit: `{report['sourceCommit']}`",
+        f"- Target selection: `{report['targetSelection']}`",
+        f"- Generated: `{report['generatedAt']}`",
+        "- Public `main` changed: **no**",
+        "- Live consumers changed: **no**",
+        "- Workflow token has contents write: **no**",
+        "",
+    ]
+    for branch in report["branches"]:
+        lines.extend(
+            [
+                f"## `{branch['branch']}`",
+                "",
+                f"- Before: `{branch['beforeCommit']}`",
+                f"- After: `{branch['afterCommit']}`",
+                f"- Pushed: **{'yes' if branch['pushed'] else 'no'}**",
+                f"- Content changed: **{'yes' if branch['contentChanged'] else 'no'}**",
+                f"- Empty write probe: **{'yes' if branch['emptyProbeCommit'] else 'no'}**",
+                "",
+            ]
+        )
+        for path in branch["changedPaths"]:
+            lines.append(f"- Updated governed path: `{path}`")
+        if not branch["changedPaths"]:
+            lines.append("- Governed content already matched `main`.")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def self_test() -> None:
+    policy = {
+        "schemaVersion": 1,
+        "mode": "shadow-rehearsal",
+        "mainAuthorityPreserved": True,
+        "liveConsumersEnabled": False,
+        "strictProtectionEnabled": False,
+        "administratorRecoveryRequired": True,
+        "cutoverIssue": 41,
+        "writerRehearsal": {
+            "enabled": True,
+            "manualDispatchOnly": True,
+            "authorizedActor": "Conroy1988",
+            "sourceBranch": "main",
+            "allowedTargets": ["release-state", "distribution"],
+            "planConfirmation": "PLAN SHADOW SYNC",
+            "applyConfirmation": "SYNC SHADOWS",
+            "credentialSecret": "DEVELOPMENT_PR_TOKEN",
+            "workflowPermission": "contents: read",
+            "allowIdempotentEmptyProbeCommit": True,
+            "liveConsumerCutoverAllowed": False,
+            "replacementIdentity": "narrowly scoped GitHub App",
+        },
+        "branches": {
+            "release-state": {"governedPaths": ["status/release-dashboard.json"]},
+            "distribution": {"governedPaths": ["dist/release-manifest.json"]},
+        },
+    }
+    writer, targets = validate_request(
+        policy=policy,
+        mode="plan",
+        target="both",
+        source_sha="a" * 40,
+        confirmation="PLAN SHADOW SYNC",
+        actor="Conroy1988",
+        write_probe=False,
+    )
+    assert writer["sourceBranch"] == "main"
+    assert targets == ["release-state", "distribution"]
+    try:
+        selected_targets("main", writer)
+    except SyncError:
+        pass
+    else:
+        raise AssertionError("main target was not rejected")
+    try:
+        validate_request(
+            policy=policy,
+            mode="apply",
+            target="release-state",
+            source_sha="a" * 40,
+            confirmation="PLAN SHADOW SYNC",
+            actor="Conroy1988",
+            write_probe=True,
+        )
+    except SyncError:
+        pass
+    else:
+        raise AssertionError("incorrect apply confirmation was not rejected")
+    print("Shadow synchronization self-tests passed.")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=("plan", "apply"))
+    parser.add_argument("--target", choices=("both", "release-state", "distribution"))
+    parser.add_argument("--source-sha")
+    parser.add_argument("--confirmation")
+    parser.add_argument("--actor")
+    parser.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    parser.add_argument("--write-probe", action="store_true")
+    parser.add_argument("--json-output", type=Path)
+    parser.add_argument("--markdown-output", type=Path)
+    parser.add_argument("--self-test", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.self_test:
+        self_test()
+        return 0
+    required = [args.mode, args.target, args.source_sha, args.confirmation, args.actor]
+    if any(value is None for value in required):
+        raise SyncError("mode, target, source-sha, confirmation and actor are required")
+
+    policy = load_policy()
+    _writer, targets = validate_request(
+        policy=policy,
+        mode=args.mode,
+        target=args.target,
+        source_sha=args.source_sha,
+        confirmation=args.confirmation,
+        actor=args.actor,
+        write_probe=args.write_probe,
+    )
+
+    head = git("rev-parse", "HEAD").strip()
+    main_head = git("rev-parse", "refs/remotes/origin/main").strip()
+    if head != args.source_sha or main_head != args.source_sha:
+        raise SyncError("The checked-out source and origin/main must match the authorized source SHA")
+
+    token = os.environ.get("SHADOW_SYNC_TOKEN", "")
+    if args.mode == "apply" and not token:
+        raise SyncError("DEVELOPMENT_PR_TOKEN is required for apply mode")
+
+    results = [
+        sync_branch(
+            branch=branch,
+            branch_policy=policy["branches"][branch],
+            source_sha=args.source_sha,
+            mode=args.mode,
+            write_probe=args.write_probe,
+            repository=args.repository,
+            token=token,
+        )
+        for branch in targets
+    ]
+    report = {
+        "schemaVersion": 1,
+        "state": "synchronized" if args.mode == "apply" else "planned",
+        "acceptable": True,
+        "mode": args.mode,
+        "targetSelection": args.target,
+        "sourceBranch": "main",
+        "sourceCommit": args.source_sha,
+        "generatedAt": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "authorizedActor": args.actor,
+        "credentialMode": "owner-token-rehearsal" if args.mode == "apply" else "read-only-plan",
+        "replacementIdentity": "narrowly scoped GitHub App",
+        "publicMainChanged": False,
+        "liveConsumersChanged": False,
+        "workflowContentsWrite": False,
+        "branches": results,
+    }
+    if args.json_output:
+        args.json_output.parent.mkdir(parents=True, exist_ok=True)
+        args.json_output.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    if args.markdown_output:
+        args.markdown_output.parent.mkdir(parents=True, exist_ok=True)
+        args.markdown_output.write_text(render_markdown(report) + "\n", encoding="utf-8")
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except SyncError as error:
+        print(f"shadow synchronization refused: {error}", file=os.sys.stderr)
+        raise SystemExit(1)

--- a/.github/scripts/test_shadow_sync_writer.py
+++ b/.github/scripts/test_shadow_sync_writer.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Contracts for the Issue #41 owner-authenticated shadow sync rehearsal."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+POLICY = ROOT / ".github" / "shadow-branch-policy.json"
+INVENTORY = ROOT / ".github" / "branch-write-inventory.json"
+SECURITY = ROOT / ".github" / "actions-security-policy.json"
+SCRIPT = ROOT / ".github" / "scripts" / "sync_shadow_branches.py"
+WORKFLOW = ROOT / ".github" / "workflows" / "sync-shadow-branches.yml"
+DOCUMENT = ROOT / "docs" / "BRANCH_WRITE_INVENTORY.md"
+
+
+def require(text: str, markers: list[str], label: str) -> None:
+    for marker in markers:
+        if marker not in text:
+            raise AssertionError(f"{label} is missing required marker: {marker}")
+
+
+def forbid(text: str, markers: list[str], label: str) -> None:
+    for marker in markers:
+        if marker in text:
+            raise AssertionError(f"{label} contains forbidden marker: {marker}")
+
+
+def main() -> int:
+    policy = json.loads(POLICY.read_text(encoding="utf-8"))
+    inventory = json.loads(INVENTORY.read_text(encoding="utf-8"))
+    security = json.loads(SECURITY.read_text(encoding="utf-8"))
+    script = SCRIPT.read_text(encoding="utf-8")
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    document = DOCUMENT.read_text(encoding="utf-8")
+
+    writer = policy.get("writerRehearsal") or {}
+    expected_writer = {
+        "enabled": True,
+        "manualDispatchOnly": True,
+        "authorizedActor": "Conroy1988",
+        "sourceBranch": "main",
+        "allowedTargets": ["release-state", "distribution"],
+        "planConfirmation": "PLAN SHADOW SYNC",
+        "applyConfirmation": "SYNC SHADOWS",
+        "credentialSecret": "DEVELOPMENT_PR_TOKEN",
+        "workflowPermission": "contents: read",
+        "allowIdempotentEmptyProbeCommit": True,
+        "liveConsumerCutoverAllowed": False,
+        "replacementIdentity": "narrowly scoped GitHub App",
+    }
+    for key, expected in expected_writer.items():
+        if writer.get(key) != expected:
+            raise AssertionError(f"writerRehearsal {key}={writer.get(key)!r}, expected {expected!r}")
+
+    entries = inventory.get("shadowBranchWriters") or []
+    if len(entries) != 1:
+        raise AssertionError(f"Expected one reviewed shadow writer, found {len(entries)}")
+    entry = entries[0]
+    for key, expected in {
+        "workflow": ".github/workflows/sync-shadow-branches.yml",
+        "script": ".github/scripts/sync_shadow_branches.py",
+        "source": "main",
+        "targets": ["release-state", "distribution"],
+        "credential": "DEVELOPMENT_PR_TOKEN",
+        "workflowPermission": "contents: read",
+        "dispatch": "manual owner-confirmed rehearsal",
+        "mainMutationAllowed": False,
+        "liveConsumerCutoverAllowed": False,
+        "replacementIdentity": "narrowly scoped GitHub App",
+    }.items():
+        if entry.get(key) != expected:
+            raise AssertionError(f"Shadow writer inventory {key} changed")
+
+    if ".github/workflows/sync-shadow-branches.yml" in (security.get("allowedWritePermissions") or {}):
+        raise AssertionError("Shadow sync workflow must not receive workflow-level write permission")
+
+    require(
+        workflow,
+        [
+            "name: Rehearse Shadow Branch Synchronization",
+            "workflow_dispatch:",
+            "permissions:\n  contents: read",
+            "github.actor == 'Conroy1988'",
+            "github.ref == 'refs/heads/main'",
+            "ref: main",
+            "persist-credentials: false",
+            "PLAN SHADOW SYNC",
+            "SYNC SHADOWS",
+            "source_sha",
+            "write_probe",
+            "+refs/heads/release-state:refs/remotes/origin/release-state",
+            "+refs/heads/distribution:refs/remotes/origin/distribution",
+            "DEVELOPMENT_PR_TOKEN",
+            "sync_shadow_branches.py --self-test",
+            "Apply owner-authorized shadow changes",
+            "Verify post-operation shadow parity",
+            "missionchief-shadow-sync-${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.source_sha }}",
+            "retention-days: 30",
+        ],
+        "Shadow sync workflow",
+    )
+    forbid(
+        workflow,
+        [
+            "pull_request_target:",
+            "schedule:",
+            "contents: write",
+            "HEAD:refs/heads/main",
+            "git update-ref refs/heads/main",
+            "gh api repos/${GITHUB_REPOSITORY}/git/refs/heads/main",
+            "secrets: inherit",
+        ],
+        "Shadow sync workflow",
+    )
+
+    require(
+        script,
+        [
+            '"release-state"',
+            '"distribution"',
+            'value == "main"',
+            'branch == "main"',
+            'f"HEAD:refs/heads/{branch}"',
+            '"DEVELOPMENT_PR_TOKEN is required for apply mode"',
+            '"owner-token-rehearsal"',
+            '"publicMainChanged": False',
+            '"liveConsumersChanged": False',
+            '"workflowContentsWrite": False',
+            '"narrowly scoped GitHub App"',
+            "Shadow synchronization self-tests passed.",
+        ],
+        "Shadow sync script",
+    )
+    forbid(
+        script,
+        [
+            '"HEAD:refs/heads/main"',
+            "git update-ref refs/heads/main",
+            "git push origin HEAD:main",
+            '"liveConsumerCutoverAllowed": True',
+        ],
+        "Shadow sync script",
+    )
+
+    for marker in [
+        "sync-shadow-branches.yml",
+        "sync_shadow_branches.py",
+        "DEVELOPMENT_PR_TOKEN",
+        "release-state",
+        "distribution",
+        "cannot update public `main`",
+    ]:
+        if marker not in document:
+            raise AssertionError(f"Human inventory is missing shadow writer marker: {marker}")
+
+    result = subprocess.run(["python3", str(SCRIPT), "--self-test"], cwd=ROOT)
+    if result.returncode != 0:
+        raise AssertionError("Shadow synchronization self-tests failed")
+
+    print("Shadow sync writer passed: manual owner confirmation, fixed targets, read-only workflow permission and no main mutation.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/shadow-branch-policy.json
+++ b/.github/shadow-branch-policy.json
@@ -6,6 +6,23 @@
   "strictProtectionEnabled": false,
   "administratorRecoveryRequired": true,
   "cutoverIssue": 41,
+  "writerRehearsal": {
+    "enabled": true,
+    "manualDispatchOnly": true,
+    "authorizedActor": "Conroy1988",
+    "sourceBranch": "main",
+    "allowedTargets": [
+      "release-state",
+      "distribution"
+    ],
+    "planConfirmation": "PLAN SHADOW SYNC",
+    "applyConfirmation": "SYNC SHADOWS",
+    "credentialSecret": "DEVELOPMENT_PR_TOKEN",
+    "workflowPermission": "contents: read",
+    "allowIdempotentEmptyProbeCommit": true,
+    "liveConsumerCutoverAllowed": false,
+    "replacementIdentity": "narrowly scoped GitHub App"
+  },
   "branches": {
     "release-state": {
       "purpose": "Mirror verified dashboard, manifest, announcement and recovery state.",

--- a/.github/workflows/sync-shadow-branches.yml
+++ b/.github/workflows/sync-shadow-branches.yml
@@ -153,9 +153,7 @@ jobs:
             2>&1 | tee shadow-sync-evidence/shadow-sync.log
 
       - name: Verify post-operation shadow parity
-        if: >-
-          (inputs.mode == 'plan' && steps.plan.outcome == 'success') ||
-          (inputs.mode == 'apply' && steps.apply.outcome == 'success')
+        if: inputs.mode == 'apply' && steps.apply.outcome == 'success'
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/sync-shadow-branches.yml
+++ b/.github/workflows/sync-shadow-branches.yml
@@ -1,0 +1,205 @@
+name: Rehearse Shadow Branch Synchronization
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Plan only or apply the reviewed shadow synchronization"
+        required: true
+        type: choice
+        options:
+          - plan
+          - apply
+      target:
+        description: "Reviewed shadow target"
+        required: true
+        type: choice
+        options:
+          - both
+          - release-state
+          - distribution
+      source_sha:
+        description: "Exact current main commit to synchronize"
+        required: true
+        type: string
+      write_probe:
+        description: "For apply mode, record one idempotent empty commit when content already matches"
+        required: true
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+      confirmation:
+        description: "PLAN SHADOW SYNC for plan mode or SYNC SHADOWS for apply mode"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: toolkit-shadow-branch-synchronization
+  cancel-in-progress: false
+
+jobs:
+  synchronize:
+    name: Plan or apply constrained shadow synchronization
+    if: >-
+      github.repository == 'Conroy1988/missionchief-toolkit-assets' &&
+      github.actor == 'Conroy1988' &&
+      github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out exact main authority
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+          show-progress: false
+
+      - name: Validate dispatch and exact source state
+        env:
+          MODE: ${{ inputs.mode }}
+          TARGET: ${{ inputs.target }}
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          WRITE_PROBE: ${{ inputs.write_probe }}
+          CONFIRMATION: ${{ inputs.confirmation }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo "::error::source_sha must be a full lowercase commit SHA."; exit 1; }
+          [[ "$TARGET" == "both" || "$TARGET" == "release-state" || "$TARGET" == "distribution" ]] || { echo "::error::Unapproved shadow target."; exit 1; }
+          [[ "$TARGET" != "main" ]] || { echo "::error::main can never be a shadow synchronization target."; exit 1; }
+          if [[ "$MODE" == "plan" ]]; then
+            [[ "$CONFIRMATION" == "PLAN SHADOW SYNC" ]] || { echo "::error::Type PLAN SHADOW SYNC exactly."; exit 1; }
+            [[ "$WRITE_PROBE" == "false" ]] || { echo "::error::A write probe is valid only in apply mode."; exit 1; }
+          elif [[ "$MODE" == "apply" ]]; then
+            [[ "$CONFIRMATION" == "SYNC SHADOWS" ]] || { echo "::error::Type SYNC SHADOWS exactly."; exit 1; }
+          else
+            echo "::error::Mode must be plan or apply."
+            exit 1
+          fi
+
+          git fetch --no-tags origin \
+            +refs/heads/main:refs/remotes/origin/main \
+            +refs/heads/release-state:refs/remotes/origin/release-state \
+            +refs/heads/distribution:refs/remotes/origin/distribution
+          [[ "$(git rev-parse HEAD)" == "$SOURCE_SHA" ]] || { echo "::error::Checkout does not match the authorized source SHA."; exit 1; }
+          [[ "$(git rev-parse origin/main)" == "$SOURCE_SHA" ]] || { echo "::error::main moved; authorize the new exact SHA."; exit 1; }
+
+      - name: Validate shadow synchronizer self-tests
+        run: python3 .github/scripts/sync_shadow_branches.py --self-test
+
+      - name: Require owner-authenticated rehearsal token
+        if: inputs.mode == 'apply'
+        env:
+          OWNER_TOKEN: ${{ secrets.DEVELOPMENT_PR_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ -n "$OWNER_TOKEN" ]] || { echo "::error::DEVELOPMENT_PR_TOKEN is required for the temporary owner-authenticated rehearsal."; exit 1; }
+
+      - name: Plan governed shadow changes
+        id: plan
+        if: inputs.mode == 'plan'
+        continue-on-error: true
+        env:
+          TARGET: ${{ inputs.target }}
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          CONFIRMATION: ${{ inputs.confirmation }}
+        shell: bash
+        run: |
+          set -o pipefail
+          mkdir -p shadow-sync-evidence
+          python3 .github/scripts/sync_shadow_branches.py \
+            --mode plan \
+            --target "$TARGET" \
+            --source-sha "$SOURCE_SHA" \
+            --confirmation "$CONFIRMATION" \
+            --actor "$GITHUB_ACTOR" \
+            --json-output shadow-sync-evidence/shadow-sync.json \
+            --markdown-output shadow-sync-evidence/shadow-sync.md \
+            2>&1 | tee shadow-sync-evidence/shadow-sync.log
+
+      - name: Apply owner-authorized shadow changes
+        id: apply
+        if: inputs.mode == 'apply'
+        continue-on-error: true
+        env:
+          TARGET: ${{ inputs.target }}
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          WRITE_PROBE: ${{ inputs.write_probe }}
+          CONFIRMATION: ${{ inputs.confirmation }}
+          SHADOW_SYNC_TOKEN: ${{ secrets.DEVELOPMENT_PR_TOKEN }}
+        shell: bash
+        run: |
+          set -o pipefail
+          mkdir -p shadow-sync-evidence
+          probe_args=()
+          [[ "$WRITE_PROBE" == "true" ]] && probe_args+=(--write-probe)
+          python3 .github/scripts/sync_shadow_branches.py \
+            --mode apply \
+            --target "$TARGET" \
+            --source-sha "$SOURCE_SHA" \
+            --confirmation "$CONFIRMATION" \
+            --actor "$GITHUB_ACTOR" \
+            "${probe_args[@]}" \
+            --json-output shadow-sync-evidence/shadow-sync.json \
+            --markdown-output shadow-sync-evidence/shadow-sync.md \
+            2>&1 | tee shadow-sync-evidence/shadow-sync.log
+
+      - name: Verify post-operation shadow parity
+        if: >-
+          (inputs.mode == 'plan' && steps.plan.outcome == 'success') ||
+          (inputs.mode == 'apply' && steps.apply.outcome == 'success')
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --force --no-tags origin \
+            +refs/heads/release-state:refs/remotes/origin/release-state \
+            +refs/heads/distribution:refs/remotes/origin/distribution
+          python3 .github/scripts/verify_shadow_branch_parity.py \
+            --json-output shadow-sync-evidence/post-sync-parity.json \
+            --markdown-output shadow-sync-evidence/post-sync-parity.md \
+            2>&1 | tee shadow-sync-evidence/post-sync-parity.log
+
+      - name: Upload immutable shadow synchronization evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: missionchief-shadow-sync-${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.source_sha }}
+          path: shadow-sync-evidence/
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Publish rehearsal summary
+        if: always()
+        shell: bash
+        run: |
+          if [[ -f shadow-sync-evidence/shadow-sync.md ]]; then
+            cat shadow-sync-evidence/shadow-sync.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "# Shadow synchronization rehearsal" >> "$GITHUB_STEP_SUMMARY"
+            echo >> "$GITHUB_STEP_SUMMARY"
+            echo "The request was refused before synchronization evidence could be generated." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Enforce requested operation result
+        if: always()
+        env:
+          MODE: ${{ inputs.mode }}
+          PLAN_OUTCOME: ${{ steps.plan.outcome }}
+          APPLY_OUTCOME: ${{ steps.apply.outcome }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$MODE" == "plan" && "$PLAN_OUTCOME" != "success" ]]; then
+            exit 1
+          fi
+          if [[ "$MODE" == "apply" && "$APPLY_OUTCOME" != "success" ]]; then
+            exit 1
+          fi

--- a/.github/workflows/validate-development-package-workflow.yml
+++ b/.github/workflows/validate-development-package-workflow.yml
@@ -16,6 +16,7 @@ on:
       - ".github/scripts/generate_release_dashboard.py"
       - ".github/scripts/reconcile_pages_incident.sh"
       - ".github/scripts/reconcile_validation_dashboard.py"
+      - ".github/scripts/sync_shadow_branches.py"
       - ".github/scripts/verify_shadow_branch_parity.py"
       - ".github/scripts/verify_validation_candidate.py"
       - ".github/actions-security-policy.json"
@@ -28,6 +29,7 @@ on:
       - ".github/scripts/test_greasyfork_parity_pipeline.py"
       - ".github/scripts/test_release_announcement_state_pipeline.py"
       - ".github/scripts/test_shadow_branch_parity.py"
+      - ".github/scripts/test_shadow_sync_writer.py"
       - ".github/scripts/test_validation_candidate_pipeline.py"
       - "docs/BRANCH_PROTECTION_MIGRATION.md"
       - "docs/BRANCH_WRITE_INVENTORY.md"
@@ -66,6 +68,7 @@ jobs:
             python3 .github/scripts/test_greasyfork_parity_pipeline.py
             python3 .github/scripts/test_release_announcement_state_pipeline.py
             python3 .github/scripts/test_shadow_branch_parity.py
+            python3 .github/scripts/test_shadow_sync_writer.py
           } 2>&1 | tee "$RUNNER_TEMP/workflow-policy.log"
 
       - name: Upload policy diagnostics

--- a/docs/BRANCH_PROTECTION_MIGRATION.md
+++ b/docs/BRANCH_PROTECTION_MIGRATION.md
@@ -11,7 +11,8 @@ The migration is tracked by Issue #41. Authority is maintained in:
 - `.github/scripts/test_validation_candidate_pipeline.py`;
 - `.github/scripts/test_greasyfork_parity_pipeline.py`;
 - `.github/scripts/test_release_announcement_state_pipeline.py`;
-- `.github/scripts/test_shadow_branch_parity.py`.
+- `.github/scripts/test_shadow_branch_parity.py`;
+- `.github/scripts/test_shadow_sync_writer.py`.
 
 ## Current safe controls
 
@@ -20,11 +21,12 @@ The migration is tracked by Issue #41. Authority is maintained in:
 - code-integrity, performance, asset, recovery and documentation validation;
 - immutable Action pins and permission auditing;
 - owner-authenticated review branches for packages and rollback preparation;
-- explicit production and recovery confirmation phrases;
+- explicit production, recovery and shadow-synchronization confirmation phrases;
 - exact commit/ref/hash validation evidence;
 - deterministic dashboard, Greasy Fork and announcement-state verification;
 - atomic primary release dashboard and announcement state;
-- isolated non-live `release-state` and `distribution` rehearsal branches.
+- isolated non-live `release-state` and `distribution` branches;
+- a manual-only, fixed-target shadow writer with read-only workflow permission.
 
 ## Completed migration stages
 
@@ -59,27 +61,56 @@ After Greasy Fork verification, private backup and Discord publication, `release
 
 The stable update manifest remains a separate guarded writer. It is dispatched and awaited in parallel with GitHub Pages.
 
-Direct public-main writers are reduced from **10 to 4**.
+Direct public-main writers remain reduced from **10 to 4**.
 
-## Shadow branch rehearsal 🟡
+### Shadow branch topology and read-only parity ✅
 
-The final branch topology now exists without any live cutover:
+PR #506 established:
 
-- `release-state` mirrors verified dashboard, manifest and announcement state;
-- `distribution` mirrors stable `dist/` and root userscript paths.
+- `release-state` for verified dashboard, manifest and announcement state;
+- `distribution` for stable `dist/` and root userscript paths.
 
-Both branches currently derive from verified `main` and contain an explicit `.github/branch-role.json` contract. They remain in `shadow-rehearsal` mode with:
+Both branches remain in `shadow-rehearsal` mode. `main` remains authoritative, live consumers are disabled, strict protection is disabled and administrator recovery remains mandatory.
 
-- `main` preserved as authority;
-- live consumers disabled;
-- strict protection disabled;
-- administrator recovery required;
-- reviewed mutable-path allowlists;
-- Issue #41 as the sole cutover authority.
+`Verify Shadow Branch Parity` has read-only contents permission. It validates role declarations and governed-file parity, retains evidence for 30 days and performs no branch mutation.
 
-`Verify Shadow Branch Parity` has read-only contents permission. It validates role declarations and governed-file parity, retains evidence for 30 days, and performs no commit, push or ref update.
+## Constrained shadow writer rehearsal 🟡
 
-This stage proves branch availability and current parity before introducing a scoped writer identity.
+The next stage introduces `.github/workflows/sync-shadow-branches.yml` and `.github/scripts/sync_shadow_branches.py` without changing live authority.
+
+### Dispatch and authorization
+
+- manual `workflow_dispatch` only;
+- repository fixed to `Conroy1988/missionchief-toolkit-assets`;
+- actor fixed to `Conroy1988`;
+- dispatch ref must be `main`;
+- checkout and `origin/main` must both equal an explicitly supplied 40-character source SHA;
+- plan mode requires `PLAN SHADOW SYNC`;
+- apply mode requires `SYNC SHADOWS`.
+
+### Target and file boundaries
+
+- allowed targets are exactly `release-state` and `distribution`;
+- `main` is rejected as a target in both workflow and script;
+- target branch roles must remain `shadow-rehearsal` and preserve main authority;
+- only branch-specific governed paths may change;
+- `.github/branch-role.json` cannot be copied or modified;
+- pushes are fast-forward commits to the two reviewed shadow refs only;
+- public `main` and live consumers remain unchanged.
+
+### Credential boundary
+
+The workflow itself retains `contents: read`. Plan mode uses no write credential. Apply mode temporarily receives the existing owner-authenticated `DEVELOPMENT_PR_TOKEN` solely for the reviewed shadow push.
+
+This is a rehearsal identity, not the final architecture. It must be replaced by a narrowly scoped GitHub App restricted to the two operational branches before consumer cutover or strict protection.
+
+### Rehearsal evidence
+
+- plan/apply JSON, Markdown and logs retained for 30 days;
+- post-operation read-only parity verification;
+- optional idempotent empty probe commits to prove branch access when governed content already matches;
+- no duplicate probe commit for the same source/target fingerprint;
+- permanent static and executable contracts reject target expansion, workflow write permission, live cutover and `main` mutation.
 
 ## Remaining generated state
 
@@ -109,7 +140,7 @@ Mutable dashboard, manifest, announcement, fallback-monitor and recovery state. 
 
 ### Immutable evidence
 
-Validation candidates, parity audits, announcement checks, dashboard projections, shadow parity reports, release bundles, checksums, audits, dry runs and handovers remain GitHub Release assets or Actions artifacts.
+Validation candidates, parity audits, synchronization plans, announcement checks, dashboard projections, release bundles, checksums, audits, dry runs and handovers remain GitHub Release assets or Actions artifacts.
 
 ## Access and speed requirements
 
@@ -130,12 +161,13 @@ The final protection design must retain fast owner operation:
 2. ✅ Separate validation, audit and verification evidence from public `main`.
 3. ✅ Make dashboard and announcement state atomic; retire the reconciliation writer.
 4. ⬜ Fold stable update-manifest publication into the consolidated release-state commit.
-5. 🟡 Create and verify non-live `release-state` and `distribution` shadow branches.
-6. Introduce a narrowly scoped branch writer identity and rehearse synchronization.
-7. Move consolidated release state and recovery state to `release-state`.
-8. Move stable `dist/` and Greasy Fork mirrors to `distribution`.
-9. Remove unnecessary `contents: write` from orchestration-only workflows.
-10. Rehearse without public-main mutation:
+5. ✅ Create and verify non-live `release-state` and `distribution` branches — PR #506.
+6. 🟡 Introduce the constrained owner-token shadow writer and rehearse plan/apply synchronization.
+7. Replace the rehearsal credential with a narrowly scoped GitHub App.
+8. Move consolidated release state and recovery state to `release-state`.
+9. Move stable `dist/` and Greasy Fork mirrors to `distribution`.
+10. Remove unnecessary `contents: write` from orchestration-only workflows.
+11. Rehearse without public-main mutation:
    - normal Release Readiness;
    - full production publication;
    - Greasy Fork-only retry;
@@ -144,15 +176,15 @@ The final protection design must retain fast owner operation:
    - dashboard reconstruction;
    - stable release-asset repair;
    - emergency rollback-candidate preparation.
-11. Rehearse owner/admin access:
+12. Rehearse owner/admin access:
    - create and update an owner branch;
    - open and update a pull request;
    - auto-merge after green checks;
    - use PR-only administrator bypass where required;
    - repair distribution and release-state branches;
    - disable or amend the ruleset.
-12. Require pull requests, approved checks, current branches and resolved conversations.
-13. Block routine direct human pushes and enable strict protection only after complete rehearsal.
+13. Require pull requests, approved checks, current branches and resolved conversations.
+14. Block routine direct human pushes and enable strict protection only after complete rehearsal.
 
 ## Exit criteria
 

--- a/docs/BRANCH_WRITE_INVENTORY.md
+++ b/docs/BRANCH_WRITE_INVENTORY.md
@@ -11,7 +11,7 @@ The repository has four workflows that can commit directly to public `main`. Two
 
 Canonical validation, release dry runs, repository audits, dashboard projection, Greasy Fork parity and announcement-state verification are now artifact-only. These six workflows use read-only repository access and retain immutable evidence instead of committing generated state.
 
-A separate read-only rehearsal workflow verifies the new `release-state` and `distribution` shadow branches. It does not add write authority and does not change live consumers.
+The `release-state` and `distribution` branches are non-live shadows. Read-only parity verification is complete. A separate manually dispatched rehearsal writer is now being introduced with fixed targets and an owner-authenticated credential, but it cannot update public `main` or enable live consumers.
 
 `.github/branch-write-inventory.json` is the machine-readable write authority. `.github/shadow-branch-policy.json` governs the isolated shadow rehearsal. Permanent contracts fail closed when a writer, permission, authority, branch role or release-state boundary changes.
 
@@ -37,9 +37,7 @@ The executable public-main push helper `.github/scripts/sync_greasyfork_root_mir
 | `import-canonical-userscript.yml` | `contents: read` | live Greasy Fork parity evidence | No source, baseline, branch or PR change. |
 | `reconcile-release-announcement-state.yml` | `contents: read` | dashboard/tracker consistency evidence | No dashboard or tracker change. |
 
-## Shadow branch rehearsal
-
-Two non-live rehearsal branches now exist:
+## Shadow branch topology
 
 | Branch | Governed paths | Current authority | Live consumers |
 |---|---|---|---|
@@ -53,18 +51,37 @@ Each branch contains `.github/branch-role.json` declaring:
 - `strictProtectionEnabled: false`;
 - administrator recovery is mandatory;
 - Issue #41 controls cutover;
-- only the reviewed operational paths may become mutable.
+- only reviewed operational paths may become mutable.
 
-`.github/workflows/verify-shadow-branch-parity.yml`:
+`.github/workflows/verify-shadow-branch-parity.yml` remains read-only. It validates branch roles and governed-file parity, retains evidence for 30 days, and never commits, pushes, updates a ref or changes a live URL.
 
-- has `contents: read` only;
-- fetches both branch refs without persisted credentials;
-- validates the branch-role declarations;
-- compares only governed paths with the current checkout;
-- retains JSON/Markdown/log evidence for 30 days;
-- never commits, pushes, updates a ref or changes a live URL.
+## Constrained shadow synchronization writer
 
-This stage proves branch creation, role isolation and baseline parity before any automation identity or consumer cutover is introduced.
+`.github/workflows/sync-shadow-branches.yml` and `.github/scripts/sync_shadow_branches.py` provide the next non-live rehearsal stage.
+
+The writer contract is:
+
+- manual `workflow_dispatch` only;
+- authorized actor fixed to `Conroy1988`;
+- exact source branch fixed to `main`;
+- exact source commit SHA required and revalidated against `origin/main`;
+- target restricted to `release-state`, `distribution` or both;
+- plan confirmation must be `PLAN SHADOW SYNC`;
+- apply confirmation must be `SYNC SHADOWS`;
+- workflow permission remains `contents: read`;
+- apply mode temporarily uses `DEVELOPMENT_PR_TOKEN` as the existing owner-authenticated credential;
+- the credential is required only for the apply step;
+- changed files must be a subset of each branch's governed paths;
+- `.github/branch-role.json` remains immutable;
+- pushes are fast-forward commits to `HEAD:refs/heads/release-state` or `HEAD:refs/heads/distribution` only;
+- `main` is rejected as a target inside both the workflow and the script;
+- an optional idempotent empty probe commit can prove write access when governed content already matches;
+- every plan/apply operation retains JSON/Markdown/log evidence for 30 days;
+- post-operation read-only parity verification must pass;
+- live consumer cutover remains forbidden;
+- the temporary owner credential must be replaced by a narrowly scoped GitHub App before final cutover.
+
+This workflow is recorded under `shadowBranchWriters`, not `directMainWriters`. It cannot update public `main` and receives no workflow-level write permission.
 
 ## Current release state
 
@@ -91,7 +108,7 @@ The public manifest URL remains unchanged:
 7. Dashboard JSON, rendered Markdown and announcement tracker are committed atomically.
 8. Stable update-manifest publication and GitHub Pages are dispatched in parallel and awaited.
 9. Dashboard, Greasy Fork and announcement workflows verify only.
-10. Shadow parity remains an independent read-only rehearsal until cutover.
+10. Shadow synchronization remains a separate non-live rehearsal until cutover.
 
 ## Indirect release orchestrators
 
@@ -108,6 +125,7 @@ Their write authority remains only because the reusable production job still wri
 |---|---|---|---|
 | `apply-development-package.yml` | Existing owner PR branch | `DEVELOPMENT_PR_TOKEN` | Review branch only. |
 | `prepare-release-rollback.yml` | Recovery branch and PR | `DEVELOPMENT_PR_TOKEN` | Review branch only. |
+| `sync-shadow-branches.yml` | `release-state` and `distribution` only | `DEVELOPMENT_PR_TOKEN` | Manual rehearsal; no `main` or consumer cutover. |
 | `backup_release_to_private_repo.sh` | private recovery repository `main` | `MIGRATION_REPO_TOKEN` | Separate repository. |
 
 ## Target architecture
@@ -115,7 +133,7 @@ Their write authority remains only because the reusable production job still wri
 - **Public `main`:** reviewed source, workflows, tests, policy and documentation.
 - **Distribution branch:** stable `dist/` and root mirrors, written by a scoped release App.
 - **Release-state branch:** dashboard, manifest, announcement, fallback-monitor and recovery state.
-- **Immutable evidence:** validation, parity, projections, bundles, audits and handovers.
+- **Immutable evidence:** validation, parity, synchronization plans, bundles, audits and handovers.
 
 ## Migration order
 
@@ -125,16 +143,18 @@ Their write authority remains only because the reusable production job still wri
 4. ✅ Retire automatic Greasy Fork importing.
 5. ✅ Make primary announcement state atomic and reconciliation read-only.
 6. ⬜ Fold stable update-manifest publication into the consolidated release-state commit.
-7. 🟡 Create shadow `release-state` and `distribution` branches and verify read-only parity.
-8. Add a narrowly scoped branch writer and rehearse shadow synchronization.
-9. Cut consolidated release state over to `release-state`.
-10. Cut stable distribution over to `distribution`.
-11. Rehearse release, recovery and administrator access.
-12. Enable strict protection only after all rehearsals pass.
+7. ✅ Create shadow `release-state` and `distribution` branches and verify read-only parity — PR #506.
+8. 🟡 Add the constrained shadow writer and rehearse plan/apply synchronization.
+9. Replace the rehearsal owner token with a narrowly scoped GitHub App.
+10. Cut consolidated release state over to `release-state`.
+11. Cut stable distribution over to `distribution`.
+12. Rehearse release, recovery and administrator access.
+13. Enable strict protection only after all rehearsals pass.
 
 ## Current migration evidence
 
 - PRs #498–#504 reduced direct public-main writers from **10 to 4**.
 - PR #505 was closed without merging; update-manifest publication remains a direct `main` writer.
-- Current change establishes isolated shadow branches and read-only parity evidence.
+- PR #506 established and verified non-live shadow branches.
+- Current change introduces a separately classified, owner-confirmed shadow writer without changing live authority.
 - No live URL, source authority or protection setting has changed.


### PR DESCRIPTION
## Purpose

Advance Issue #41 by adding a manually controlled writer rehearsal for the non-live `release-state` and `distribution` branches without granting workflow-level write access or changing any production consumer.

## Writer boundary

- Source is fixed to the exact current `main` commit.
- Targets are fixed to `release-state`, `distribution`, or both.
- Public `main` is rejected as a target in both the workflow and synchronizer.
- Plan mode requires `PLAN SHADOW SYNC` and performs no write.
- Apply mode requires `SYNC SHADOWS` and temporarily uses the existing owner-authenticated `DEVELOPMENT_PR_TOKEN`.
- The workflow itself retains `contents: read`.
- Only branch-specific governed paths may change.
- `.github/branch-role.json` remains immutable.
- Pushes are normal fast-forward commits to the two reviewed shadow refs only.
- Live-consumer cutover remains forbidden.

## Rehearsal features

- Deterministic plan evidence before any branch write.
- Exact source-SHA and `origin/main` revalidation.
- Branch-role and allowlist validation before mutation.
- Optional idempotent empty probe commit when governed content already matches, proving actual write access without modifying data.
- No duplicate probe for the same source/target fingerprint.
- Post-apply read-only shadow parity verification.
- JSON, Markdown and log evidence retained for 30 days.
- Permanent static and executable contracts covering actor, confirmations, credential, targets, branch roles, permissions and prohibited `main` mutation.

## Current architecture

The live repository still has four direct public-`main` writers. PR #505 was closed without merging, so update-manifest publication remains separate. This PR adds one separately classified `shadowBranchWriter`; it does not reduce or expand public-main write authority.

## Future identity

`DEVELOPMENT_PR_TOKEN` is used only as a temporary owner-authenticated rehearsal credential. It must be replaced by a narrowly scoped GitHub App restricted to `release-state` and `distribution` before any live cutover or strict protection.

## Safety

- No userscript, distribution, release state or production version change.
- No live raw URL, Greasy Fork source, update-manifest consumer or Pages source change.
- No branch-protection setting is enabled.
- No workflow receives `contents: write`.
- No automatic trigger, schedule or release integration is added.
- Production remains v5.0.7.

## Validation

All six checks pass on exact head `19e31c058d6afa6f082cba5b2eef303a7c1e815c`:

- Development and Automation Workflow Policy
- Actions security
- Verify Shadow Branch Parity
- Verify Greasy Fork Canonical Parity
- Verify Release Announcement State
- Development status

The executable policy suite confirmed:

- manual owner confirmation;
- exact current-main SHA binding;
- fixed `release-state` and `distribution` targets;
- read-only workflow permission;
- governed-path-only commits;
- immutable branch-role files;
- no public-main mutation;
- no live-consumer cutover;
- mandatory future replacement by a narrowly scoped GitHub App.

The PR is current with `main`, conflict-free, and has no review comments.

After merge, the rehearsal sequence is: plan against the exact new `main`, inspect evidence, then apply an idempotent write probe to both shadow branches and verify parity.

Advances #41