### PR TITLE
Move fallback announcement tracker to release-state

### DIFF
--- a/.github/branch-write-inventory.json
+++ b/.github/branch-write-inventory.json
@@ -1,19 +1,9 @@
 {
   "schemaVersion": 1,
   "reviewedAt": "2026-07-24",
-  "reviewedMainCommit": "092c20afcd05eb0f159c4e7e2da8bd2a0bb52c59",
+  "reviewedMainCommit": "66881414ba8fc542c8fed44fd501296d74b56b8e",
   "strictProtectionEnabled": false,
   "directMainWriters": [
-    {
-      "workflow": ".github/workflows/greasyfork-release-monitor.yml",
-      "purpose": "Record fallback Greasy Fork/Discord announcement state when primary release completion is absent.",
-      "credential": "github.token",
-      "actor": "github-actions[bot]",
-      "writes": [
-        ".github/greasyfork-version.txt"
-      ],
-      "migrationTarget": "release-state branch"
-    },
     {
       "workflow": ".github/workflows/release-recovery.yml",
       "purpose": "Record controlled Greasy Fork, private-backup, Discord and dashboard recovery state.",
@@ -139,10 +129,26 @@
     }
   ],
   "directMainPushSources": [
-    ".github/workflows/greasyfork-release-monitor.yml",
     ".github/workflows/release-recovery.yml",
     ".github/workflows/release-toolkit.yml",
     ".github/scripts/sync_greasyfork_root_mirror.sh"
+  ],
+  "releaseStateBranchWriters": [
+    {
+      "workflow": ".github/workflows/greasyfork-release-monitor.yml",
+      "helper": ".github/scripts/release_state_branch.py",
+      "sourceAuthority": "main release dashboard",
+      "target": "release-state",
+      "writes": [
+        ".github/greasyfork-version.txt"
+      ],
+      "credential": "github.token",
+      "actor": "github-actions[bot]",
+      "mainMutationAllowed": false,
+      "forcePushAllowed": false,
+      "liveConsumerCutoverAllowed": false,
+      "migrationState": "transitional fallback-tracker authority"
+    }
   ],
   "externalRepositoryMainPushSources": [
     {

--- a/.github/scripts/release_state_branch.py
+++ b/.github/scripts/release_state_branch.py
@@ -12,9 +12,7 @@ import argparse
 import base64
 import json
 import os
-import shutil
 import subprocess
-import tempfile
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -71,8 +69,11 @@ def validate_role(role: dict) -> set[str]:
             raise ReleaseStateError(
                 f"release-state role {key}={role.get(key)!r}, expected {value!r}"
             )
+
     allowed = role.get("allowedMutablePaths")
-    if not isinstance(allowed, list) or not all(isinstance(path, str) and path for path in allowed):
+    if not isinstance(allowed, list) or not all(
+        isinstance(path, str) and path for path in allowed
+    ):
         raise ReleaseStateError("release-state allowedMutablePaths is invalid")
     allowed_paths = set(allowed)
     required = {
@@ -92,8 +93,7 @@ def validate_role(role: dict) -> set[str]:
 def validate_worktree(worktree: Path) -> set[str]:
     if not worktree.is_dir():
         raise ReleaseStateError(f"release-state worktree is missing: {worktree}")
-    role = load_role(worktree)
-    return validate_role(role)
+    return validate_role(load_role(worktree))
 
 
 def write_output(name: str, value: str) -> None:
@@ -114,7 +114,6 @@ def prepare(worktree: Path) -> None:
 
     git(
         "fetch",
-        "--force",
         "--no-tags",
         "origin",
         f"+refs/heads/{TARGET_BRANCH}:{REMOTE_REF}",
@@ -157,7 +156,9 @@ def status_paths(worktree: Path) -> set[str]:
 
 
 def authorization_header(token: str) -> str:
-    encoded = base64.b64encode(f"x-access-token:{token}".encode("utf-8")).decode("ascii")
+    encoded = base64.b64encode(
+        f"x-access-token:{token}".encode("utf-8")
+    ).decode("ascii")
     return f"AUTHORIZATION: basic {encoded}"
 
 
@@ -203,7 +204,6 @@ def commit(worktree: Path, message: str, requested_paths: list[str]) -> None:
 
     git(
         "fetch",
-        "--force",
         "--no-tags",
         "origin",
         f"+refs/heads/{TARGET_BRANCH}:{REMOTE_REF}",

--- a/.github/scripts/release_state_branch.py
+++ b/.github/scripts/release_state_branch.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""Prepare and commit governed operational state on the release-state branch.
+
+This helper is intentionally branch-specific. It never targets public ``main``,
+never force-pushes, validates the branch-role declaration before every write,
+and rejects changes outside the reviewed release-state allowlist.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+TARGET_BRANCH = "release-state"
+REMOTE_REF = f"refs/remotes/origin/{TARGET_BRANCH}"
+PUSH_REF = f"HEAD:refs/heads/{TARGET_BRANCH}"
+ROLE_PATH = Path(".github/branch-role.json")
+
+
+class ReleaseStateError(RuntimeError):
+    """Fail-closed release-state operation error."""
+
+
+def git(*args: str, cwd: Path = ROOT, capture: bool = True) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        text=True,
+        capture_output=capture,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "git command failed").strip()
+        raise ReleaseStateError(f"git {' '.join(args)} failed: {detail}")
+    return result.stdout.strip() if capture else ""
+
+
+def load_role(worktree: Path) -> dict:
+    path = worktree / ROLE_PATH
+    if not path.is_file() or path.is_symlink():
+        raise ReleaseStateError("release-state branch role is missing or unsafe")
+    try:
+        role = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ReleaseStateError("release-state branch role is not valid JSON") from error
+    if not isinstance(role, dict):
+        raise ReleaseStateError("release-state branch role must be a JSON object")
+    return role
+
+
+def validate_role(role: dict) -> set[str]:
+    expected = {
+        "schemaVersion": 1,
+        "branch": TARGET_BRANCH,
+        "mode": "shadow-rehearsal",
+        "authority": "main remains authoritative until Issue #41 cutover",
+        "liveConsumersEnabled": False,
+        "strictProtectionEnabled": False,
+        "administratorRecoveryRequired": True,
+        "cutoverIssue": 41,
+    }
+    for key, value in expected.items():
+        if role.get(key) != value:
+            raise ReleaseStateError(
+                f"release-state role {key}={role.get(key)!r}, expected {value!r}"
+            )
+    allowed = role.get("allowedMutablePaths")
+    if not isinstance(allowed, list) or not all(isinstance(path, str) and path for path in allowed):
+        raise ReleaseStateError("release-state allowedMutablePaths is invalid")
+    allowed_paths = set(allowed)
+    required = {
+        "status/release-dashboard.json",
+        "status/README.md",
+        "status/update-manifest.json",
+        ".github/greasyfork-version.txt",
+        ROLE_PATH.as_posix(),
+    }
+    if allowed_paths != required:
+        raise ReleaseStateError(
+            f"release-state mutable-path allowlist changed: {sorted(allowed_paths)}"
+        )
+    return allowed_paths - {ROLE_PATH.as_posix()}
+
+
+def validate_worktree(worktree: Path) -> set[str]:
+    if not worktree.is_dir():
+        raise ReleaseStateError(f"release-state worktree is missing: {worktree}")
+    role = load_role(worktree)
+    return validate_role(role)
+
+
+def write_output(name: str, value: str) -> None:
+    output = os.environ.get("GITHUB_OUTPUT")
+    if output:
+        with Path(output).open("a", encoding="utf-8") as handle:
+            handle.write(f"{name}={value}\n")
+
+
+def prepare(worktree: Path) -> None:
+    if TARGET_BRANCH == "main" or PUSH_REF.endswith("/main"):
+        raise ReleaseStateError("public main can never be a release-state target")
+    if worktree.exists():
+        if any(worktree.iterdir()):
+            raise ReleaseStateError(f"refusing to reuse non-empty worktree path: {worktree}")
+        worktree.rmdir()
+    worktree.parent.mkdir(parents=True, exist_ok=True)
+
+    git(
+        "fetch",
+        "--force",
+        "--no-tags",
+        "origin",
+        f"+refs/heads/{TARGET_BRANCH}:{REMOTE_REF}",
+    )
+    before = git("rev-parse", REMOTE_REF)
+    git("worktree", "add", "--detach", str(worktree), REMOTE_REF, capture=False)
+    validate_worktree(worktree)
+    head = git("rev-parse", "HEAD", cwd=worktree)
+    if head != before:
+        raise ReleaseStateError("prepared worktree does not match current release-state ref")
+
+    write_output("root", str(worktree))
+    write_output("before_sha", before)
+    print(f"Prepared governed {TARGET_BRANCH} worktree at {worktree} ({before})")
+
+
+def status_paths(worktree: Path) -> set[str]:
+    raw = git("status", "--porcelain=v1", "-z", cwd=worktree)
+    if not raw:
+        return set()
+    entries = raw.split("\0")
+    paths: set[str] = set()
+    index = 0
+    while index < len(entries):
+        entry = entries[index]
+        index += 1
+        if not entry:
+            continue
+        if len(entry) < 4:
+            raise ReleaseStateError(f"unrecognised git status entry: {entry!r}")
+        status = entry[:2]
+        path = entry[3:]
+        if "R" in status or "C" in status:
+            if index >= len(entries) or not entries[index]:
+                raise ReleaseStateError("rename/copy status entry is incomplete")
+            paths.add(entries[index])
+            index += 1
+        paths.add(path)
+    return paths
+
+
+def authorization_header(token: str) -> str:
+    encoded = base64.b64encode(f"x-access-token:{token}".encode("utf-8")).decode("ascii")
+    return f"AUTHORIZATION: basic {encoded}"
+
+
+def commit(worktree: Path, message: str, requested_paths: list[str]) -> None:
+    if not message.strip():
+        raise ReleaseStateError("release-state commit message is required")
+    if not requested_paths:
+        raise ReleaseStateError("at least one governed release-state path is required")
+    if TARGET_BRANCH == "main" or "refs/heads/main" in PUSH_REF:
+        raise ReleaseStateError("public main can never be a release-state target")
+
+    allowed = validate_worktree(worktree)
+    requested = {Path(path).as_posix() for path in requested_paths}
+    if ROLE_PATH.as_posix() in requested:
+        raise ReleaseStateError("release-state branch role is immutable")
+    if not requested <= allowed:
+        raise ReleaseStateError(
+            f"unapproved release-state paths requested: {sorted(requested - allowed)}"
+        )
+
+    changed = status_paths(worktree)
+    if not changed:
+        print("Release-state content is already current; no commit required.")
+        write_output("changed", "false")
+        write_output("commit_sha", git("rev-parse", "HEAD", cwd=worktree))
+        return
+    if not changed <= requested:
+        raise ReleaseStateError(
+            f"release-state worktree contains unexpected changes: {sorted(changed - requested)}"
+        )
+
+    role_before = (worktree / ROLE_PATH).read_bytes()
+    git("add", "--", *sorted(requested), cwd=worktree, capture=False)
+    staged = {
+        path
+        for path in git("diff", "--cached", "--name-only", cwd=worktree).splitlines()
+        if path
+    }
+    if not staged or not staged <= requested:
+        raise ReleaseStateError(f"invalid staged release-state paths: {sorted(staged)}")
+    if (worktree / ROLE_PATH).read_bytes() != role_before:
+        raise ReleaseStateError("release-state branch role changed during the operation")
+
+    git(
+        "fetch",
+        "--force",
+        "--no-tags",
+        "origin",
+        f"+refs/heads/{TARGET_BRANCH}:{REMOTE_REF}",
+        cwd=worktree,
+    )
+    head = git("rev-parse", "HEAD", cwd=worktree)
+    remote = git("rev-parse", REMOTE_REF, cwd=worktree)
+    if head != remote:
+        raise ReleaseStateError(
+            "release-state moved after preparation; rerun against the current branch head"
+        )
+
+    git("config", "user.name", "github-actions[bot]", cwd=worktree, capture=False)
+    git(
+        "config",
+        "user.email",
+        "41898282+github-actions[bot]@users.noreply.github.com",
+        cwd=worktree,
+        capture=False,
+    )
+    git("commit", "-m", message, cwd=worktree, capture=False)
+    commit_sha = git("rev-parse", "HEAD", cwd=worktree)
+
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN") or ""
+    if not token:
+        raise ReleaseStateError("GH_TOKEN is required to publish release-state changes")
+    header = authorization_header(token)
+    git(
+        "-c",
+        f"http.https://github.com/.extraheader={header}",
+        "push",
+        "origin",
+        PUSH_REF,
+        cwd=worktree,
+        capture=False,
+    )
+
+    write_output("changed", "true")
+    write_output("commit_sha", commit_sha)
+    print(f"Published governed release-state commit {commit_sha}")
+
+
+def self_test() -> None:
+    role = {
+        "schemaVersion": 1,
+        "branch": "release-state",
+        "mode": "shadow-rehearsal",
+        "authority": "main remains authoritative until Issue #41 cutover",
+        "purpose": "test",
+        "allowedMutablePaths": [
+            "status/release-dashboard.json",
+            "status/README.md",
+            "status/update-manifest.json",
+            ".github/greasyfork-version.txt",
+            ".github/branch-role.json",
+        ],
+        "liveConsumersEnabled": False,
+        "strictProtectionEnabled": False,
+        "administratorRecoveryRequired": True,
+        "cutoverIssue": 41,
+    }
+    allowed = validate_role(role)
+    assert ".github/greasyfork-version.txt" in allowed
+    assert ".github/branch-role.json" not in allowed
+
+    broken = dict(role)
+    broken["branch"] = "main"
+    try:
+        validate_role(broken)
+    except ReleaseStateError:
+        pass
+    else:
+        raise AssertionError("main branch role was accepted")
+
+    broken = json.loads(json.dumps(role))
+    broken["allowedMutablePaths"].append("README.md")
+    try:
+        validate_role(broken)
+    except ReleaseStateError:
+        pass
+    else:
+        raise AssertionError("expanded mutable-path allowlist was accepted")
+
+    assert PUSH_REF == "HEAD:refs/heads/release-state"
+    assert "main" not in PUSH_REF
+    print("Release-state branch writer self-tests passed.")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    subcommands = parser.add_subparsers(dest="command", required=False)
+
+    prepare_parser = subcommands.add_parser("prepare")
+    prepare_parser.add_argument("--worktree", type=Path, required=True)
+
+    commit_parser = subcommands.add_parser("commit")
+    commit_parser.add_argument("--worktree", type=Path, required=True)
+    commit_parser.add_argument("--message", required=True)
+    commit_parser.add_argument("--path", action="append", dest="paths", required=True)
+
+    parser.add_argument("--self-test", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.self_test:
+        self_test()
+        return 0
+    if args.command == "prepare":
+        prepare(args.worktree.resolve())
+        return 0
+    if args.command == "commit":
+        commit(args.worktree.resolve(), args.message, args.paths)
+        return 0
+    raise ReleaseStateError("prepare, commit or --self-test is required")
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ReleaseStateError as error:
+        print(f"release-state operation refused: {error}", file=os.sys.stderr)
+        raise SystemExit(1)

--- a/.github/scripts/sync_shadow_branches.py
+++ b/.github/scripts/sync_shadow_branches.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""Synchronize governed files to Issue #41 shadow branches.
+"""Synchronize only reviewed mirror files to Issue #41 operational branches.
 
 The synchronizer is deliberately non-live. It accepts only the reviewed
-`release-state` and `distribution` branches, preserves `main` as authority,
-requires an exact source SHA and confirmation phrase, and never updates `main`.
+``release-state`` and ``distribution`` branches, preserves operational branch
+state, requires an exact source SHA and confirmation phrase, and never updates
+public ``main``.
 """
 
 from __future__ import annotations
@@ -27,7 +28,7 @@ FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
 
 
 class SyncError(RuntimeError):
-    """A fail-closed synchronization error."""
+    """Fail-closed synchronization error."""
 
 
 def git(*args: str, cwd: Path = ROOT, check: bool = True) -> str:
@@ -43,10 +44,43 @@ def git(*args: str, cwd: Path = ROOT, check: bool = True) -> str:
 
 
 def load_policy(path: Path = POLICY_PATH) -> dict:
-    value = json.loads(path.read_text(encoding="utf-8"))
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise SyncError("Shadow branch policy is missing or invalid") from error
     if not isinstance(value, dict):
         raise SyncError("Shadow branch policy must be a JSON object")
     return value
+
+
+def validate_path_classes(branch: str, branch_policy: dict) -> tuple[list[str], list[str]]:
+    governed = branch_policy.get("governedPaths")
+    mirrored = branch_policy.get("mirroredPaths")
+    operational = branch_policy.get("operationalPaths")
+    if not all(isinstance(value, list) for value in [governed, mirrored, operational]):
+        raise SyncError(f"{branch} governed, mirrored and operational paths must be lists")
+    if not governed or any(not isinstance(path, str) or not path for path in governed):
+        raise SyncError(f"{branch} governedPaths is invalid")
+    if any(not isinstance(path, str) or not path for path in [*mirrored, *operational]):
+        raise SyncError(f"{branch} path classes contain invalid entries")
+    if len(governed) != len(set(governed)):
+        raise SyncError(f"{branch} governedPaths contains duplicates")
+    if set(mirrored) & set(operational):
+        raise SyncError(f"{branch} mirroredPaths and operationalPaths overlap")
+    if set(governed) != set(mirrored) | set(operational):
+        raise SyncError(f"{branch} path classes do not partition governedPaths")
+    if ROLE_PATH in governed:
+        raise SyncError(f"{branch} role file must not be synchronized from main")
+    if branch == "release-state":
+        if operational != [".github/greasyfork-version.txt"]:
+            raise SyncError("release-state operational path must remain the fallback tracker only")
+        if branch_policy.get("operationalWriter") != ".github/workflows/greasyfork-release-monitor.yml":
+            raise SyncError("release-state operational writer changed")
+    if branch == "distribution" and operational:
+        raise SyncError("distribution cannot have operational paths before cutover")
+    if branch_policy.get("externalConsumersEnabled") is not False:
+        raise SyncError(f"{branch} external consumers must remain disabled")
+    return list(mirrored), list(operational)
 
 
 def validate_policy(policy: dict) -> dict:
@@ -89,15 +123,11 @@ def validate_policy(policy: dict) -> dict:
 
     branches = policy.get("branches")
     if not isinstance(branches, dict) or set(branches) != set(allowed_targets):
-        raise SyncError("Shadow branch definitions differ from the writer allowlist")
+        raise SyncError("Operational branch definitions differ from the writer allowlist")
     for branch, branch_policy in branches.items():
         if branch == "main" or not isinstance(branch_policy, dict):
-            raise SyncError("Invalid shadow branch policy")
-        paths = branch_policy.get("governedPaths")
-        if not isinstance(paths, list) or not paths or any(not isinstance(path, str) for path in paths):
-            raise SyncError(f"{branch} governedPaths is invalid")
-        if ROLE_PATH in paths:
-            raise SyncError(f"{branch} role file must not be synchronized from main")
+            raise SyncError("Invalid operational branch policy")
+        validate_path_classes(branch, branch_policy)
     return writer
 
 
@@ -106,7 +136,7 @@ def selected_targets(value: str, writer: dict) -> list[str]:
     if value == "both":
         return allowed
     if value not in allowed or value == "main":
-        raise SyncError(f"Target {value!r} is not an approved shadow branch")
+        raise SyncError(f"Target {value!r} is not an approved operational branch")
     return [value]
 
 
@@ -132,19 +162,33 @@ def validate_request(
         raise SyncError(f"Confirmation must be exactly {required_confirmation!r}")
     if mode != "apply" and write_probe:
         raise SyncError("A write probe is valid only in apply mode")
-    targets = selected_targets(target, writer)
-    return writer, targets
+    return writer, selected_targets(target, writer)
 
 
 def read_branch_json(branch: str, path: str) -> dict:
     raw = git("show", f"refs/remotes/origin/{branch}:{path}")
-    value = json.loads(raw)
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise SyncError(f"Invalid JSON object at {branch}:{path}") from error
     if not isinstance(value, dict):
         raise SyncError(f"Expected JSON object at {branch}:{path}")
     return value
 
 
-def validate_role(branch: str, role: dict, policy: dict) -> None:
+def read_branch_bytes(branch: str, path: str) -> bytes:
+    result = subprocess.run(
+        ["git", "show", f"refs/remotes/origin/{branch}:{path}"],
+        cwd=ROOT,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise SyncError(f"{branch} is missing governed path {path}")
+    return result.stdout
+
+
+def validate_role(branch: str, role: dict, branch_policy: dict) -> None:
     expected = {
         "schemaVersion": 1,
         "branch": branch,
@@ -157,27 +201,26 @@ def validate_role(branch: str, role: dict, policy: dict) -> None:
     for key, expected_value in expected.items():
         if role.get(key) != expected_value:
             raise SyncError(f"{branch} role {key}={role.get(key)!r}, expected {expected_value!r}")
-    allowed = role.get("allowedMutablePaths")
-    expected_allowed = [*policy["governedPaths"], ROLE_PATH]
-    if allowed != expected_allowed:
+    expected_allowed = [*branch_policy["governedPaths"], ROLE_PATH]
+    if role.get("allowedMutablePaths") != expected_allowed:
         raise SyncError(f"{branch} role allowedMutablePaths differs from the reviewed allowlist")
     if "main remains authoritative" not in str(role.get("authority") or ""):
         raise SyncError(f"{branch} role no longer preserves main authority")
 
 
-def file_hash(path: Path) -> str:
-    return hashlib.sha256(path.read_bytes()).hexdigest()
+def file_hash_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
 
 
 def changed_paths(worktree: Path) -> list[str]:
-    changed = set(
+    changed = {
         line.strip()
-        for line in git("-C", str(worktree), "diff", "--name-only").splitlines()
+        for line in git("diff", "--name-only", cwd=worktree).splitlines()
         if line.strip()
-    )
+    }
     changed.update(
         line.strip()
-        for line in git("-C", str(worktree), "ls-files", "--others", "--exclude-standard").splitlines()
+        for line in git("ls-files", "--others", "--exclude-standard", cwd=worktree).splitlines()
         if line.strip()
     )
     return sorted(changed)
@@ -194,12 +237,13 @@ def authenticated_url(repository: str, token: str) -> str:
 def push_branch(*, worktree: Path, branch: str, repository: str, token: str) -> None:
     url = authenticated_url(repository, token)
     result = subprocess.run(
-        ["git", "-C", str(worktree), "push", url, f"HEAD:refs/heads/{branch}"],
+        ["git", "push", url, f"HEAD:refs/heads/{branch}"],
+        cwd=worktree,
         text=True,
         capture_output=True,
     )
     if result.returncode != 0:
-        raise SyncError(f"Owner-authenticated push to {branch} failed")
+        raise SyncError(f"Owner-authenticated non-force push to {branch} failed")
 
 
 def sync_branch(
@@ -213,37 +257,51 @@ def sync_branch(
     token: str,
 ) -> dict:
     if branch == "main" or branch not in {"release-state", "distribution"}:
-        raise SyncError("Refusing non-shadow target")
+        raise SyncError("Refusing non-operational target")
 
+    mirrored_paths, operational_paths = validate_path_classes(branch, branch_policy)
     remote_ref = f"refs/remotes/origin/{branch}"
     before_sha = git("rev-parse", remote_ref).strip()
     role = read_branch_json(branch, ROLE_PATH)
     validate_role(branch, role, branch_policy)
-    paths = list(branch_policy["governedPaths"])
+
     fingerprint = hashlib.sha256(
-        (source_sha + "\0" + branch + "\0" + "\0".join(paths)).encode("utf-8")
+        (
+            source_sha
+            + "\0"
+            + branch
+            + "\0mirrored\0"
+            + "\0".join(mirrored_paths)
+            + "\0operational\0"
+            + "\0".join(operational_paths)
+        ).encode("utf-8")
     ).hexdigest()[:16]
     marker = f"[shadow-sync:{fingerprint}]"
 
     files: list[dict[str, object]] = []
-    for path in paths:
+    for path in mirrored_paths:
         source = ROOT / path
         if not source.is_file() or source.is_symlink():
-            raise SyncError(f"Source governed path is missing or unsafe: {path}")
-        try:
-            branch_bytes = subprocess.run(
-                ["git", "show", f"{remote_ref}:{path}"],
-                cwd=ROOT,
-                check=True,
-                capture_output=True,
-            ).stdout
-        except subprocess.CalledProcessError as exc:
-            raise SyncError(f"{branch} is missing governed path {path}") from exc
+            raise SyncError(f"Source mirrored path is missing or unsafe: {path}")
+        source_bytes = source.read_bytes()
+        branch_bytes = read_branch_bytes(branch, path)
         files.append(
             {
                 "path": path,
-                "equalBefore": source.read_bytes() == branch_bytes,
-                "sourceSha256": file_hash(source),
+                "mode": "mirror",
+                "equalBefore": source_bytes == branch_bytes,
+                "sourceSha256": file_hash_bytes(source_bytes),
+                "branchSha256": file_hash_bytes(branch_bytes),
+            }
+        )
+    for path in operational_paths:
+        branch_bytes = read_branch_bytes(branch, path)
+        files.append(
+            {
+                "path": path,
+                "mode": "operational-preserved",
+                "equalBefore": None,
+                "branchSha256": file_hash_bytes(branch_bytes),
             }
         )
 
@@ -251,55 +309,70 @@ def sync_branch(
         worktree = Path(temporary) / "worktree"
         git("worktree", "add", "--detach", str(worktree), remote_ref)
         try:
-            for path in paths:
+            role_before = (worktree / ROLE_PATH).read_bytes()
+            operational_before = {
+                path: (worktree / path).read_bytes() for path in operational_paths
+            }
+            for path in mirrored_paths:
                 source = ROOT / path
                 destination = worktree / path
                 destination.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copyfile(source, destination)
 
             changed = changed_paths(worktree)
-            unexpected = sorted(set(changed) - set(paths))
+            unexpected = sorted(set(changed) - set(mirrored_paths))
             if unexpected:
-                raise SyncError(f"{branch} synchronization changed non-governed paths: {unexpected}")
-            if ROLE_PATH in changed:
-                raise SyncError(f"{branch} role declaration must remain immutable during sync")
+                raise SyncError(
+                    f"{branch} synchronization changed non-mirrored paths: {unexpected}"
+                )
+            if (worktree / ROLE_PATH).read_bytes() != role_before:
+                raise SyncError(f"{branch} role declaration changed during sync")
+            for path, before in operational_before.items():
+                if (worktree / path).read_bytes() != before:
+                    raise SyncError(f"{branch} operational path was modified during mirror sync: {path}")
 
-            latest_message = git("-C", str(worktree), "log", "-1", "--format=%B")
+            latest_message = git("log", "-1", "--format=%B", cwd=worktree)
             probe_already_recorded = marker in latest_message
-            should_commit = bool(changed) or (mode == "apply" and write_probe and not probe_already_recorded)
+            should_commit = bool(changed) or (
+                mode == "apply" and write_probe and not probe_already_recorded
+            )
             pushed = False
             empty_probe = False
             after_sha = before_sha
 
             if mode == "apply" and should_commit:
-                git("-C", str(worktree), "config", "user.name", "Conroy1988 shadow rehearsal")
+                git("config", "user.name", "Conroy1988 shadow rehearsal", cwd=worktree)
                 git(
-                    "-C",
-                    str(worktree),
                     "config",
                     "user.email",
                     "27301455+Conroy1988@users.noreply.github.com",
+                    cwd=worktree,
                 )
                 if changed:
-                    git("-C", str(worktree), "add", "--", *paths)
+                    git("add", "--", *mirrored_paths, cwd=worktree)
+                    staged = {
+                        path
+                        for path in git("diff", "--cached", "--name-only", cwd=worktree).splitlines()
+                        if path
+                    }
+                    if not staged or not staged <= set(mirrored_paths):
+                        raise SyncError(f"Invalid staged mirror paths: {sorted(staged)}")
                     git(
-                        "-C",
-                        str(worktree),
                         "commit",
                         "-m",
-                        f"Rehearse {branch} shadow sync from {source_sha[:12]} {marker}",
+                        f"Rehearse {branch} mirror sync from {source_sha[:12]} {marker}",
+                        cwd=worktree,
                     )
                 else:
                     empty_probe = True
                     git(
-                        "-C",
-                        str(worktree),
                         "commit",
                         "--allow-empty",
                         "-m",
                         f"Rehearse {branch} shadow writer access from {source_sha[:12]} {marker}",
+                        cwd=worktree,
                     )
-                after_sha = git("-C", str(worktree), "rev-parse", "HEAD").strip()
+                after_sha = git("rev-parse", "HEAD", cwd=worktree).strip()
                 push_branch(
                     worktree=worktree,
                     branch=branch,
@@ -312,6 +385,8 @@ def sync_branch(
                 "branch": branch,
                 "beforeCommit": before_sha,
                 "afterCommit": after_sha,
+                "mirroredPaths": mirrored_paths,
+                "preservedOperationalPaths": operational_paths,
                 "changedPaths": changed,
                 "contentChanged": bool(changed),
                 "emptyProbeCommit": empty_probe,
@@ -334,7 +409,7 @@ def render_markdown(report: dict) -> str:
         f"- Target selection: `{report['targetSelection']}`",
         f"- Generated: `{report['generatedAt']}`",
         "- Public `main` changed: **no**",
-        "- Live consumers changed: **no**",
+        "- External consumers changed: **no**",
         "- Workflow token has contents write: **no**",
         "",
     ]
@@ -346,15 +421,17 @@ def render_markdown(report: dict) -> str:
                 f"- Before: `{branch['beforeCommit']}`",
                 f"- After: `{branch['afterCommit']}`",
                 f"- Pushed: **{'yes' if branch['pushed'] else 'no'}**",
-                f"- Content changed: **{'yes' if branch['contentChanged'] else 'no'}**",
+                f"- Mirror content changed: **{'yes' if branch['contentChanged'] else 'no'}**",
                 f"- Empty write probe: **{'yes' if branch['emptyProbeCommit'] else 'no'}**",
                 "",
             ]
         )
         for path in branch["changedPaths"]:
-            lines.append(f"- Updated governed path: `{path}`")
+            lines.append(f"- Updated mirrored path: `{path}`")
+        for path in branch["preservedOperationalPaths"]:
+            lines.append(f"- Preserved operational path: `{path}`")
         if not branch["changedPaths"]:
-            lines.append("- Governed content already matched `main`.")
+            lines.append("- Mirrored content already matched `main`.")
         lines.append("")
     return "\n".join(lines)
 
@@ -383,8 +460,22 @@ def self_test() -> None:
             "replacementIdentity": "narrowly scoped GitHub App",
         },
         "branches": {
-            "release-state": {"governedPaths": ["status/release-dashboard.json"]},
-            "distribution": {"governedPaths": ["dist/release-manifest.json"]},
+            "release-state": {
+                "governedPaths": [
+                    "status/release-dashboard.json",
+                    ".github/greasyfork-version.txt",
+                ],
+                "mirroredPaths": ["status/release-dashboard.json"],
+                "operationalPaths": [".github/greasyfork-version.txt"],
+                "operationalWriter": ".github/workflows/greasyfork-release-monitor.yml",
+                "externalConsumersEnabled": False,
+            },
+            "distribution": {
+                "governedPaths": ["dist/release-manifest.json"],
+                "mirroredPaths": ["dist/release-manifest.json"],
+                "operationalPaths": [],
+                "externalConsumersEnabled": False,
+            },
         },
     }
     writer, targets = validate_request(
@@ -398,12 +489,28 @@ def self_test() -> None:
     )
     assert writer["sourceBranch"] == "main"
     assert targets == ["release-state", "distribution"]
+    mirrored, operational = validate_path_classes(
+        "release-state", policy["branches"]["release-state"]
+    )
+    assert mirrored == ["status/release-dashboard.json"]
+    assert operational == [".github/greasyfork-version.txt"]
+
     try:
         selected_targets("main", writer)
     except SyncError:
         pass
     else:
         raise AssertionError("main target was not rejected")
+
+    broken = json.loads(json.dumps(policy["branches"]["release-state"]))
+    broken["mirroredPaths"].append(".github/greasyfork-version.txt")
+    try:
+        validate_path_classes("release-state", broken)
+    except SyncError:
+        pass
+    else:
+        raise AssertionError("operational path overlap was accepted")
+
     try:
         validate_request(
             policy=policy,
@@ -478,19 +585,22 @@ def main() -> int:
         for branch in targets
     ]
     report = {
-        "schemaVersion": 1,
+        "schemaVersion": 2,
         "state": "synchronized" if args.mode == "apply" else "planned",
         "acceptable": True,
         "mode": args.mode,
         "targetSelection": args.target,
         "sourceBranch": "main",
         "sourceCommit": args.source_sha,
-        "generatedAt": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "generatedAt": datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z"),
         "authorizedActor": args.actor,
         "credentialMode": "owner-token-rehearsal" if args.mode == "apply" else "read-only-plan",
         "replacementIdentity": "narrowly scoped GitHub App",
         "publicMainChanged": False,
-        "liveConsumersChanged": False,
+        "externalConsumersChanged": False,
         "workflowContentsWrite": False,
         "branches": results,
     }

--- a/.github/scripts/test_branch_write_inventory.py
+++ b/.github/scripts/test_branch_write_inventory.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Enforce the public-main write inventory used by Issue #41."""
+"""Enforce the protected-branch write inventory used by Issue #41."""
 
 from __future__ import annotations
 
@@ -21,9 +21,12 @@ def fail(message: str) -> None:
 
 
 def load_json(path: Path) -> dict:
-    if not path.exists():
+    if not path.is_file():
         fail(f"Required inventory input is missing: {path.relative_to(ROOT)}")
-    return json.loads(path.read_text(encoding="utf-8"))
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        fail(f"Required inventory input is not a JSON object: {path.relative_to(ROOT)}")
+    return value
 
 
 def relative(path: Path) -> str:
@@ -43,26 +46,33 @@ def executable_automation_files() -> list[Path]:
 
 def contains_main_ref_mutation(text: str) -> bool:
     return bool(
-        re.search(r"\bgit\s+push\b[^\n]*(?:HEAD:main|(?:origin|upstream)\s+main(?:\s|$))", text)
+        re.search(r"\bgit\s+push\b[^\n]*(?:HEAD:main|HEAD:refs/heads/main|(?:origin|upstream)\s+main(?:\s|$))", text)
         or re.search(r"\bgit\s+update-ref\s+refs/heads/main\b", text)
         or re.search(r"(?:gh\s+api|curl)[\s\S]{0,240}(?:git/refs/heads/main|refs/heads/main)", text)
     )
+
+
+def require(text: str, markers: list[str], label: str) -> None:
+    for marker in markers:
+        if marker not in text:
+            fail(f"{label} is missing required marker: {marker}")
+
+
+def forbid(text: str, markers: list[str], label: str) -> None:
+    for marker in markers:
+        if marker in text:
+            fail(f"{label} contains forbidden marker: {marker}")
 
 
 def document_mentions(document: str, repository_path: str) -> bool:
     return repository_path in document or Path(repository_path).name in document
 
 
-def require_markers(text: str, markers: list[str], label: str) -> None:
-    for marker in markers:
-        if marker not in text:
-            fail(f"{label} is missing required marker: {marker}")
-
-
-def forbid_markers(text: str, markers: list[str], label: str) -> None:
-    for marker in markers:
-        if marker in text:
-            fail(f"{label} contains forbidden mutation marker: {marker}")
+def workflow_set(entries: list[dict]) -> set[str]:
+    result = {str(entry.get("workflow") or "") for entry in entries}
+    if "" in result:
+        fail("Every classified workflow requires a repository-relative path")
+    return result
 
 
 def main() -> int:
@@ -78,24 +88,24 @@ def main() -> int:
     direct_entries = inventory.get("directMainWriters") or []
     orchestrator_entries = inventory.get("indirectMainWriteOrchestrators") or []
     artifact_entries = inventory.get("artifactOnlyEvidenceWorkflows") or []
+    state_entries = inventory.get("releaseStateBranchWriters") or []
     external_entries = inventory.get("externalRepositoryMainPushSources") or []
     review_entries = inventory.get("reviewBranchWriters") or []
+    shadow_entries = inventory.get("shadowBranchWriters") or []
 
-    direct_workflows = {str(entry.get("workflow") or "") for entry in direct_entries}
-    orchestrator_workflows = {str(entry.get("workflow") or "") for entry in orchestrator_entries}
-    artifact_workflows = {str(entry.get("workflow") or "") for entry in artifact_entries}
-    classified_contents = direct_workflows | orchestrator_workflows
+    direct = workflow_set(direct_entries)
+    orchestrators = workflow_set(orchestrator_entries)
+    artifacts = workflow_set(artifact_entries)
+    state_writers = workflow_set(state_entries)
 
-    if "" in direct_workflows | orchestrator_workflows | artifact_workflows:
-        fail("Every classified workflow requires a repository-relative path")
-    if direct_workflows & orchestrator_workflows:
-        fail("A workflow cannot be both a direct main writer and an orchestrator")
-    if artifact_workflows & classified_contents:
-        fail("Artifact-only workflows cannot retain contents-write classification")
-    if len(direct_workflows) != 3:
-        fail(f"Expected three reviewed direct public-main writers, found {len(direct_workflows)}")
-    if len(orchestrator_workflows) != 2:
-        fail(f"Expected two reviewed release orchestrators, found {len(orchestrator_workflows)}")
+    expected_direct = {
+        ".github/workflows/release-recovery.yml",
+        ".github/workflows/release-toolkit.yml",
+    }
+    expected_orchestrators = {
+        ".github/workflows/auto-release-after-validation.yml",
+        ".github/workflows/owner-release-command.yml",
+    }
     expected_artifacts = {
         ".github/workflows/validate-userscript.yml",
         ".github/workflows/release-toolkit-dry-run.yml",
@@ -105,8 +115,22 @@ def main() -> int:
         ".github/workflows/reconcile-release-announcement-state.yml",
         ".github/workflows/publish-update-manifest.yml",
     }
-    if artifact_workflows != expected_artifacts:
-        fail(f"Unexpected artifact-only workflow inventory: {sorted(artifact_workflows)}")
+    expected_state_writers = {".github/workflows/greasyfork-release-monitor.yml"}
+
+    if direct != expected_direct:
+        fail(f"Unexpected direct public-main writers: {sorted(direct)}")
+    if orchestrators != expected_orchestrators:
+        fail(f"Unexpected release orchestrators: {sorted(orchestrators)}")
+    if artifacts != expected_artifacts:
+        fail(f"Unexpected artifact-only workflow inventory: {sorted(artifacts)}")
+    if state_writers != expected_state_writers:
+        fail(f"Unexpected release-state writer inventory: {sorted(state_writers)}")
+
+    classified_groups = [direct, orchestrators, artifacts, state_writers]
+    for index, left in enumerate(classified_groups):
+        for right in classified_groups[index + 1 :]:
+            if left & right:
+                fail(f"Workflow classifications overlap: {sorted(left & right)}")
 
     policy_contents = {
         path
@@ -114,6 +138,7 @@ def main() -> int:
         if "contents" in (permissions or [])
     }
     inventory_contents = set(inventory.get("contentsWriteAuthority") or [])
+    classified_contents = direct | orchestrators | state_writers
     if policy_contents != inventory_contents:
         fail(
             "Contents-write authority differs between policy and inventory: "
@@ -122,7 +147,7 @@ def main() -> int:
         )
     if classified_contents != inventory_contents:
         fail(
-            "Every contents-write workflow must be classified: "
+            "Every contents-write workflow must have an explicit branch class: "
             f"unclassified={sorted(inventory_contents - classified_contents)}, "
             f"unexpected={sorted(classified_contents - inventory_contents)}"
         )
@@ -139,7 +164,8 @@ def main() -> int:
             f"inventory-only={sorted(inventory_contents - declared_contents_write)}"
         )
 
-    for workflow in sorted(classified_contents | artifact_workflows):
+    all_classified = direct | orchestrators | artifacts | state_writers
+    for workflow in sorted(all_classified):
         path = ROOT / workflow
         if not path.is_file():
             fail(f"Classified workflow is missing: {workflow}")
@@ -160,11 +186,10 @@ def main() -> int:
             f"unclassified={sorted(discovered_main_sources - expected_all_sources)}, "
             f"missing={sorted(expected_all_sources - discovered_main_sources)}"
         )
-    missing_direct_pushes = direct_workflows - expected_public_sources
-    if missing_direct_pushes:
-        fail(f"Direct writers missing from directMainPushSources: {sorted(missing_direct_pushes)}")
-    if (orchestrator_workflows | artifact_workflows) & discovered_main_sources:
-        fail("Orchestrator and artifact-only workflows must not mutate public main")
+    if direct - expected_public_sources:
+        fail(f"Direct writers missing from directMainPushSources: {sorted(direct - expected_public_sources)}")
+    if (orchestrators | artifacts | state_writers) & discovered_main_sources:
+        fail("Non-main workflow classes must not mutate public main")
 
     for entry in orchestrator_entries:
         workflow = str(entry["workflow"])
@@ -173,130 +198,122 @@ def main() -> int:
         if invoked.replace(".github/workflows/", "./.github/workflows/") not in text:
             fail(f"Orchestrator {workflow} no longer invokes {invoked}")
 
-    dry_run = (ROOT / ".github/workflows/release-toolkit-dry-run.yml").read_text(encoding="utf-8")
-    require_markers(dry_run, [
-        "permissions:\n  contents: read",
-        "persist-credentials: false",
-        "Write immutable dry-run evidence",
-        "publicMainChanged: false",
-        "Upload reviewable release bundle and evidence",
-    ], "Artifact-only dry-run workflow")
-    forbid_markers(dry_run, [
-        "contents: write", "status/release-dashboard.json", "git commit", "git push",
-        "git pull --rebase", "github-actions[bot]",
-    ], "Artifact-only dry-run workflow")
+    artifact_markers = {
+        ".github/workflows/validate-userscript.yml": [
+            "permissions:\n  contents: read",
+            "persist-credentials: false",
+            "Write immutable validation candidate evidence",
+        ],
+        ".github/workflows/release-toolkit-dry-run.yml": [
+            "permissions:\n  contents: read",
+            "persist-credentials: false",
+            "Upload reviewable release bundle and evidence",
+        ],
+        ".github/workflows/repository-audit.yml": [
+            "permissions:\n  contents: read",
+            "persist-credentials: false",
+            "Upload immutable audit reports",
+        ],
+        ".github/workflows/update-release-dashboard.yml": [
+            "permissions:\n  contents: read",
+            "persist-credentials: false",
+            "Upload dashboard projection evidence",
+        ],
+        ".github/workflows/import-canonical-userscript.yml": [
+            "permissions:\n  contents: read",
+            "persist-credentials: false",
+            "Upload immutable parity evidence",
+        ],
+        ".github/workflows/reconcile-release-announcement-state.yml": [
+            "permissions:\n  contents: read",
+            "persist-credentials: false",
+            "Upload immutable announcement-state evidence",
+        ],
+        ".github/workflows/publish-update-manifest.yml": [
+            "permissions:\n  contents: read",
+            "persist-credentials: false",
+            "Upload immutable update-manifest evidence",
+        ],
+    }
+    for workflow, markers in artifact_markers.items():
+        text = (ROOT / workflow).read_text(encoding="utf-8")
+        require(text, markers, workflow)
+        forbid(
+            text,
+            ["contents: write", "git push origin HEAD:main", "git push origin HEAD:refs/heads/main"],
+            workflow,
+        )
 
-    repository_workflow = (ROOT / ".github/workflows/repository-audit.yml").read_text(encoding="utf-8")
-    repository_script = (ROOT / ".github/scripts/audit_repository.py").read_text(encoding="utf-8")
-    require_markers(repository_workflow, [
-        "permissions:\n  contents: read",
-        "persist-credentials: false",
-        "REPOSITORY_AUDIT_OUTPUT_DIR: repository-audit-output",
-        "Upload immutable audit reports",
-        "storage.publicMainChanged == false",
-        "storage.releaseDashboardChanged == false",
-    ], "Artifact-only repository-audit workflow")
-    forbid_markers(repository_workflow, [
-        "contents: write", "status/release-dashboard.json", "git commit", "git push",
-        "git pull --rebase", "github-actions[bot]",
-    ], "Artifact-only repository-audit workflow")
-    require_markers(repository_script, [
-        '"type": "workflow-artifact"',
-        '"publicMainChanged": False',
-        '"releaseDashboardChanged": False',
-        "REPOSITORY_AUDIT_OUTPUT_DIR",
-    ], "Repository-audit script")
-    forbid_markers(repository_script, [
-        'ROOT / "status" / "release-dashboard.json"',
-        'dashboard["currentVersion"]',
-        'dashboard["status"]',
-        'dashboard["lastUpdated"]',
-    ], "Repository-audit script")
+    if len(state_entries) != 1:
+        fail(f"Expected one release-state writer, found {len(state_entries)}")
+    state_entry = state_entries[0]
+    expected_state = {
+        "workflow": ".github/workflows/greasyfork-release-monitor.yml",
+        "helper": ".github/scripts/release_state_branch.py",
+        "sourceAuthority": "main release dashboard",
+        "target": "release-state",
+        "writes": [".github/greasyfork-version.txt"],
+        "credential": "github.token",
+        "actor": "github-actions[bot]",
+        "mainMutationAllowed": False,
+        "forcePushAllowed": False,
+        "liveConsumerCutoverAllowed": False,
+        "migrationState": "transitional fallback-tracker authority",
+    }
+    if state_entry != expected_state:
+        fail("Release-state fallback-monitor inventory changed")
 
-    dashboard_workflow = (ROOT / ".github/workflows/update-release-dashboard.yml").read_text(encoding="utf-8")
-    dashboard_generator = (ROOT / ".github/scripts/generate_release_dashboard.py").read_text(encoding="utf-8")
-    require_markers(dashboard_workflow, [
-        "permissions:\n  contents: read",
-        "persist-credentials: false",
-        "Generate and compare read-only dashboard projection",
-        "--check",
-        "--output dashboard-projection/status-README.md",
-        "cmp --silent status/README.md dashboard-projection/status-README.md",
-        "Upload dashboard projection evidence",
-        "Public main changed: no",
-    ], "Artifact-only dashboard-projection workflow")
-    forbid_markers(dashboard_workflow, [
-        "contents: write", "git commit", "git push", "git pull --rebase", "github-actions[bot]",
-    ], "Artifact-only dashboard-projection workflow")
-    require_markers(dashboard_generator, [
-        'parser.add_argument("--output"',
-        '"--check"',
-        "if args.check:",
-        "Dashboard ledger sanitation would change the committed JSON",
-        "def render_dashboard(data: dict) -> str:",
-    ], "Dashboard generator projection mode")
-
-    parity_workflow = (ROOT / ".github/workflows/import-canonical-userscript.yml").read_text(encoding="utf-8")
-    parity_auditor = (ROOT / ".github/scripts/audit_greasyfork_canonical_parity.py").read_text(encoding="utf-8")
-    require_markers(parity_workflow, [
-        "name: Verify Greasy Fork Canonical Parity",
-        "permissions:\n  contents: read",
-        "persist-credentials: false",
-        "Audit GitHub canonical authority",
-        "Upload immutable parity evidence",
-        "missionchief-greasyfork-canonical-parity-${{ github.sha }}",
-        "Automatic importing is retired; owner review is required.",
-    ], "Artifact-only Greasy Fork parity workflow")
-    forbid_markers(parity_workflow, [
-        "contents: write", "git commit", "git push", "git pull --rebase",
-        "github-actions[bot]", "DEVELOPMENT_PR_TOKEN", "gh pr create",
-    ], "Artifact-only Greasy Fork parity workflow")
-    require_markers(parity_auditor, [
-        '"authority": "GitHub canonical source"',
-        '"automaticImportEnabled": False',
-        '"publicMainChanged": False',
-        '"canonicalSourceChanged": False',
-        '"sourceBaselineChanged": False',
-        '"liveAheadRequiresOwnerReview": True',
-    ], "Greasy Fork parity auditor")
-
-    announcement_workflow = (ROOT / ".github/workflows/reconcile-release-announcement-state.yml").read_text(encoding="utf-8")
-    require_markers(announcement_workflow, [
-        "name: Verify Release Announcement State",
-        "permissions:\n  contents: read",
-        "persist-credentials: false",
-        "Verify dashboard and announcement tracker",
-        "announcementTrackerChanged: false",
-        "Upload immutable announcement-state evidence",
-        "missionchief-release-announcement-state-${{ github.sha }}",
-        "No automatic mutation was attempted.",
-    ], "Artifact-only announcement-state workflow")
-    forbid_markers(announcement_workflow, [
-        "contents: write", "git commit", "git push", "git pull --rebase",
-        "github-actions[bot]", "git reset --hard",
-    ], "Artifact-only announcement-state workflow")
-
-    manifest_workflow = (ROOT / ".github/workflows/publish-update-manifest.yml").read_text(encoding="utf-8")
-    manifest_builder = (ROOT / ".github/scripts/build_stable_update_manifest.py").read_text(encoding="utf-8")
-    require_markers(manifest_workflow, [
-        "name: Verify Toolkit Update Manifest",
-        "permissions:\n  contents: read",
-        "persist-credentials: false",
-        "Verify committed manifest against release ledger",
-        "--check",
-        "Upload immutable update-manifest evidence",
-        "missionchief-update-manifest-verification-${{ github.sha }}",
-        "No repository mutation was attempted.",
-    ], "Artifact-only update-manifest workflow")
-    forbid_markers(manifest_workflow, [
-        "contents: write", "git commit", "git push", "git pull --rebase", "github-actions[bot]",
-    ], "Artifact-only update-manifest workflow")
-    require_markers(manifest_builder, [
-        "def build_manifest(dashboard: dict, settings: dict)",
-        '"publicMainChanged": False',
-        '"releaseDashboardChanged": False',
-        "Stable update manifest self-tests passed.",
-    ], "Stable update-manifest builder")
+    monitor = (ROOT / state_entry["workflow"]).read_text(encoding="utf-8")
+    helper = (ROOT / state_entry["helper"]).read_text(encoding="utf-8")
+    require(
+        monitor,
+        [
+            "Check out latest main authority",
+            "persist-credentials: false",
+            "Prepare governed release-state worktree",
+            "release_state_branch.py prepare",
+            "RELEASE_STATE_ROOT/.github/greasyfork-version.txt",
+            "DASHBOARD_FILE=\"status/release-dashboard.json\"",
+            "Reconcile release-state tracker from verified main dashboard",
+            "Record announced version on release-state",
+            "release_state_branch.py commit",
+            "GH_TOKEN: ${{ github.token }}",
+        ],
+        "Greasy Fork fallback monitor",
+    )
+    forbid(
+        monitor,
+        [
+            "git push origin HEAD:main",
+            "git push origin HEAD:refs/heads/main",
+            "git reset --hard origin/main",
+            "STATE_FILE=\".github/greasyfork-version.txt\"",
+        ],
+        "Greasy Fork fallback monitor",
+    )
+    require(
+        helper,
+        [
+            'TARGET_BRANCH = "release-state"',
+            'PUSH_REF = f"HEAD:refs/heads/{TARGET_BRANCH}"',
+            "release-state branch role is immutable",
+            "release-state moved after preparation",
+            "http.https://github.com/.extraheader",
+            "Release-state branch writer self-tests passed.",
+        ],
+        "Release-state branch helper",
+    )
+    forbid(
+        helper,
+        [
+            'TARGET_BRANCH = "main"',
+            "HEAD:refs/heads/main",
+            "--force",
+            "force-with-lease",
+            "git reset --hard origin/main",
+        ],
+        "Release-state branch helper",
+    )
 
     for entry in external_entries:
         path = ROOT / str(entry["path"])
@@ -316,23 +333,33 @@ def main() -> int:
         if str(entry.get("credential") or "") not in workflow.read_text(encoding="utf-8"):
             fail(f"Review-branch writer no longer uses reviewed credential: {relative(workflow)}")
 
+    if len(shadow_entries) != 1:
+        fail(f"Expected one shadow synchronization writer, found {len(shadow_entries)}")
+    shadow_workflow = ROOT / str(shadow_entries[0].get("workflow") or "")
+    if not shadow_workflow.is_file():
+        fail("Shadow synchronization workflow is missing")
+    if relative(shadow_workflow) in discovered_main_sources:
+        fail("Shadow synchronization workflow must not mutate public main")
+
     for path in sorted(expected_public_sources | expected_external_sources):
         if not document_mentions(document, path):
             fail(f"Human inventory omits executable write source: {path}")
 
     for claim in [
         "Strict pull-request-only protection is **not yet safe to enable**",
-        "three workflows that can commit directly to public `main`",
-        "Canonical validation, release dry runs, repository audits, dashboard projection, Greasy Fork parity, announcement-state verification and stable update-manifest verification are now artifact-only",
+        "two workflows that can commit directly to public `main`",
+        "seven workflows use read-only repository access",
+        "fallback announcement tracker is now written only to `release-state`",
     ]:
         if claim not in document:
             fail(f"Human inventory is missing migration claim: {claim}")
 
     print(
         "Branch-write inventory passed: "
-        f"{len(direct_workflows)} direct main writers, "
-        f"{len(orchestrator_workflows)} orchestrators, "
-        f"{len(artifact_workflows)} artifact-only workflows, "
+        f"{len(direct)} direct main writers, "
+        f"{len(state_writers)} release-state writer, "
+        f"{len(orchestrators)} orchestrators, "
+        f"{len(artifacts)} artifact-only workflows, "
         f"{len(review_entries)} review-branch writers and "
         f"{len(external_entries)} external-repository writer."
     )

--- a/.github/scripts/test_release_state_monitor_pipeline.py
+++ b/.github/scripts/test_release_state_monitor_pipeline.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Contracts for the transitional Greasy Fork fallback tracker on release-state."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "greasyfork-release-monitor.yml"
+HELPER = ROOT / ".github" / "scripts" / "release_state_branch.py"
+INVENTORY = ROOT / ".github" / "branch-write-inventory.json"
+POLICY = ROOT / ".github" / "actions-security-policy.json"
+ROLE_POLICY = ROOT / ".github" / "shadow-branch-policy.json"
+DOCUMENT = ROOT / "docs" / "BRANCH_WRITE_INVENTORY.md"
+
+
+def require(text: str, markers: list[str], label: str) -> None:
+    for marker in markers:
+        if marker not in text:
+            raise AssertionError(f"{label} is missing required marker: {marker}")
+
+
+def forbid(text: str, markers: list[str], label: str) -> None:
+    for marker in markers:
+        if marker in text:
+            raise AssertionError(f"{label} contains forbidden marker: {marker}")
+
+
+def main() -> int:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    helper = HELPER.read_text(encoding="utf-8")
+    inventory = json.loads(INVENTORY.read_text(encoding="utf-8"))
+    policy = json.loads(POLICY.read_text(encoding="utf-8"))
+    role_policy = json.loads(ROLE_POLICY.read_text(encoding="utf-8"))
+    document = DOCUMENT.read_text(encoding="utf-8")
+
+    entries = inventory.get("releaseStateBranchWriters") or []
+    if len(entries) != 1:
+        raise AssertionError(f"Expected one release-state branch writer, found {len(entries)}")
+    entry = entries[0]
+    expected = {
+        "workflow": ".github/workflows/greasyfork-release-monitor.yml",
+        "helper": ".github/scripts/release_state_branch.py",
+        "sourceAuthority": "main release dashboard",
+        "target": "release-state",
+        "writes": [".github/greasyfork-version.txt"],
+        "credential": "github.token",
+        "actor": "github-actions[bot]",
+        "mainMutationAllowed": False,
+        "forcePushAllowed": False,
+        "liveConsumerCutoverAllowed": False,
+        "migrationState": "transitional fallback-tracker authority",
+    }
+    if entry != expected:
+        raise AssertionError("Fallback-monitor release-state inventory changed")
+
+    permissions = policy.get("allowedWritePermissions") or {}
+    if permissions.get(entry["workflow"]) != ["contents"]:
+        raise AssertionError("Fallback monitor contents-write permission changed")
+
+    release_state = (role_policy.get("branches") or {}).get("release-state") or {}
+    governed = set(release_state.get("governedPaths") or [])
+    if ".github/greasyfork-version.txt" not in governed:
+        raise AssertionError("Release-state policy no longer governs the fallback tracker")
+
+    require(
+        workflow,
+        [
+            "name: Greasy Fork Release Fallback Monitor",
+            "permissions:\n  contents: write",
+            "group: toolkit-production-release",
+            "Check out latest main authority",
+            "ref: main",
+            "persist-credentials: false",
+            "Prepare governed release-state worktree",
+            "release_state_branch.py --self-test",
+            "release_state_branch.py prepare",
+            "RELEASE_STATE_ROOT: ${{ steps.release_state.outputs.root }}",
+            "STATE_FILE=\"$RELEASE_STATE_ROOT/.github/greasyfork-version.txt\"",
+            "DASHBOARD_FILE=\"status/release-dashboard.json\"",
+            "Reconcile release-state tracker from verified main dashboard",
+            "git show origin/release-state:.github/greasyfork-version.txt",
+            "git show origin/main:status/release-dashboard.json",
+            "Record announced version on release-state",
+            "release_state_branch.py commit",
+            "--path .github/greasyfork-version.txt",
+            "GH_TOKEN: ${{ github.token }}",
+        ],
+        "Fallback monitor workflow",
+    )
+    forbid(
+        workflow,
+        [
+            "git push origin HEAD:main",
+            "git push origin HEAD:refs/heads/main",
+            "git reset --hard origin/main",
+            "git add \"$STATE_FILE\"",
+            "STATE_FILE=\".github/greasyfork-version.txt\"",
+            "DEVELOPMENT_PR_TOKEN",
+            "MIGRATION_REPO_TOKEN",
+        ],
+        "Fallback monitor workflow",
+    )
+
+    require(
+        helper,
+        [
+            'TARGET_BRANCH = "release-state"',
+            'REMOTE_REF = f"refs/remotes/origin/{TARGET_BRANCH}"',
+            'PUSH_REF = f"HEAD:refs/heads/{TARGET_BRANCH}"',
+            'ROLE_PATH = Path(".github/branch-role.json")',
+            '"mode": "shadow-rehearsal"',
+            "release-state mutable-path allowlist changed",
+            "release-state branch role is immutable",
+            "release-state moved after preparation",
+            "GH_TOKEN is required to publish release-state changes",
+            "http.https://github.com/.extraheader",
+            "Release-state branch writer self-tests passed.",
+        ],
+        "Release-state writer helper",
+    )
+    forbid(
+        helper,
+        [
+            'TARGET_BRANCH = "main"',
+            "HEAD:refs/heads/main",
+            "--force",
+            "force-with-lease",
+            "git reset --hard origin/main",
+            '"README.md"',
+        ],
+        "Release-state writer helper",
+    )
+
+    for marker in [
+        "fallback announcement tracker is now written only to `release-state`",
+        "release_state_branch.py",
+        "greasyfork-release-monitor.yml",
+        "two workflows that can commit directly to public `main`",
+    ]:
+        if marker not in document:
+            raise AssertionError(f"Human inventory is missing monitor migration marker: {marker}")
+
+    result = subprocess.run(["python3", str(HELPER), "--self-test"], cwd=ROOT)
+    if result.returncode != 0:
+        raise AssertionError("Release-state branch helper self-tests failed")
+
+    print(
+        "Fallback monitor release-state contract passed: main dashboard authority, "
+        "single governed tracker path, no main mutation and normal non-force branch push."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_release_state_monitor_pipeline.py
+++ b/.github/scripts/test_release_state_monitor_pipeline.py
@@ -129,7 +129,6 @@ def main() -> int:
             "--force",
             "force-with-lease",
             "git reset --hard origin/main",
-            '"README.md"',
         ],
         "Release-state writer helper",
     )

--- a/.github/scripts/test_shadow_branch_parity.py
+++ b/.github/scripts/test_shadow_branch_parity.py
@@ -90,7 +90,7 @@ def main() -> int:
         script,
         [
             "Mirrored paths must remain byte-identical",
-            "Transitional operational paths may differ",
+            "operational paths may differ",
             'POLICY_PATH = ROOT / ".github" / "shadow-branch-policy.json"',
             '"release-state"',
             '"distribution"',

--- a/.github/scripts/test_shadow_branch_parity.py
+++ b/.github/scripts/test_shadow_branch_parity.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Contracts for Issue #41 read-only shadow branch rehearsal."""
+"""Contracts for Issue #41 read-only operational branch governance."""
 
 from __future__ import annotations
 
@@ -45,69 +45,118 @@ def main() -> int:
 
     branches = policy.get("branches") or {}
     if set(branches) != {"release-state", "distribution"}:
-        raise AssertionError(f"Unexpected shadow branches: {sorted(branches)}")
-    if branches["release-state"].get("governedPaths") != [
+        raise AssertionError(f"Unexpected operational branches: {sorted(branches)}")
+
+    release_state = branches["release-state"]
+    if release_state.get("governedPaths") != [
         "status/release-dashboard.json",
         "status/README.md",
         "status/update-manifest.json",
         ".github/greasyfork-version.txt",
     ]:
         raise AssertionError("release-state governed paths changed")
-    if branches["distribution"].get("governedPaths") != [
+    if release_state.get("mirroredPaths") != [
+        "status/release-dashboard.json",
+        "status/README.md",
+        "status/update-manifest.json",
+    ]:
+        raise AssertionError("release-state mirrored paths changed")
+    if release_state.get("operationalPaths") != [".github/greasyfork-version.txt"]:
+        raise AssertionError("release-state operational paths changed")
+    if release_state.get("operationalWriter") != ".github/workflows/greasyfork-release-monitor.yml":
+        raise AssertionError("release-state operational writer changed")
+    if release_state.get("externalConsumersEnabled") is not False:
+        raise AssertionError("release-state external consumers must remain disabled")
+
+    distribution = branches["distribution"]
+    expected_distribution = [
         "dist/MissionChief_Map_Command_Toolkit.user.js",
         "dist/MissionChief_Map_Command_Toolkit.txt",
         "dist/SHA256SUMS.txt",
         "dist/release-manifest.json",
         "MissionChief_Map_Command_Toolkit.user.js",
         "MissionChief_Map_Command_Toolkit.txt",
-    ]:
+    ]
+    if distribution.get("governedPaths") != expected_distribution:
         raise AssertionError("distribution governed paths changed")
+    if distribution.get("mirroredPaths") != expected_distribution:
+        raise AssertionError("distribution mirrored paths changed")
+    if distribution.get("operationalPaths") != []:
+        raise AssertionError("distribution cannot have operational paths before cutover")
+    if distribution.get("externalConsumersEnabled") is not False:
+        raise AssertionError("distribution external consumers must remain disabled")
 
-    require(script, [
-        '"release-state"',
-        '"distribution"',
-        '"mode": "shadow-rehearsal"',
-        '"liveConsumersEnabled": False',
-        '"strictProtectionEnabled": False',
-        '"administratorRecoveryRequired": True',
-        '"cutoverIssue": 41',
-        '"publicMainChanged": False',
-        '"liveConsumersChanged": False',
-        "Shadow branch parity self-tests passed.",
-    ], "Shadow branch verifier")
-    forbid(script, [
-        "git push",
-        "git commit",
-        "git update-ref",
-        "gh api",
-        "DEVELOPMENT_PR_TOKEN",
-    ], "Shadow branch verifier")
+    require(
+        script,
+        [
+            "Mirrored paths must remain byte-identical",
+            "Transitional operational paths may differ",
+            'POLICY_PATH = ROOT / ".github" / "shadow-branch-policy.json"',
+            '"release-state"',
+            '"distribution"',
+            '"mode": "shadow-rehearsal"',
+            '"liveConsumersEnabled": False',
+            '"strictProtectionEnabled": False',
+            '"administratorRecoveryRequired": True',
+            '"cutoverIssue": 41',
+            'operational != [".github/greasyfork-version.txt"]',
+            "validate_operational_content",
+            'SEMVER.fullmatch(value)',
+            '"schemaVersion": 2',
+            '"publicMainChanged": False',
+            '"externalConsumersChanged": False',
+            "Shadow branch parity self-tests passed.",
+        ],
+        "Operational branch verifier",
+    )
+    forbid(
+        script,
+        [
+            "git push",
+            "git commit",
+            "git update-ref",
+            "gh api",
+            "DEVELOPMENT_PR_TOKEN",
+            "contents: write",
+        ],
+        "Operational branch verifier",
+    )
 
-    require(workflow, [
-        "name: Verify Shadow Branch Parity",
-        "permissions:\n  contents: read",
-        "persist-credentials: false",
-        "Fetch shadow branch refs read-only",
-        "+refs/heads/release-state:refs/remotes/origin/release-state",
-        "+refs/heads/distribution:refs/remotes/origin/distribution",
-        "Verify governed paths and branch roles",
-        "Upload immutable shadow-branch evidence",
-        "missionchief-shadow-branch-parity-${{ github.sha }}",
-        "No branch mutation was attempted.",
-    ], "Shadow branch parity workflow")
-    forbid(workflow, [
-        "contents: write",
-        "git push",
-        "git commit",
-        "github-actions[bot]",
-        "DEVELOPMENT_PR_TOKEN",
-    ], "Shadow branch parity workflow")
+    require(
+        workflow,
+        [
+            "name: Verify Shadow Branch Parity",
+            "permissions:\n  contents: read",
+            "persist-credentials: false",
+            "Fetch shadow branch refs read-only",
+            "+refs/heads/release-state:refs/remotes/origin/release-state",
+            "+refs/heads/distribution:refs/remotes/origin/distribution",
+            "Verify governed paths and branch roles",
+            "Upload immutable shadow-branch evidence",
+            "missionchief-shadow-branch-parity-${{ github.sha }}",
+        ],
+        "Operational branch verification workflow",
+    )
+    forbid(
+        workflow,
+        [
+            "contents: write",
+            "git push",
+            "git commit",
+            "github-actions[bot]",
+            "DEVELOPMENT_PR_TOKEN",
+        ],
+        "Operational branch verification workflow",
+    )
 
     result = subprocess.run(["python3", str(SCRIPT), "--self-test"], cwd=ROOT)
     if result.returncode != 0:
-        raise AssertionError("Shadow branch verifier self-tests failed")
+        raise AssertionError("Operational branch verifier self-tests failed")
 
-    print("Shadow branch rehearsal passed: read-only roles, governed paths and no live cutover.")
+    print(
+        "Operational branch governance passed: mirrored paths remain equal, "
+        "the fallback tracker has a reviewed schema, and no external cutover is enabled."
+    )
     return 0
 
 

--- a/.github/scripts/test_shadow_sync_writer.py
+++ b/.github/scripts/test_shadow_sync_writer.py
@@ -129,7 +129,7 @@ def main() -> int:
         script,
         [
             "Synchronize only reviewed mirror files",
-            "preserves operational branch state",
+            "preserves operational branch",
             'value == "main"',
             'branch == "main"',
             'f"HEAD:refs/heads/{branch}"',

--- a/.github/scripts/test_shadow_sync_writer.py
+++ b/.github/scripts/test_shadow_sync_writer.py
@@ -51,9 +51,18 @@ def main() -> int:
         "liveConsumerCutoverAllowed": False,
         "replacementIdentity": "narrowly scoped GitHub App",
     }
-    for key, expected in expected_writer.items():
-        if writer.get(key) != expected:
-            raise AssertionError(f"writerRehearsal {key}={writer.get(key)!r}, expected {expected!r}")
+    if writer != expected_writer:
+        raise AssertionError("writerRehearsal policy changed")
+
+    release_state = (policy.get("branches") or {}).get("release-state") or {}
+    if release_state.get("mirroredPaths") != [
+        "status/release-dashboard.json",
+        "status/README.md",
+        "status/update-manifest.json",
+    ]:
+        raise AssertionError("release-state mirror allowlist changed")
+    if release_state.get("operationalPaths") != [".github/greasyfork-version.txt"]:
+        raise AssertionError("release-state operational allowlist changed")
 
     entries = inventory.get("shadowBranchWriters") or []
     if len(entries) != 1:
@@ -119,15 +128,24 @@ def main() -> int:
     require(
         script,
         [
-            '"release-state"',
-            '"distribution"',
+            "Synchronize only reviewed mirror files",
+            "preserves operational branch state",
             'value == "main"',
             'branch == "main"',
             'f"HEAD:refs/heads/{branch}"',
+            'mirrored = branch_policy.get("mirroredPaths")',
+            'operational = branch_policy.get("operationalPaths")',
+            'operational != [".github/greasyfork-version.txt"]',
+            'mirrored_paths, operational_paths = validate_path_classes',
+            'for path in mirrored_paths:',
+            'for path in operational_paths:',
+            '"mode": "operational-preserved"',
+            '"preservedOperationalPaths": operational_paths',
+            "operational path was modified during mirror sync",
             '"DEVELOPMENT_PR_TOKEN is required for apply mode"',
             '"owner-token-rehearsal"',
             '"publicMainChanged": False',
-            '"liveConsumersChanged": False',
+            '"externalConsumersChanged": False',
             '"workflowContentsWrite": False',
             '"narrowly scoped GitHub App"',
             "Shadow synchronization self-tests passed.",
@@ -141,6 +159,10 @@ def main() -> int:
             "git update-ref refs/heads/main",
             "git push origin HEAD:main",
             '"liveConsumerCutoverAllowed": True',
+            'paths = list(branch_policy["governedPaths"])',
+            "shutil.copyfile(ROOT / path, worktree / path)",
+            "push --force",
+            "force-with-lease",
         ],
         "Shadow sync script",
     )
@@ -151,7 +173,8 @@ def main() -> int:
         "DEVELOPMENT_PR_TOKEN",
         "release-state",
         "distribution",
-        "cannot update public `main`",
+        "public `main` rejected as a target",
+        "manual synchronizer copies only `mirroredPaths`",
     ]:
         if marker not in document:
             raise AssertionError(f"Human inventory is missing shadow writer marker: {marker}")
@@ -160,7 +183,10 @@ def main() -> int:
     if result.returncode != 0:
         raise AssertionError("Shadow synchronization self-tests failed")
 
-    print("Shadow sync writer passed: manual owner confirmation, fixed targets, read-only workflow permission and no main mutation.")
+    print(
+        "Shadow sync writer passed: manual owner confirmation, fixed targets, "
+        "mirror-only copies, preserved operational paths and no main mutation."
+    )
     return 0
 
 

--- a/.github/scripts/test_shadow_sync_writer.py
+++ b/.github/scripts/test_shadow_sync_writer.py
@@ -174,7 +174,7 @@ def main() -> int:
         "release-state",
         "distribution",
         "public `main` rejected as a target",
-        "manual synchronizer copies only `mirroredPaths`",
+        "`.github/greasyfork-version.txt` only",
     ]:
         if marker not in document:
             raise AssertionError(f"Human inventory is missing shadow writer marker: {marker}")

--- a/.github/scripts/verify_shadow_branch_parity.py
+++ b/.github/scripts/verify_shadow_branch_parity.py
@@ -1,59 +1,24 @@
 #!/usr/bin/env python3
-"""Verify Issue #41 shadow branch roles and governed-file parity.
+"""Verify Issue #41 operational branch roles and governed-file policy.
 
-This verifier is read-only. It compares current checkout files with the selected
-operational files on the `release-state` and `distribution` rehearsal branches.
-It never creates, updates or force-pushes a ref.
+Mirrored paths must remain byte-identical to the current checkout. Transitional
+operational paths may differ, but must satisfy their reviewed schema. This
+verifier is read-only and never creates, updates or force-pushes a ref.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
+POLICY_PATH = ROOT / ".github" / "shadow-branch-policy.json"
 ROLE_PATH = ".github/branch-role.json"
-BRANCH_POLICIES = {
-    "release-state": {
-        "purpose": "release-state shadow branch",
-        "allowedMutablePaths": [
-            "status/release-dashboard.json",
-            "status/README.md",
-            "status/update-manifest.json",
-            ".github/greasyfork-version.txt",
-            ROLE_PATH,
-        ],
-        "governedPaths": [
-            "status/release-dashboard.json",
-            "status/README.md",
-            "status/update-manifest.json",
-            ".github/greasyfork-version.txt",
-        ],
-    },
-    "distribution": {
-        "purpose": "distribution shadow branch",
-        "allowedMutablePaths": [
-            "dist/MissionChief_Map_Command_Toolkit.user.js",
-            "dist/MissionChief_Map_Command_Toolkit.txt",
-            "dist/SHA256SUMS.txt",
-            "dist/release-manifest.json",
-            "MissionChief_Map_Command_Toolkit.user.js",
-            "MissionChief_Map_Command_Toolkit.txt",
-            ROLE_PATH,
-        ],
-        "governedPaths": [
-            "dist/MissionChief_Map_Command_Toolkit.user.js",
-            "dist/MissionChief_Map_Command_Toolkit.txt",
-            "dist/SHA256SUMS.txt",
-            "dist/release-manifest.json",
-            "MissionChief_Map_Command_Toolkit.user.js",
-            "MissionChief_Map_Command_Toolkit.txt",
-        ],
-    },
-}
+SEMVER = re.compile(r"^\d+\.\d+\.\d+(?:[+-][0-9A-Za-z.-]+)?$")
 
 
 def git(*args: str, binary: bool = False) -> bytes | str:
@@ -64,7 +29,7 @@ def git(*args: str, binary: bool = False) -> bytes | str:
         capture_output=True,
         text=not binary,
     )
-    return result.stdout if not binary else result.stdout
+    return result.stdout
 
 
 def branch_ref(branch: str) -> str:
@@ -82,6 +47,55 @@ def branch_json(branch: str, path: str) -> dict:
     return value
 
 
+def load_policy() -> dict:
+    value = json.loads(POLICY_PATH.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("Shadow branch policy must be a JSON object")
+    expected = {
+        "schemaVersion": 1,
+        "mode": "shadow-rehearsal",
+        "mainAuthorityPreserved": True,
+        "liveConsumersEnabled": False,
+        "strictProtectionEnabled": False,
+        "administratorRecoveryRequired": True,
+        "cutoverIssue": 41,
+    }
+    for key, expected_value in expected.items():
+        if value.get(key) != expected_value:
+            raise ValueError(
+                f"Shadow branch policy {key}={value.get(key)!r}, expected {expected_value!r}"
+            )
+    branches = value.get("branches")
+    if not isinstance(branches, dict) or set(branches) != {"release-state", "distribution"}:
+        raise ValueError("Shadow branch policy must define release-state and distribution")
+    for branch, policy in branches.items():
+        validate_path_classes(branch, policy)
+    return value
+
+
+def validate_path_classes(branch: str, policy: dict) -> None:
+    governed = policy.get("governedPaths")
+    mirrored = policy.get("mirroredPaths")
+    operational = policy.get("operationalPaths")
+    if not all(isinstance(value, list) for value in [governed, mirrored, operational]):
+        raise ValueError(f"{branch} path classes must be lists")
+    if len(governed) != len(set(governed)):
+        raise ValueError(f"{branch} governedPaths contains duplicates")
+    if set(mirrored) & set(operational):
+        raise ValueError(f"{branch} mirrored and operational paths overlap")
+    if set(governed) != set(mirrored) | set(operational):
+        raise ValueError(f"{branch} path classes do not partition governedPaths")
+    if branch == "release-state":
+        if operational != [".github/greasyfork-version.txt"]:
+            raise ValueError("release-state operational path must remain the fallback tracker only")
+        if policy.get("operationalWriter") != ".github/workflows/greasyfork-release-monitor.yml":
+            raise ValueError("release-state operational writer changed")
+    if branch == "distribution" and operational:
+        raise ValueError("distribution cannot have operational paths before cutover")
+    if policy.get("externalConsumersEnabled") is not False:
+        raise ValueError(f"{branch} external consumers must remain disabled")
+
+
 def validate_role(branch: str, role: dict, policy: dict) -> list[str]:
     errors: list[str] = []
     expected = {
@@ -97,36 +111,79 @@ def validate_role(branch: str, role: dict, policy: dict) -> list[str]:
         if role.get(key) != value:
             errors.append(f"{branch} role {key}={role.get(key)!r}, expected {value!r}")
 
-    allowed = role.get("allowedMutablePaths")
-    if allowed != policy["allowedMutablePaths"]:
+    expected_allowed = [*policy["governedPaths"], ROLE_PATH]
+    if role.get("allowedMutablePaths") != expected_allowed:
         errors.append(f"{branch} allowedMutablePaths differs from reviewed policy")
     authority = str(role.get("authority") or "")
     if "main remains authoritative" not in authority:
-        errors.append(f"{branch} role does not preserve main authority during rehearsal")
+        errors.append(f"{branch} role does not preserve main authority during migration")
     return errors
+
+
+def validate_operational_content(path: str, content: bytes) -> tuple[bool, str]:
+    if path == ".github/greasyfork-version.txt":
+        value = content.decode("utf-8").strip()
+        if not SEMVER.fullmatch(value):
+            return False, f"fallback tracker is not a stable semantic version: {value!r}"
+        return True, f"operational tracker v{value}"
+    return False, f"no operational schema is defined for {path}"
 
 
 def compare_branch(branch: str, policy: dict) -> dict:
     role = branch_json(branch, ROLE_PATH)
     errors = validate_role(branch, role, policy)
     files: list[dict[str, object]] = []
+    mirrored = set(policy["mirroredPaths"])
+    operational = set(policy["operationalPaths"])
+
     for path in policy["governedPaths"]:
         local_path = ROOT / path
-        if not local_path.is_file():
-            errors.append(f"Current checkout is missing governed path {path}")
-            files.append({"path": path, "equal": False, "reason": "local-missing"})
-            continue
-        local = local_path.read_bytes()
         try:
             remote = branch_file(branch, path)
         except subprocess.CalledProcessError:
             errors.append(f"{branch} is missing governed path {path}")
-            files.append({"path": path, "equal": False, "reason": "branch-missing"})
+            files.append(
+                {
+                    "path": path,
+                    "mode": "operational" if path in operational else "mirror",
+                    "equal": False,
+                    "acceptable": False,
+                    "reason": "branch-missing",
+                }
+            )
             continue
-        equal = local == remote
-        files.append({"path": path, "equal": equal, "bytes": len(local)})
-        if not equal:
-            errors.append(f"{branch}:{path} differs from current checkout")
+
+        local = local_path.read_bytes() if local_path.is_file() else None
+        equal = local == remote if local is not None else False
+        if path in mirrored:
+            acceptable = local is not None and equal
+            reason = "byte-identical" if acceptable else "mirror-mismatch"
+            if local is None:
+                errors.append(f"Current checkout is missing mirrored path {path}")
+            elif not equal:
+                errors.append(f"{branch}:{path} differs from current checkout")
+            mode = "mirror"
+        elif path in operational:
+            acceptable, reason = validate_operational_content(path, remote)
+            if not acceptable:
+                errors.append(f"{branch}:{path} is invalid: {reason}")
+            mode = "operational"
+        else:
+            acceptable = False
+            reason = "unclassified"
+            mode = "unknown"
+            errors.append(f"{branch}:{path} has no reviewed path class")
+
+        files.append(
+            {
+                "path": path,
+                "mode": mode,
+                "equal": equal,
+                "acceptable": acceptable,
+                "reason": reason,
+                "bytes": len(remote),
+            }
+        )
 
     return {
         "branch": branch,
@@ -134,34 +191,40 @@ def compare_branch(branch: str, policy: dict) -> dict:
         "commit": str(git("rev-parse", branch_ref(branch))).strip(),
         "role": role,
         "files": files,
-        "acceptable": not errors,
+        "acceptable": not errors and all(bool(file["acceptable"]) for file in files),
         "errors": errors,
     }
 
 
 def render_markdown(report: dict) -> str:
     lines = [
-        "# Issue #41 shadow branch parity",
+        "# Issue #41 operational branch governance",
         "",
-        f"- State: **{'synchronized' if report['acceptable'] else 'mismatch'}**",
+        f"- State: **{'acceptable' if report['acceptable'] else 'mismatch'}**",
         f"- Source commit: `{report['sourceCommit']}`",
         f"- Generated: `{report['generatedAt']}`",
-        "- Live consumers changed: **no**",
+        "- External consumers changed: **no**",
         "- Public `main` changed: **no**",
         "",
     ]
     for branch in report["branches"]:
-        lines.extend([
-            f"## `{branch['branch']}`",
-            "",
-            f"- Commit: `{branch['commit']}`",
-            f"- Role valid: **{'yes' if not branch['errors'] else 'no'}**",
-            f"- Governed paths synchronized: **{'yes' if branch['acceptable'] else 'no'}**",
-            "",
-        ])
+        lines.extend(
+            [
+                f"## `{branch['branch']}`",
+                "",
+                f"- Commit: `{branch['commit']}`",
+                f"- Role valid: **{'yes' if not branch['errors'] else 'no'}**",
+                f"- Governed paths acceptable: **{'yes' if branch['acceptable'] else 'no'}**",
+                "",
+            ]
+        )
         for file in branch["files"]:
-            marker = "✅" if file["equal"] else "❌"
-            lines.append(f"- {marker} `{file['path']}`")
+            marker = "✅" if file["acceptable"] else "❌"
+            suffix = "mirror" if file["mode"] == "mirror" else "operational"
+            equality = "equal" if file["equal"] else "independent"
+            lines.append(
+                f"- {marker} `{file['path']}` — {suffix}, {equality}: {file['reason']}"
+            )
         if branch["errors"]:
             lines.extend(["", "### Errors", ""])
             lines.extend(f"- {error}" for error in branch["errors"])
@@ -170,21 +233,41 @@ def render_markdown(report: dict) -> str:
 
 
 def self_test() -> None:
+    policy = {
+        "purpose": "test",
+        "governedPaths": [
+            "status/release-dashboard.json",
+            ".github/greasyfork-version.txt",
+        ],
+        "mirroredPaths": ["status/release-dashboard.json"],
+        "operationalPaths": [".github/greasyfork-version.txt"],
+        "operationalWriter": ".github/workflows/greasyfork-release-monitor.yml",
+        "externalConsumersEnabled": False,
+    }
+    validate_path_classes("release-state", policy)
     role = {
         "schemaVersion": 1,
         "branch": "release-state",
         "mode": "shadow-rehearsal",
         "authority": "main remains authoritative until cutover",
-        "allowedMutablePaths": BRANCH_POLICIES["release-state"]["allowedMutablePaths"],
+        "allowedMutablePaths": [*policy["governedPaths"], ROLE_PATH],
         "liveConsumersEnabled": False,
         "strictProtectionEnabled": False,
         "administratorRecoveryRequired": True,
         "cutoverIssue": 41,
     }
-    assert not validate_role("release-state", role, BRANCH_POLICIES["release-state"])
-    broken = dict(role)
-    broken["liveConsumersEnabled"] = True
-    assert validate_role("release-state", broken, BRANCH_POLICIES["release-state"])
+    assert not validate_role("release-state", role, policy)
+    assert validate_operational_content(".github/greasyfork-version.txt", b"5.0.7\n")[0]
+    assert not validate_operational_content(".github/greasyfork-version.txt", b"latest\n")[0]
+
+    broken = dict(policy)
+    broken["mirroredPaths"] = [*policy["mirroredPaths"], ".github/greasyfork-version.txt"]
+    try:
+        validate_path_classes("release-state", broken)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("overlapping path classes were accepted")
     print("Shadow branch parity self-tests passed.")
 
 
@@ -204,15 +287,23 @@ def main() -> int:
     if not args.json_output or not args.markdown_output:
         raise SystemExit("--json-output and --markdown-output are required")
 
-    branches = [compare_branch(branch, policy) for branch, policy in BRANCH_POLICIES.items()]
+    policy = load_policy()
+    branches = [
+        compare_branch(branch, branch_policy)
+        for branch, branch_policy in policy["branches"].items()
+    ]
+    acceptable = all(branch["acceptable"] for branch in branches)
     report = {
-        "schemaVersion": 1,
-        "state": "synchronized" if all(branch["acceptable"] for branch in branches) else "mismatch",
-        "acceptable": all(branch["acceptable"] for branch in branches),
+        "schemaVersion": 2,
+        "state": "acceptable" if acceptable else "mismatch",
+        "acceptable": acceptable,
         "sourceCommit": str(git("rev-parse", "HEAD")).strip(),
-        "generatedAt": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "generatedAt": datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z"),
         "publicMainChanged": False,
-        "liveConsumersChanged": False,
+        "externalConsumersChanged": False,
         "branches": branches,
     }
     args.json_output.parent.mkdir(parents=True, exist_ok=True)
@@ -220,7 +311,7 @@ def main() -> int:
     args.json_output.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
     args.markdown_output.write_text(render_markdown(report), encoding="utf-8")
     print(json.dumps(report, indent=2))
-    return 0 if report["acceptable"] else 1
+    return 0 if acceptable else 1
 
 
 if __name__ == "__main__":

--- a/.github/shadow-branch-policy.json
+++ b/.github/shadow-branch-policy.json
@@ -25,14 +25,24 @@
   },
   "branches": {
     "release-state": {
-      "purpose": "Mirror verified dashboard, manifest, announcement and recovery state.",
+      "purpose": "Mirror verified dashboard and manifest state while operating the transitional fallback announcement tracker.",
       "rolePath": ".github/branch-role.json",
       "governedPaths": [
         "status/release-dashboard.json",
         "status/README.md",
         "status/update-manifest.json",
         ".github/greasyfork-version.txt"
-      ]
+      ],
+      "mirroredPaths": [
+        "status/release-dashboard.json",
+        "status/README.md",
+        "status/update-manifest.json"
+      ],
+      "operationalPaths": [
+        ".github/greasyfork-version.txt"
+      ],
+      "operationalWriter": ".github/workflows/greasyfork-release-monitor.yml",
+      "externalConsumersEnabled": false
     },
     "distribution": {
       "purpose": "Mirror stable Toolkit distribution files without changing live publication.",
@@ -44,7 +54,17 @@
         "dist/release-manifest.json",
         "MissionChief_Map_Command_Toolkit.user.js",
         "MissionChief_Map_Command_Toolkit.txt"
-      ]
+      ],
+      "mirroredPaths": [
+        "dist/MissionChief_Map_Command_Toolkit.user.js",
+        "dist/MissionChief_Map_Command_Toolkit.txt",
+        "dist/SHA256SUMS.txt",
+        "dist/release-manifest.json",
+        "MissionChief_Map_Command_Toolkit.user.js",
+        "MissionChief_Map_Command_Toolkit.txt"
+      ],
+      "operationalPaths": [],
+      "externalConsumersEnabled": false
     }
   }
 }

--- a/.github/workflows/greasyfork-release-monitor.yml
+++ b/.github/workflows/greasyfork-release-monitor.yml
@@ -19,19 +19,31 @@ jobs:
     timeout-minutes: 12
 
     steps:
-      - name: Check out latest main
+      - name: Check out latest main authority
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: main
           fetch-depth: 0
+          persist-credentials: false
+
+      - name: Prepare governed release-state worktree
+        id: release_state
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/release_state_branch.py --self-test
+          python3 .github/scripts/release_state_branch.py prepare \
+            --worktree "$RUNNER_TEMP/release-state"
 
       - name: Read live and announcement state
         id: version
+        env:
+          RELEASE_STATE_ROOT: ${{ steps.release_state.outputs.root }}
         shell: bash
         run: |
           set -euo pipefail
           META_URL="https://update.greasyfork.org/scripts/586018/MissionChief%20Map%20Command%20Toolkit.meta.js"
-          STATE_FILE=".github/greasyfork-version.txt"
+          STATE_FILE="$RELEASE_STATE_ROOT/.github/greasyfork-version.txt"
           DASHBOARD_FILE="status/release-dashboard.json"
 
           LIVE_VERSION="$(
@@ -55,8 +67,8 @@ jobs:
           fi
 
           echo "Live Greasy Fork version: ${LIVE_VERSION:-unavailable}"
-          echo "Fallback tracker version: ${ANNOUNCED_VERSION:-none}"
-          echo "Dashboard release version: ${DASHBOARD_VERSION:-none}"
+          echo "Release-state tracker version: ${ANNOUNCED_VERSION:-none}"
+          echo "Main dashboard release version: ${DASHBOARD_VERSION:-none}"
           echo "Dashboard already announced: $DASHBOARD_ANNOUNCED"
 
           echo "live=$LIVE_VERSION" >> "$GITHUB_OUTPUT"
@@ -76,45 +88,35 @@ jobs:
             echo "reconcile=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Reconcile tracker from verified release dashboard
+      - name: Reconcile release-state tracker from verified main dashboard
         if: steps.version.outputs.reconcile == 'true'
         env:
           CURRENT_VERSION: ${{ steps.version.outputs.live }}
+          RELEASE_STATE_ROOT: ${{ steps.release_state.outputs.root }}
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
-          STATE_FILE=".github/greasyfork-version.txt"
+          STATE_FILE="$RELEASE_STATE_ROOT/.github/greasyfork-version.txt"
           DASHBOARD_FILE="status/release-dashboard.json"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          REMOTE_STATE="$(tr -d '\r\n ' < "$STATE_FILE" 2>/dev/null || true)"
+          DASHBOARD_VERSION="$(jq -r '.latestRelease.version // empty' "$DASHBOARD_FILE" 2>/dev/null || true)"
+          DASHBOARD_GREASYFORK="$(jq -r '.latestRelease.greasyForkVerified // false' "$DASHBOARD_FILE" 2>/dev/null || true)"
+          DASHBOARD_DISCORD="$(jq -r '.latestRelease.discordPosted // false' "$DASHBOARD_FILE" 2>/dev/null || true)"
 
-          for attempt in 1 2 3; do
-            git fetch origin main --prune
-            git reset --hard origin/main
+          [[ "$REMOTE_STATE" == "$CURRENT_VERSION" ]] && exit 0
+          if [[ "$DASHBOARD_VERSION" != "$CURRENT_VERSION" ||
+                "$DASHBOARD_GREASYFORK" != "true" ||
+                "$DASHBOARD_DISCORD" != "true" ]]; then
+            echo "::warning::The verified main dashboard changed before reconciliation. The release-state tracker was not modified."
+            exit 0
+          fi
 
-            REMOTE_STATE="$(tr -d '\r\n ' < "$STATE_FILE" 2>/dev/null || true)"
-            DASHBOARD_VERSION="$(jq -r '.latestRelease.version // empty' "$DASHBOARD_FILE" 2>/dev/null || true)"
-            DASHBOARD_GREASYFORK="$(jq -r '.latestRelease.greasyForkVerified // false' "$DASHBOARD_FILE" 2>/dev/null || true)"
-            DASHBOARD_DISCORD="$(jq -r '.latestRelease.discordPosted // false' "$DASHBOARD_FILE" 2>/dev/null || true)"
-
-            [[ "$REMOTE_STATE" == "$CURRENT_VERSION" ]] && exit 0
-
-            if [[ "$DASHBOARD_VERSION" != "$CURRENT_VERSION" ||
-                  "$DASHBOARD_GREASYFORK" != "true" ||
-                  "$DASHBOARD_DISCORD" != "true" ]]; then
-              echo "::warning::The verified dashboard state changed before reconciliation. The fallback tracker was not modified."
-              exit 0
-            fi
-
-            printf '%s\n' "$CURRENT_VERSION" > "$STATE_FILE"
-            git add "$STATE_FILE"
-            git commit -m "Reconcile announced Toolkit version ${CURRENT_VERSION}"
-            git push origin HEAD:main && exit 0
-            sleep 5
-          done
-
-          echo "::error::Could not reconcile the fallback announcement tracker after three attempts."
-          exit 1
+          printf '%s\n' "$CURRENT_VERSION" > "$STATE_FILE"
+          python3 .github/scripts/release_state_branch.py commit \
+            --worktree "$RELEASE_STATE_ROOT" \
+            --message "Reconcile announced Toolkit version ${CURRENT_VERSION}" \
+            --path .github/greasyfork-version.txt
 
       - name: Read unannounced changelog entries
         id: changelog
@@ -137,8 +139,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          git fetch origin main --prune
-          REMOTE_STATE="$(git show origin/main:.github/greasyfork-version.txt 2>/dev/null | tr -d '\r\n ' || true)"
+          git fetch --force --no-tags origin \
+            +refs/heads/main:refs/remotes/origin/main \
+            +refs/heads/release-state:refs/remotes/origin/release-state
+          REMOTE_STATE="$(git show origin/release-state:.github/greasyfork-version.txt 2>/dev/null | tr -d '\r\n ' || true)"
           REMOTE_DASHBOARD="$(git show origin/main:status/release-dashboard.json 2>/dev/null || true)"
           DASHBOARD_VERSION="$(jq -r '.latestRelease.version // empty' <<< "$REMOTE_DASHBOARD" 2>/dev/null || true)"
           DASHBOARD_GREASYFORK="$(jq -r '.latestRelease.greasyForkVerified // false' <<< "$REMOTE_DASHBOARD" 2>/dev/null || true)"
@@ -149,7 +153,7 @@ jobs:
           elif [[ "$DASHBOARD_VERSION" == "$CURRENT_VERSION" &&
                   "$DASHBOARD_GREASYFORK" == "true" &&
                   "$DASHBOARD_DISCORD" == "true" ]]; then
-            echo "The verified release dashboard already records this Discord announcement."
+            echo "The verified main dashboard already records this Discord announcement."
             echo "pending=false" >> "$GITHUB_OUTPUT"
           elif [[ "$REMOTE_STATE" == "$PREVIOUS_VERSION" && "$REMOTE_STATE" != "$CURRENT_VERSION" ]]; then
             echo "pending=true" >> "$GITHUB_OUTPUT"
@@ -189,30 +193,22 @@ jobs:
             --request POST --header 'Content-Type: application/json' \
             --data @discord-payload.json "${DISCORD_WEBHOOK_URL}?wait=true"
 
-      - name: Record announced version
+      - name: Record announced version on release-state
         if: steps.pending.outputs.pending == 'true'
         env:
           CURRENT_VERSION: ${{ steps.version.outputs.live }}
           PREVIOUS_VERSION: ${{ steps.version.outputs.announced }}
+          RELEASE_STATE_ROOT: ${{ steps.release_state.outputs.root }}
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
-          STATE_FILE=".github/greasyfork-version.txt"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          for attempt in 1 2 3; do
-            git fetch origin main --prune
-            git reset --hard origin/main
-            REMOTE_STATE="$(tr -d '\r\n ' < "$STATE_FILE" 2>/dev/null || true)"
-            [[ "$REMOTE_STATE" == "$CURRENT_VERSION" ]] && exit 0
-            [[ "$REMOTE_STATE" != "$PREVIOUS_VERSION" ]] && exit 0
-            printf '%s\n' "$CURRENT_VERSION" > "$STATE_FILE"
-            git add "$STATE_FILE"
-            git commit -m "Track Greasy Fork version ${CURRENT_VERSION}"
-            git push origin HEAD:main && exit 0
-            sleep 5
-          done
-
-          echo "::error::The notification was sent, but the announcement state could not be recorded."
-          exit 1
+          STATE_FILE="$RELEASE_STATE_ROOT/.github/greasyfork-version.txt"
+          REMOTE_STATE="$(tr -d '\r\n ' < "$STATE_FILE" 2>/dev/null || true)"
+          [[ "$REMOTE_STATE" == "$CURRENT_VERSION" ]] && exit 0
+          [[ "$REMOTE_STATE" != "$PREVIOUS_VERSION" ]] && exit 0
+          printf '%s\n' "$CURRENT_VERSION" > "$STATE_FILE"
+          python3 .github/scripts/release_state_branch.py commit \
+            --worktree "$RELEASE_STATE_ROOT" \
+            --message "Track Greasy Fork version ${CURRENT_VERSION}" \
+            --path .github/greasyfork-version.txt

--- a/.github/workflows/validate-development-package-workflow.yml
+++ b/.github/workflows/validate-development-package-workflow.yml
@@ -17,6 +17,7 @@ on:
       - ".github/scripts/generate_release_dashboard.py"
       - ".github/scripts/reconcile_pages_incident.sh"
       - ".github/scripts/reconcile_validation_dashboard.py"
+      - ".github/scripts/release_state_branch.py"
       - ".github/scripts/sync_shadow_branches.py"
       - ".github/scripts/verify_shadow_branch_parity.py"
       - ".github/scripts/verify_validation_candidate.py"
@@ -29,6 +30,7 @@ on:
       - ".github/scripts/test_development_package_workflow.py"
       - ".github/scripts/test_greasyfork_parity_pipeline.py"
       - ".github/scripts/test_release_announcement_state_pipeline.py"
+      - ".github/scripts/test_release_state_monitor_pipeline.py"
       - ".github/scripts/test_shadow_branch_parity.py"
       - ".github/scripts/test_shadow_sync_writer.py"
       - ".github/scripts/test_update_manifest_pipeline.py"
@@ -70,6 +72,7 @@ jobs:
             python3 .github/scripts/test_validation_candidate_pipeline.py
             python3 .github/scripts/test_greasyfork_parity_pipeline.py
             python3 .github/scripts/test_release_announcement_state_pipeline.py
+            python3 .github/scripts/test_release_state_monitor_pipeline.py
             python3 .github/scripts/test_shadow_branch_parity.py
             python3 .github/scripts/test_shadow_sync_writer.py
             python3 .github/scripts/test_update_manifest_pipeline.py

--- a/docs/BRANCH_PROTECTION_MIGRATION.md
+++ b/docs/BRANCH_PROTECTION_MIGRATION.md
@@ -1,6 +1,6 @@
 # Branch Protection Migration Plan
 
-Strict pull-request-only protection is **not yet enabled**. Controlled automation commits remain because stable distribution publication, consolidated release state, fallback monitoring and recovery still mutate public `main`.
+Strict pull-request-only protection is **not yet enabled**. Controlled automation commits remain because stable distribution publication, consolidated release state and recovery still mutate public `main`.
 
 The migration is tracked by Issue #41. Authority is maintained in:
 
@@ -12,6 +12,7 @@ The migration is tracked by Issue #41. Authority is maintained in:
 - `.github/scripts/test_greasyfork_parity_pipeline.py`;
 - `.github/scripts/test_release_announcement_state_pipeline.py`;
 - `.github/scripts/test_update_manifest_pipeline.py`;
+- `.github/scripts/test_release_state_monitor_pipeline.py`;
 - `.github/scripts/test_shadow_branch_parity.py`;
 - `.github/scripts/test_shadow_sync_writer.py`.
 
@@ -28,13 +29,14 @@ The migration is tracked by Issue #41. Authority is maintained in:
 - atomic primary release dashboard, stable manifest and announcement state;
 - isolated non-live `release-state` and `distribution` branches;
 - a manual-only, fixed-target shadow writer with read-only workflow permission;
-- verified administrator repair access to both operational branches.
+- verified administrator repair access to both operational branches;
+- a constrained release-state worktree helper with role, path and ancestry validation.
 
 ## Completed migration stages
 
 ### Write-path inventory ✅
 
-The 24 July 2026 baseline identified 10 direct public-main writers. Every `contents: write` workflow and executable main-ref mutation is classified and fail-closed in CI.
+The 24 July 2026 baseline identified 10 direct public-main writers. Every `contents: write` workflow and executable main-ref mutation is classified by target branch and fail-closed in CI.
 
 ### Artifact-only validation and evidence ✅
 
@@ -63,53 +65,70 @@ After Greasy Fork verification, private backup and Discord publication, `release
 - `status/update-manifest.json`;
 - `.github/greasyfork-version.txt`.
 
-The manifest is built by `.github/scripts/build_stable_update_manifest.py` from the verified dashboard and reviewed release settings. The former publisher is now a read-only projection verifier with 30-day retained evidence.
+The manifest is built by `.github/scripts/build_stable_update_manifest.py`. The former publisher is now a read-only projection verifier with 30-day retained evidence.
 
 The existing v5.0.7 runtime URL remains unchanged:
 
 `raw.githubusercontent.com/Conroy1988/missionchief-toolkit-assets/main/status/update-manifest.json`
 
-This is a compatibility stage. A later versioned Toolkit release will move the runtime consumer to the final `release-state` endpoint, after which the `main` compatibility manifest can be frozen and removed from future mutable state.
+This is a compatibility stage. A later versioned Toolkit release will move the runtime consumer to the final `release-state` endpoint.
 
-Direct public-main writers are reduced from **10 to 3**.
-
-### Shadow branch topology and access rehearsal ✅
+### Operational branch topology and access rehearsal ✅
 
 PRs #506–#507 established:
 
 - `release-state` for verified dashboard, manifest and announcement state;
 - `distribution` for stable `dist/` and root userscript paths;
-- read-only branch-role and governed-file parity verification;
-- a manual exact-SHA-bound synchronizer restricted to the two shadow refs.
+- read-only branch-role and governed-file verification;
+- a manual exact-SHA-bound synchronizer restricted to the two operational refs.
 
-Both branches remain in `shadow-rehearsal` mode. `main` remains authoritative, live consumers are disabled, strict protection is disabled and administrator recovery remains mandatory.
+Both branches remain in `shadow-rehearsal` mode. External consumers are disabled, strict protection is disabled and administrator recovery remains mandatory.
 
 The connected administrator identity completed:
 
 - an exact-current-`main` read-only plan;
-- 10/10 governed-file parity;
+- 10/10 governed-file parity at the initial baseline;
 - same-tree fast-forward write probes on both branches;
 - post-write role and content verification;
 - no force push, history rewrite, public-main mutation or live-consumer change.
 
-The workflow-dispatch token path remains temporary and must be replaced by a narrowly scoped GitHub App before live cutover.
+### Fallback tracker moved to release-state ✅
+
+`greasyfork-release-monitor.yml` no longer commits to public `main`.
+
+The transitional authority split is:
+
+- verified dashboard: `main`;
+- fallback announcement tracker: `release-state`;
+- external consumers: disabled;
+- production tracker compatibility copy: still written atomically on `main` by `release-toolkit.yml` until the primary state cutover.
+
+`.github/scripts/release_state_branch.py` prepares a detached release-state worktree, validates `.github/branch-role.json`, allows only reviewed paths, rejects `main`, rejects force pushes, fails on stale ancestry and pushes only `HEAD:refs/heads/release-state`.
+
+The read-only operational verifier now distinguishes:
+
+- **mirrored paths** — must remain byte-identical to `main`;
+- **operational paths** — may differ but must satisfy a reviewed schema.
+
+Only `.github/greasyfork-version.txt` is operational at this stage. Dashboard JSON/Markdown and the stable manifest remain mirrored.
+
+Direct public-main writers are reduced from **10 to 2**.
 
 ## Remaining generated state
 
 Public `main` still contains:
 
 1. stable `dist/` and root Greasy Fork mirrors;
-2. verified dashboard, stable manifest and announcement state;
-3. fallback monitor state;
-4. guarded recovery state.
+2. verified dashboard, stable manifest and primary announcement state;
+3. guarded recovery state.
 
-The update manifest no longer has a standalone writer, but the compatibility file remains part of the atomic production commit until the versioned consumer migration.
+The fallback monitor no longer writes `main`. The update manifest no longer has a standalone writer, but its compatibility file remains part of the atomic production commit until the versioned consumer migration.
 
 ## Target architecture
 
 ### Public `main`
 
-Reviewed source, workflows, tests, policy, documentation and stable configuration only.
+Reviewed source, workflows, tests, policy, documentation and temporary compatibility configuration only.
 
 ### Distribution branch
 
@@ -141,15 +160,17 @@ The final protection design must retain fast owner operation:
 1. ✅ Inventory every workflow and script capable of updating public `main`.
 2. ✅ Separate validation, audit and verification evidence from public `main`.
 3. ✅ Make dashboard and announcement state atomic; retire reconciliation writing.
-4. ✅ Fold stable update-manifest publication into the same atomic release-state commit.
+4. ✅ Fold stable update-manifest publication into the same atomic release commit — PR #505.
 5. ✅ Create and verify non-live `release-state` and `distribution` branches — PR #506.
 6. ✅ Introduce the constrained shadow writer and rehearse plan/write access — PR #507 and Issue #41 evidence.
-7. Replace the rehearsal credential with a narrowly scoped GitHub App.
-8. Publish a versioned Toolkit migration that reads the manifest from `release-state` with a reviewed compatibility fallback.
-9. Move consolidated release, fallback-monitor and recovery state to `release-state`.
-10. Move stable `dist/` and Greasy Fork mirrors to `distribution`.
-11. Remove unnecessary `contents: write` from orchestration-only workflows.
-12. Rehearse without public-main mutation:
+7. ✅ Move the fallback announcement tracker writer to `release-state`.
+8. Move release recovery state to `release-state`.
+9. Move primary dashboard, manifest and announcement authority to `release-state`.
+10. Publish a versioned Toolkit migration that reads the manifest from `release-state` with a reviewed compatibility fallback.
+11. Move stable `dist/` and Greasy Fork mirrors to `distribution`.
+12. Replace temporary credentials with a narrowly scoped GitHub App.
+13. Remove unnecessary `contents: write` from orchestration-only workflows.
+14. Rehearse without public-main mutation:
     - normal Release Readiness;
     - full production publication;
     - Greasy Fork-only retry;
@@ -158,15 +179,15 @@ The final protection design must retain fast owner operation:
     - dashboard reconstruction;
     - stable release-asset repair;
     - emergency rollback-candidate preparation.
-13. Rehearse owner/admin access:
+15. Rehearse owner/admin access:
     - create and update an owner branch;
     - open and update a pull request;
     - auto-merge after green checks;
     - use PR-only administrator bypass where required;
     - repair distribution and release-state branches;
     - disable or amend the ruleset.
-14. Require pull requests, approved checks, current branches and resolved conversations.
-15. Block routine direct human pushes and enable strict protection only after complete rehearsal.
+16. Require pull requests, approved checks, current branches and resolved conversations.
+17. Block routine direct human pushes and enable strict protection only after complete rehearsal.
 
 ## Exit criteria
 

--- a/docs/BRANCH_WRITE_INVENTORY.md
+++ b/docs/BRANCH_WRITE_INVENTORY.md
@@ -7,23 +7,52 @@
 
 Strict pull-request-only protection is **not yet safe to enable**.
 
-The repository has three workflows that can commit directly to public `main`. Two release orchestrators invoke the reusable production writer but contain no direct public-main push. The remaining writes are limited to fallback monitoring, release recovery and guarded production publication.
+The repository now has two workflows that can commit directly to public `main`: controlled release recovery and guarded production publication. Two release orchestrators invoke the reusable production writer but contain no direct public-main push.
 
 Canonical validation, release dry runs, repository audits, dashboard projection, Greasy Fork parity, announcement-state verification and stable update-manifest verification are now artifact-only. These seven workflows use read-only repository access and retain immutable evidence instead of committing generated state.
 
-The `release-state` and `distribution` branches are non-live shadows. Read-only parity, an exact-SHA plan and same-tree write-access probes are complete. The constrained writer cannot update public `main` or enable live consumers.
+The fallback announcement tracker is now written only to `release-state`. The fallback monitor still reads the verified release dashboard from `main` during this transitional stage, preventing duplicate Discord posts while removing its direct public-main mutation.
 
-`.github/branch-write-inventory.json` is the machine-readable write authority. `.github/shadow-branch-policy.json` governs the isolated shadow rehearsal. Permanent contracts fail closed when a writer, permission, authority, branch role or release-state boundary changes.
+The `release-state` and `distribution` branches remain non-live operational shadows. Read-only parity, an exact-SHA synchronization plan and same-tree administrator write probes are complete. Strict protection and external consumer cutover remain disabled.
+
+`.github/branch-write-inventory.json` is the machine-readable write authority. `.github/shadow-branch-policy.json` governs branch roles and reviewed paths. Permanent contracts fail closed when a writer, permission, authority, branch role or release-state boundary changes.
 
 ## Direct public `main` writers
 
 | Workflow | Current mutation | Required migration |
 |---|---|---|
-| `greasyfork-release-monitor.yml` | fallback `.github/greasyfork-version.txt` state | Move fallback monitoring to the release-state branch. |
-| `release-recovery.yml` | dashboard JSON/Markdown and announcement recovery state | Move mutable recovery state to the release-state branch. |
-| `release-toolkit.yml` | stable distribution plus atomic dashboard, update-manifest and announcement state | Move distribution and state to dedicated branches under a scoped GitHub App. |
+| `release-recovery.yml` | dashboard JSON/Markdown and announcement recovery state | Move mutable recovery state to `release-state`; retain GitHub Release API repair capability. |
+| `release-toolkit.yml` | stable distribution plus atomic dashboard, update-manifest and announcement state | Split distribution and state across dedicated branches under a scoped GitHub App. |
 
 The executable public-main push helper `.github/scripts/sync_greasyfork_root_mirror.sh` is owned by `release-toolkit.yml`. The deterministic helper `.github/scripts/build_stable_update_manifest.py` writes only the manifest projection inside that existing guarded release commit.
+
+## Release-state branch writer
+
+`greasyfork-release-monitor.yml` is now classified under `releaseStateBranchWriters`, not `directMainWriters`.
+
+| Property | Enforced value |
+|---|---|
+| Source authority | Verified `main` dashboard |
+| Target branch | `release-state` |
+| Governed write | `.github/greasyfork-version.txt` only |
+| Credential | `github.token` |
+| Push mode | Normal fast-forward only |
+| Public-main mutation | Forbidden |
+| Consumer cutover | Disabled |
+
+`.github/scripts/release_state_branch.py` owns the branch transaction:
+
+- fetches only `release-state` into a detached worktree;
+- validates `.github/branch-role.json` before every operation;
+- requires the exact reviewed mutable-path allowlist;
+- rejects role-file changes and unapproved paths;
+- fails if the remote branch moves after preparation;
+- uses compare-and-swap ancestry with no rebase, force push or history rewrite;
+- pushes only `HEAD:refs/heads/release-state`;
+- requires `GH_TOKEN` only for the final governed push;
+- contains executable self-tests that reject `main` and allowlist expansion.
+
+The monitor checks out `main` with `persist-credentials: false`, reads the current dashboard from `main`, reads the tracker from the release-state worktree, rechecks both remote refs before a fallback post, and records only the tracker on `release-state`.
 
 ## Artifact-only evidence workflows
 
@@ -37,11 +66,11 @@ The executable public-main push helper `.github/scripts/sync_greasyfork_root_mir
 | `reconcile-release-announcement-state.yml` | `contents: read` | dashboard/tracker consistency evidence | No dashboard or tracker change. |
 | `publish-update-manifest.yml` | `contents: read` | manifest projection JSON/Markdown/log | No manifest, dashboard or branch change. |
 
-## Shadow branch topology
+## Operational branch topology
 
-| Branch | Governed paths | Current authority | Live consumers |
+| Branch | Governed paths | Current authority | External consumers |
 |---|---|---|---|
-| `release-state` | dashboard JSON/Markdown, stable update manifest, announcement tracker | `main` | Disabled |
+| `release-state` | dashboard JSON/Markdown, stable update manifest, announcement tracker | Transitional tracker writes; remaining state still authoritative on `main` | Disabled |
 | `distribution` | stable `dist/` files and root userscript mirrors | `main` | Disabled |
 
 Each branch contains `.github/branch-role.json` declaring:
@@ -53,55 +82,51 @@ Each branch contains `.github/branch-role.json` declaring:
 - Issue #41 controls cutover;
 - only reviewed operational paths may become mutable.
 
-`.github/workflows/verify-shadow-branch-parity.yml` remains read-only. It validates branch roles and governed-file parity, retains evidence for 30 days, and never commits, pushes, updates a ref or changes a live URL.
+`.github/workflows/verify-shadow-branch-parity.yml` remains read-only. During the transitional tracker migration, parity policy will be refined to distinguish the intentionally operational tracker from state that must still mirror `main`.
 
 ## Constrained shadow synchronization writer
 
-`.github/workflows/sync-shadow-branches.yml` and `.github/scripts/sync_shadow_branches.py` provide the non-live rehearsal writer.
+`.github/workflows/sync-shadow-branches.yml` and `.github/scripts/sync_shadow_branches.py` remain the manual non-live rehearsal writer.
 
-The writer contract is:
+The contract remains:
 
 - manual `workflow_dispatch` only;
 - authorized actor fixed to `Conroy1988`;
-- exact source branch fixed to `main`;
-- exact source commit SHA required and revalidated against `origin/main`;
-- target restricted to `release-state`, `distribution` or both;
-- plan confirmation must be `PLAN SHADOW SYNC`;
-- apply confirmation must be `SYNC SHADOWS`;
-- workflow permission remains `contents: read`;
-- apply mode temporarily uses `DEVELOPMENT_PR_TOKEN` as the existing owner-authenticated credential;
-- changed files must be a subset of each branch's governed paths;
-- `.github/branch-role.json` remains immutable;
-- pushes are fast-forward commits to the two reviewed shadow refs only;
-- `main` is rejected as a target inside both the workflow and script;
-- an idempotent empty probe can prove write access when governed content already matches;
-- every plan/apply operation retains evidence;
-- live consumer cutover remains forbidden;
-- the temporary owner credential must be replaced by a narrowly scoped GitHub App before final cutover.
+- source fixed to exact current `main`;
+- targets restricted to `release-state`, `distribution` or both;
+- `PLAN SHADOW SYNC` and `SYNC SHADOWS` confirmation phrases;
+- workflow-level `contents: read`;
+- temporary `DEVELOPMENT_PR_TOKEN` only for reviewed apply operations;
+- branch-specific governed paths only;
+- `.github/branch-role.json` immutable;
+- normal fast-forward pushes only;
+- public `main` rejected as a target;
+- live consumer cutover forbidden;
+- replacement by a narrowly scoped GitHub App required before final cutover.
 
-The connected administrator identity has completed the read-only plan and same-tree branch probes. No force push, history rewrite, public-main change or live-consumer change occurred.
+The connected administrator identity completed the read-only plan and same-tree branch probes. No force push, history rewrite, public-main change or live-consumer change occurred.
 
 ## Current release state
 
-After Greasy Fork verification, private backup and Discord publication, `release-toolkit.yml` now writes the following together in one commit:
+After Greasy Fork verification, private backup and Discord publication, `release-toolkit.yml` writes the following together in one public-main commit:
 
 - `status/release-dashboard.json`;
 - `status/README.md`;
 - `status/update-manifest.json`;
 - `.github/greasyfork-version.txt`.
 
-The stable manifest is generated by `.github/scripts/build_stable_update_manifest.py` from the verified dashboard and reviewed release settings. `publish-update-manifest.yml` independently verifies the committed projection with read-only access.
+The stable manifest is generated by `.github/scripts/build_stable_update_manifest.py`. `publish-update-manifest.yml` independently verifies the committed projection with read-only access.
 
 The current v5.0.7 runtime consumer remains unchanged:
 
 `raw.githubusercontent.com/Conroy1988/missionchief-toolkit-assets/main/status/update-manifest.json`
 
-This compatibility URL remains on `main` until a versioned Toolkit release moves the runtime consumer to the final `release-state` endpoint. Existing installations are therefore not stranded during migration.
+This compatibility URL remains on `main` until a versioned Toolkit release moves the runtime consumer to the final `release-state` endpoint.
 
 ## Production release sequence
 
 1. Canonical validation uploads exact immutable candidate evidence.
-2. Automatic release verifies that exact run and rejects stale commits.
+2. Automatic release verifies the exact run and rejects stale commits.
 3. Release Readiness independently rebuilds and validates distribution.
 4. Production publishes stable distribution and root mirrors.
 5. GitHub Release is published and Greasy Fork is verified.
@@ -109,7 +134,7 @@ This compatibility URL remains on `main` until a versioned Toolkit release moves
 7. Dashboard JSON, rendered Markdown, stable update manifest and announcement tracker are committed atomically.
 8. GitHub Pages is dispatched and awaited.
 9. Dashboard, Greasy Fork, announcement and update-manifest workflows verify only.
-10. Shadow parity remains independent until the versioned consumer cutover.
+10. The fallback monitor reconciles its dedicated release-state tracker without writing `main`.
 
 ## Indirect release orchestrators
 
@@ -118,20 +143,21 @@ This compatibility URL remains on `main` until a versioned Toolkit release moves
 | `auto-release-after-validation.yml` | `release-toolkit.yml` | Consumes exact validation evidence and starts guarded release. |
 | `owner-release-command.yml` | `release-toolkit.yml` | Performs owner authorization and fresh validation. |
 
-Their write authority remains only because the reusable production job still writes distribution and release state.
+Their write authority remains because the reusable production job still writes distribution and release state.
 
-## Explicit non-public-main writers
+## Other non-public-main writers
 
 | Automation | Target | Credential | Protection posture |
 |---|---|---|---|
 | `apply-development-package.yml` | Existing owner PR branch | `DEVELOPMENT_PR_TOKEN` | Review branch only. |
 | `prepare-release-rollback.yml` | Recovery branch and PR | `DEVELOPMENT_PR_TOKEN` | Review branch only. |
 | `sync-shadow-branches.yml` | `release-state` and `distribution` only | `DEVELOPMENT_PR_TOKEN` | Manual rehearsal; no `main` or consumer cutover. |
+| `greasyfork-release-monitor.yml` | `release-state` tracker only | `github.token` | Scheduled transitional operational writer; no `main`. |
 | `backup_release_to_private_repo.sh` | private recovery repository `main` | `MIGRATION_REPO_TOKEN` | Separate repository. |
 
 ## Target architecture
 
-- **Public `main`:** reviewed source, workflows, tests, policy and documentation.
+- **Public `main`:** reviewed source, workflows, tests, policy and compatibility configuration.
 - **Distribution branch:** stable `dist/` and root mirrors, written by a scoped release App.
 - **Release-state branch:** dashboard, manifest, announcement, fallback-monitor and recovery state.
 - **Immutable evidence:** validation, parity, synchronization plans, bundles, audits and handovers.
@@ -143,19 +169,23 @@ Their write authority remains only because the reusable production job still wri
 3. ✅ Convert dashboard refresh to read-only projection.
 4. ✅ Retire automatic Greasy Fork importing.
 5. ✅ Make primary announcement state atomic and reconciliation read-only.
-6. ✅ Fold stable update-manifest publication into the consolidated release-state commit.
-7. ✅ Create shadow `release-state` and `distribution` branches and verify read-only parity — PR #506.
-8. ✅ Add the constrained shadow writer and rehearse plan/apply access — PR #507 and Issue #41 evidence.
-9. Replace the rehearsal owner token with a narrowly scoped GitHub App.
-10. Move the versioned manifest consumer and consolidated release state to `release-state`.
-11. Cut stable distribution over to `distribution`.
-12. Rehearse release, recovery and administrator access.
-13. Enable strict protection only after all rehearsals pass.
+6. ✅ Fold stable update-manifest publication into the atomic release commit — PR #505.
+7. ✅ Create and validate `release-state` and `distribution` branches — PR #506.
+8. ✅ Add the constrained writer and rehearse plan/apply access — PR #507 and Issue #41 evidence.
+9. ✅ Move the fallback announcement tracker writer from `main` to `release-state`.
+10. Move release recovery state to `release-state`.
+11. Move primary dashboard/manifest/announcement authority to `release-state`.
+12. Migrate a versioned Toolkit runtime to the release-state manifest URL.
+13. Cut stable distribution over to `distribution`.
+14. Replace temporary credentials with a narrowly scoped GitHub App.
+15. Rehearse release, recovery and administrator access.
+16. Enable strict protection only after all rehearsals pass.
 
 ## Current migration evidence
 
 - PRs #498–#504 reduced direct public-main writers from **10 to 4**.
-- The current atomic update-manifest change reduces direct public-main writers from **4 to 3**.
+- PR #505 reduced direct public-main writers from **4 to 3**.
+- This migration reduces direct public-main writers from **3 to 2**.
 - PRs #506–#507 established isolated operational branches, read-only parity and constrained administrator rehearsal access.
 - Existing v5.0.7 installations retain their exact manifest URL.
-- No userscript, production version, release object, live URL or protection setting is changed by this migration step.
+- No userscript, production version, release object, external URL or protection setting changes in this step.


### PR DESCRIPTION
## Purpose

Advance Issue #41 by removing `greasyfork-release-monitor.yml` as a direct public-`main` writer while preserving fallback Discord protection and the current v5.0.7 consumer architecture.

## Transitional authority

- The verified release dashboard remains authoritative on `main`.
- The fallback announcement tracker is written only to `release-state`.
- Dashboard JSON/Markdown and the stable update manifest remain mirrored between `main` and `release-state`.
- `.github/greasyfork-version.txt` becomes the only operational release-state path.
- External/live consumers remain disabled.

## Changes

- Add `.github/scripts/release_state_branch.py` for constrained release-state worktree transactions.
- Validate branch role, exact mutable-path allowlist and current remote ancestry before every write.
- Push only `HEAD:refs/heads/release-state` using a normal non-force push.
- Rewrite the fallback monitor to read the dashboard from `main` and read/write the tracker on `release-state`.
- Reconfirm both remote refs before any fallback Discord post.
- Classify the monitor as a `releaseStateBranchWriter` instead of a direct-main writer.
- Reduce direct public-main writers from three to two.
- Upgrade read-only branch verification to distinguish byte-identical mirror paths from schema-validated operational paths.
- Prevent the manual shadow synchronizer from copying operational tracker data from `main`.
- Add permanent helper, monitor, inventory, parity and synchronizer contracts.

## Safety

- No userscript or production version change.
- No release, Discord post or recovery action is executed by this PR.
- No dashboard, manifest, tracker or distribution content changes in this PR.
- No external consumer, Greasy Fork source or raw URL change.
- No branch protection setting is enabled.
- The production release workflow remains unchanged.
- Release-state and distribution branch roles remain in `shadow-rehearsal` mode.

## Validation

All six checks pass on exact head `f3db52a841b574f7156dce798059d2c7480d30a2`:

- Development and Automation Workflow Policy
- Actions security
- Verify Shadow Branch Parity
- Verify Greasy Fork Canonical Parity
- Verify Release Announcement State
- Development status

The executable policy suite confirms:

- exactly two direct public-main writers;
- one explicitly classified release-state writer;
- seven read-only evidence workflows;
- tracker-only release-state mutation;
- main-dashboard authority during transition;
- role and path allowlist validation;
- normal non-force release-state pushes;
- mirrored dashboard/manifest paths;
- schema-validated operational tracker state;
- manual synchronizer preservation of operational paths;
- no public-main mutation or external consumer cutover.

`main` remains `66881414ba8fc542c8fed44fd501296d74b56b8e`. GitHub reports the PR mergeable, with no comments or unresolved review threads.

## Result

Direct public-main writers become:

1. `release-recovery.yml`
2. `release-toolkit.yml`

The scheduled fallback monitor retains its production concurrency lock and Discord deduplication behaviour, but tracker reconciliation is recorded on `release-state` only.

Advances #41