### PR TITLE
Move release recovery ledger to release-state

### DIFF
--- a/.github/branch-write-inventory.json
+++ b/.github/branch-write-inventory.json
@@ -1,21 +1,9 @@
 {
   "schemaVersion": 1,
   "reviewedAt": "2026-07-24",
-  "reviewedMainCommit": "66881414ba8fc542c8fed44fd501296d74b56b8e",
+  "reviewedMainCommit": "e51a44431c1769dcdab292f1d5f3b570b4c1f867",
   "strictProtectionEnabled": false,
   "directMainWriters": [
-    {
-      "workflow": ".github/workflows/release-recovery.yml",
-      "purpose": "Record controlled Greasy Fork, private-backup, Discord and dashboard recovery state.",
-      "credential": "github.token",
-      "actor": "github-actions[bot]",
-      "writes": [
-        "status/release-dashboard.json",
-        "status/README.md",
-        ".github/greasyfork-version.txt"
-      ],
-      "migrationTarget": "release-state branch; release-object repair remains API-based"
-    },
     {
       "workflow": ".github/workflows/release-toolkit.yml",
       "purpose": "Publish stable distribution and record verified dashboard, update-manifest and announcement state atomically.",
@@ -129,7 +117,6 @@
     }
   ],
   "directMainPushSources": [
-    ".github/workflows/release-recovery.yml",
     ".github/workflows/release-toolkit.yml",
     ".github/scripts/sync_greasyfork_root_mirror.sh"
   ],
@@ -148,6 +135,25 @@
       "forcePushAllowed": false,
       "liveConsumerCutoverAllowed": false,
       "migrationState": "transitional fallback-tracker authority"
+    },
+    {
+      "workflow": ".github/workflows/release-recovery.yml",
+      "helper": ".github/scripts/release_recovery_state.py",
+      "branchHelper": ".github/scripts/release_state_branch.py",
+      "sourceAuthority": "verified GitHub Release bundle plus governed recovery inputs",
+      "target": "release-state",
+      "writes": [
+        "status/release-dashboard.json",
+        "status/README.md",
+        "status/update-manifest.json",
+        ".github/greasyfork-version.txt"
+      ],
+      "credential": "github.token",
+      "actor": "github-actions[bot]",
+      "mainMutationAllowed": false,
+      "forcePushAllowed": false,
+      "liveConsumerCutoverAllowed": false,
+      "migrationState": "operational recovery ledger authority"
     }
   ],
   "externalRepositoryMainPushSources": [

--- a/.github/scripts/release_recovery_state.py
+++ b/.github/scripts/release_recovery_state.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env python3
+"""Apply controlled Toolkit recovery-state transitions on ``release-state``.
+
+The GitHub Release, Greasy Fork, private backup and Discord side effects remain
+owned by the workflow. This module owns only the governed operational ledger:
+dashboard JSON, rendered Markdown, stable update manifest and announcement
+tracker. Every commit is delegated to ``release_state_branch.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+HELPER = ROOT / ".github" / "scripts" / "release_state_branch.py"
+DASHBOARD_REL = Path("status/release-dashboard.json")
+README_REL = Path("status/README.md")
+MANIFEST_REL = Path("status/update-manifest.json")
+TRACKER_REL = Path(".github/greasyfork-version.txt")
+SETTINGS = ROOT / ".github" / "release-settings.json"
+GENERATOR = ROOT / ".github" / "scripts" / "generate_release_dashboard.py"
+MANIFEST_BUILDER = ROOT / ".github" / "scripts" / "build_stable_update_manifest.py"
+SEMVER = re.compile(r"^\d+\.\d+\.\d+(?:[+-][0-9A-Za-z.-]+)?$")
+FULL_HASH = re.compile(r"^[0-9a-f]{64}$")
+FULL_COMMIT = re.compile(r"^[0-9a-f]{40}$")
+
+
+class RecoveryStateError(RuntimeError):
+    """Fail-closed recovery-state transition error."""
+
+
+def run(*args: str, cwd: Path = ROOT) -> None:
+    result = subprocess.run(args, cwd=cwd, text=True, check=False)
+    if result.returncode != 0:
+        raise RecoveryStateError(f"Command failed ({result.returncode}): {' '.join(args)}")
+
+
+def write_output(name: str, value: str) -> None:
+    output = os.environ.get("GITHUB_OUTPUT")
+    if output:
+        with Path(output).open("a", encoding="utf-8") as handle:
+            handle.write(f"{name}={value}\n")
+
+
+def now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def validate_version(version: str) -> str:
+    if not SEMVER.fullmatch(version):
+        raise RecoveryStateError(f"Invalid stable version: {version!r}")
+    return version
+
+
+def paths(state_root: Path) -> dict[str, Path]:
+    state_root = state_root.resolve()
+    return {
+        "dashboard": state_root / DASHBOARD_REL,
+        "readme": state_root / README_REL,
+        "manifest": state_root / MANIFEST_REL,
+        "tracker": state_root / TRACKER_REL,
+    }
+
+
+def read_json(path: Path) -> dict:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise RecoveryStateError(f"Invalid JSON file: {path}") from error
+    if not isinstance(value, dict):
+        raise RecoveryStateError(f"Expected JSON object: {path}")
+    return value
+
+
+def write_json(path: Path, value: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+    temporary.replace(path)
+
+
+def dashboard_version(dashboard: dict) -> str:
+    return str((dashboard.get("latestRelease") or {}).get("version") or "").strip()
+
+
+def main_dashboard() -> dict:
+    return read_json(ROOT / DASHBOARD_REL)
+
+
+def render_dashboard(state_root: Path) -> None:
+    state = paths(state_root)
+    run(
+        "python3",
+        str(GENERATOR),
+        "--source",
+        str(state["dashboard"]),
+        "--output",
+        str(state["readme"]),
+    )
+
+
+def build_manifest(state_root: Path) -> None:
+    state = paths(state_root)
+    run(
+        "python3",
+        str(MANIFEST_BUILDER),
+        "--dashboard",
+        str(state["dashboard"]),
+        "--settings",
+        str(SETTINGS),
+        "--output",
+        str(state["manifest"]),
+    )
+
+
+def commit_state(state_root: Path, message: str, changed_paths: list[Path]) -> None:
+    arguments = [
+        "python3",
+        str(HELPER),
+        "commit",
+        "--worktree",
+        str(state_root.resolve()),
+        "--message",
+        message,
+    ]
+    for path in changed_paths:
+        arguments.extend(["--path", path.as_posix()])
+    run(*arguments)
+
+
+def seed_from_main(state_root: Path, version: str, allow_missing: bool = False) -> None:
+    version = validate_version(version)
+    state = paths(state_root)
+    current = read_json(state["dashboard"])
+    if dashboard_version(current) == version:
+        print(f"release-state already records Toolkit v{version}")
+        return
+
+    source = main_dashboard()
+    if dashboard_version(source) != version:
+        if allow_missing:
+            print(
+                f"No v{version} dashboard seed exists on main; the requested rebuild will construct it."
+            )
+            return
+        raise RecoveryStateError(
+            f"Neither release-state nor main records the requested latest release v{version}"
+        )
+
+    for relative in [DASHBOARD_REL, README_REL, MANIFEST_REL, TRACKER_REL]:
+        source_path = ROOT / relative
+        target_path = state_root / relative
+        if not source_path.is_file():
+            raise RecoveryStateError(f"Main compatibility state is missing {relative}")
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source_path, target_path)
+
+    commit_state(
+        state_root,
+        f"Seed Toolkit {version} recovery state from main",
+        [DASHBOARD_REL, README_REL, MANIFEST_REL, TRACKER_REL],
+    )
+
+
+def require_release(dashboard: dict, version: str) -> dict:
+    latest = dashboard.get("latestRelease") or {}
+    if str(latest.get("version") or "") != version:
+        raise RecoveryStateError("release-state latest release does not match recovery version")
+    return latest
+
+
+def record_greasyfork(state_root: Path, version: str) -> None:
+    version = validate_version(version)
+    state = paths(state_root)
+    dashboard = read_json(state["dashboard"])
+    latest = require_release(dashboard, version)
+    dashboard.setdefault("status", {})["greasyForkSync"] = "verified"
+    latest["greasyForkVerified"] = True
+    dashboard["lastUpdated"] = now()
+    write_json(state["dashboard"], dashboard)
+    render_dashboard(state_root)
+    commit_state(
+        state_root,
+        f"Record Toolkit {version} Greasy Fork recovery",
+        [DASHBOARD_REL, README_REL],
+    )
+
+
+def record_backup(state_root: Path, version: str, backup_commit: str) -> None:
+    version = validate_version(version)
+    if not FULL_COMMIT.fullmatch(backup_commit):
+        raise RecoveryStateError("Private backup commit must be a full commit SHA")
+    state = paths(state_root)
+    dashboard = read_json(state["dashboard"])
+    latest = require_release(dashboard, version)
+    dashboard.setdefault("status", {})["backup"] = "private-repository-verified"
+    latest["privateBackupCommit"] = backup_commit
+    dashboard["lastUpdated"] = now()
+    write_json(state["dashboard"], dashboard)
+    render_dashboard(state_root)
+    commit_state(
+        state_root,
+        f"Record Toolkit {version} private backup recovery",
+        [DASHBOARD_REL, README_REL],
+    )
+
+
+def claim_discord(state_root: Path, version: str, nonce: str) -> None:
+    version = validate_version(version)
+    if not nonce.strip():
+        raise RecoveryStateError("Discord recovery nonce is required")
+    state = paths(state_root)
+    dashboard = read_json(state["dashboard"])
+    latest = require_release(dashboard, version)
+    if latest.get("greasyForkVerified") is not True:
+        raise RecoveryStateError("Greasy Fork is not verified; Discord retry is blocked")
+    backup_commit = str(latest.get("privateBackupCommit") or "").strip()
+    if not backup_commit:
+        raise RecoveryStateError("Private backup is not recorded; Discord retry is blocked")
+    if latest.get("discordPosted") is True:
+        write_output("skip", "true")
+        print("Discord is already recorded as posted; retry suppressed.")
+        return
+
+    recovery = dashboard.setdefault("recovery", {})
+    if (recovery.get("discordAnnouncement") or {}).get("state"):
+        raise RecoveryStateError(
+            "A previous Discord retry is pending; inspect Discord before another post"
+        )
+    recovery["discordAnnouncement"] = {
+        "version": version,
+        "state": "pending",
+        "nonce": nonce,
+        "startedAt": now(),
+    }
+    write_json(state["dashboard"], dashboard)
+    render_dashboard(state_root)
+    commit_state(
+        state_root,
+        f"Claim Toolkit {version} Discord recovery",
+        [DASHBOARD_REL, README_REL],
+    )
+    write_output("skip", "false")
+    write_output("backup_commit", backup_commit)
+    write_output("nonce", nonce)
+
+
+def finalize_discord(state_root: Path, version: str, expected_nonce: str) -> None:
+    version = validate_version(version)
+    state = paths(state_root)
+    dashboard = read_json(state["dashboard"])
+    latest = require_release(dashboard, version)
+    claim = (dashboard.get("recovery") or {}).get("discordAnnouncement") or {}
+    if str(claim.get("nonce") or "") != expected_nonce:
+        raise RecoveryStateError("Discord recovery claim changed before finalization")
+
+    completed = now()
+    dashboard.setdefault("status", {})["discordRelease"] = "posted"
+    latest["discordPosted"] = True
+    latest["completedAt"] = str(latest.get("completedAt") or completed)
+    dashboard["lastUpdated"] = completed
+    recovery = dashboard.get("recovery") or {}
+    recovery.pop("discordAnnouncement", None)
+    if not recovery:
+        dashboard.pop("recovery", None)
+    write_json(state["dashboard"], dashboard)
+    state["tracker"].write_text(version + "\n", encoding="utf-8")
+    render_dashboard(state_root)
+    build_manifest(state_root)
+    commit_state(
+        state_root,
+        f"Record Toolkit {version} Discord recovery",
+        [DASHBOARD_REL, README_REL, MANIFEST_REL, TRACKER_REL],
+    )
+
+
+def rebuild_dashboard(
+    state_root: Path,
+    version: str,
+    sha256: str,
+    release_url: str,
+    backup_commit: str,
+    discord_state: str,
+) -> None:
+    version = validate_version(version)
+    if not FULL_HASH.fullmatch(sha256):
+        raise RecoveryStateError("Release SHA-256 is invalid")
+    if not FULL_COMMIT.fullmatch(backup_commit):
+        raise RecoveryStateError("Private backup commit is invalid")
+    if release_url != (
+        f"https://github.com/Conroy1988/missionchief-toolkit-assets/releases/tag/v{version}"
+    ):
+        raise RecoveryStateError("GitHub Release URL is not canonical")
+    if discord_state not in {"preserve", "posted", "not-posted"}:
+        raise RecoveryStateError("Unsupported Discord rebuild state")
+
+    state = paths(state_root)
+    dashboard = read_json(state["dashboard"])
+    if discord_state == "preserve":
+        if dashboard_version(dashboard) != version:
+            raise RecoveryStateError(
+                "Cannot preserve Discord state because release-state records a different version"
+            )
+        discord_posted = bool((dashboard.get("latestRelease") or {}).get("discordPosted"))
+    else:
+        discord_posted = discord_state == "posted"
+
+    completed = now()
+    dashboard["currentVersion"] = version
+    status = dashboard.setdefault("status", {})
+    status.update(
+        {
+            "validation": "passed",
+            "githubRelease": "published",
+            "greasyForkSync": "verified",
+            "backup": "private-repository-verified",
+            "discordRelease": "posted" if discord_posted else "not-posted",
+            "assetAudit": "passed",
+            "releaseReadiness": "passed",
+        }
+    )
+    dashboard["releaseReadiness"] = {
+        "version": version,
+        "state": "passed",
+        "requiredSecrets": True,
+        "privateRepositoryReadWrite": True,
+        "greasyForkMetadataVerified": True,
+        "publicReleaseCreated": False,
+        "completedAt": completed,
+    }
+    dashboard["latestRelease"] = {
+        "version": version,
+        "sha256": sha256,
+        "githubRelease": release_url,
+        "greasyForkVerified": True,
+        "privateBackupCommit": backup_commit,
+        "discordPosted": discord_posted,
+        "completedAt": completed,
+    }
+    dashboard["lastUpdated"] = completed
+    recovery = dashboard.get("recovery") or {}
+    recovery.pop("discordAnnouncement", None)
+    if not recovery:
+        dashboard.pop("recovery", None)
+    write_json(state["dashboard"], dashboard)
+    render_dashboard(state_root)
+
+    changed = [DASHBOARD_REL, README_REL]
+    if discord_posted:
+        state["tracker"].write_text(version + "\n", encoding="utf-8")
+        build_manifest(state_root)
+        changed.extend([MANIFEST_REL, TRACKER_REL])
+    commit_state(
+        state_root,
+        f"Rebuild Toolkit {version} release dashboard",
+        changed,
+    )
+
+
+def self_test() -> None:
+    validate_version("5.0.7")
+    try:
+        validate_version("latest")
+    except RecoveryStateError:
+        pass
+    else:
+        raise AssertionError("Invalid recovery version was accepted")
+    assert DASHBOARD_REL.as_posix() == "status/release-dashboard.json"
+    assert TRACKER_REL.as_posix() == ".github/greasyfork-version.txt"
+    print("Release recovery state self-tests passed.")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--self-test", action="store_true")
+    subcommands = parser.add_subparsers(dest="command")
+
+    seed = subcommands.add_parser("seed")
+    seed.add_argument("--state-root", type=Path, required=True)
+    seed.add_argument("--version", required=True)
+    seed.add_argument("--allow-missing", action="store_true")
+
+    greasyfork = subcommands.add_parser("record-greasyfork")
+    greasyfork.add_argument("--state-root", type=Path, required=True)
+    greasyfork.add_argument("--version", required=True)
+
+    backup = subcommands.add_parser("record-backup")
+    backup.add_argument("--state-root", type=Path, required=True)
+    backup.add_argument("--version", required=True)
+    backup.add_argument("--backup-commit", required=True)
+
+    claim = subcommands.add_parser("claim-discord")
+    claim.add_argument("--state-root", type=Path, required=True)
+    claim.add_argument("--version", required=True)
+    claim.add_argument("--nonce", required=True)
+
+    finalize = subcommands.add_parser("finalize-discord")
+    finalize.add_argument("--state-root", type=Path, required=True)
+    finalize.add_argument("--version", required=True)
+    finalize.add_argument("--nonce", required=True)
+
+    rebuild = subcommands.add_parser("rebuild-dashboard")
+    rebuild.add_argument("--state-root", type=Path, required=True)
+    rebuild.add_argument("--version", required=True)
+    rebuild.add_argument("--sha256", required=True)
+    rebuild.add_argument("--release-url", required=True)
+    rebuild.add_argument("--backup-commit", required=True)
+    rebuild.add_argument("--discord-state", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.self_test:
+        self_test()
+        return 0
+    if args.command == "seed":
+        seed_from_main(args.state_root, args.version, args.allow_missing)
+    elif args.command == "record-greasyfork":
+        record_greasyfork(args.state_root, args.version)
+    elif args.command == "record-backup":
+        record_backup(args.state_root, args.version, args.backup_commit)
+    elif args.command == "claim-discord":
+        claim_discord(args.state_root, args.version, args.nonce)
+    elif args.command == "finalize-discord":
+        finalize_discord(args.state_root, args.version, args.nonce)
+    elif args.command == "rebuild-dashboard":
+        rebuild_dashboard(
+            args.state_root,
+            args.version,
+            args.sha256,
+            args.release_url,
+            args.backup_commit,
+            args.discord_state,
+        )
+    else:
+        raise RecoveryStateError("A recovery-state command or --self-test is required")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except RecoveryStateError as error:
+        print(f"release recovery state refused: {error}", file=os.sys.stderr)
+        raise SystemExit(1)

--- a/.github/scripts/sync_shadow_branches.py
+++ b/.github/scripts/sync_shadow_branches.py
@@ -2,8 +2,8 @@
 """Synchronize only reviewed mirror files to Issue #41 operational branches.
 
 The synchronizer is deliberately non-live. It accepts only the reviewed
-``release-state`` and ``distribution`` branches, preserves operational branch
-state, requires an exact source SHA and confirmation phrase, and never updates
+``release-state`` and ``distribution`` branches, preserves every operational
+path, requires an exact source SHA and confirmation phrase, and never updates
 public ``main``.
 """
 
@@ -25,6 +25,16 @@ ROOT = Path(__file__).resolve().parents[2]
 POLICY_PATH = ROOT / ".github" / "shadow-branch-policy.json"
 ROLE_PATH = ".github/branch-role.json"
 FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
+RELEASE_STATE_PATHS = [
+    "status/release-dashboard.json",
+    "status/README.md",
+    "status/update-manifest.json",
+    ".github/greasyfork-version.txt",
+]
+RELEASE_STATE_WRITERS = [
+    ".github/workflows/greasyfork-release-monitor.yml",
+    ".github/workflows/release-recovery.yml",
+]
 
 
 class SyncError(RuntimeError):
@@ -33,10 +43,7 @@ class SyncError(RuntimeError):
 
 def git(*args: str, cwd: Path = ROOT, check: bool = True) -> str:
     result = subprocess.run(
-        ["git", *args],
-        cwd=cwd,
-        text=True,
-        capture_output=True,
+        ["git", *args], cwd=cwd, text=True, capture_output=True, check=False
     )
     if check and result.returncode != 0:
         raise SyncError(result.stderr.strip() or f"git {' '.join(args)} failed")
@@ -47,22 +54,21 @@ def load_policy(path: Path = POLICY_PATH) -> dict:
     try:
         value = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as error:
-        raise SyncError("Shadow branch policy is missing or invalid") from error
+        raise SyncError("Operational branch policy is missing or invalid") from error
     if not isinstance(value, dict):
-        raise SyncError("Shadow branch policy must be a JSON object")
+        raise SyncError("Operational branch policy must be a JSON object")
     return value
 
 
-def validate_path_classes(branch: str, branch_policy: dict) -> tuple[list[str], list[str]]:
-    governed = branch_policy.get("governedPaths")
-    mirrored = branch_policy.get("mirroredPaths")
-    operational = branch_policy.get("operationalPaths")
-    if not all(isinstance(value, list) for value in [governed, mirrored, operational]):
-        raise SyncError(f"{branch} governed, mirrored and operational paths must be lists")
+def validate_path_classes(branch: str, policy: dict) -> tuple[list[str], list[str]]:
+    governed = policy.get("governedPaths")
+    mirrored = policy.get("mirroredPaths")
+    operational = policy.get("operationalPaths")
+    writers = policy.get("operationalWriters")
+    if not all(isinstance(value, list) for value in [governed, mirrored, operational, writers]):
+        raise SyncError(f"{branch} path classes and writers must be lists")
     if not governed or any(not isinstance(path, str) or not path for path in governed):
         raise SyncError(f"{branch} governedPaths is invalid")
-    if any(not isinstance(path, str) or not path for path in [*mirrored, *operational]):
-        raise SyncError(f"{branch} path classes contain invalid entries")
     if len(governed) != len(set(governed)):
         raise SyncError(f"{branch} governedPaths contains duplicates")
     if set(mirrored) & set(operational):
@@ -70,16 +76,22 @@ def validate_path_classes(branch: str, branch_policy: dict) -> tuple[list[str], 
     if set(governed) != set(mirrored) | set(operational):
         raise SyncError(f"{branch} path classes do not partition governedPaths")
     if ROLE_PATH in governed:
-        raise SyncError(f"{branch} role file must not be synchronized from main")
-    if branch == "release-state":
-        if operational != [".github/greasyfork-version.txt"]:
-            raise SyncError("release-state operational path must remain the fallback tracker only")
-        if branch_policy.get("operationalWriter") != ".github/workflows/greasyfork-release-monitor.yml":
-            raise SyncError("release-state operational writer changed")
-    if branch == "distribution" and operational:
-        raise SyncError("distribution cannot have operational paths before cutover")
-    if branch_policy.get("externalConsumersEnabled") is not False:
+        raise SyncError(f"{branch} role file must never be copied from main")
+    if policy.get("externalConsumersEnabled") is not False:
         raise SyncError(f"{branch} external consumers must remain disabled")
+
+    if branch == "release-state":
+        if mirrored != [] or operational != RELEASE_STATE_PATHS:
+            raise SyncError("release-state recovery ledger must remain operational and mirror-free")
+        if writers != RELEASE_STATE_WRITERS:
+            raise SyncError("release-state operational writers changed")
+    elif branch == "distribution":
+        if operational or writers:
+            raise SyncError("distribution cannot have operational paths before cutover")
+        if mirrored != governed:
+            raise SyncError("distribution governed paths must remain mirrored")
+    else:
+        raise SyncError(f"Unsupported operational branch: {branch}")
     return list(mirrored), list(operational)
 
 
@@ -98,13 +110,12 @@ def validate_policy(policy: dict) -> dict:
             raise SyncError(f"Shadow policy {key}={policy.get(key)!r}, expected {expected_value!r}")
 
     writer = policy.get("writerRehearsal")
-    if not isinstance(writer, dict):
-        raise SyncError("writerRehearsal policy is missing")
-    writer_expected = {
+    expected_writer = {
         "enabled": True,
         "manualDispatchOnly": True,
         "authorizedActor": "Conroy1988",
         "sourceBranch": "main",
+        "allowedTargets": ["release-state", "distribution"],
         "planConfirmation": "PLAN SHADOW SYNC",
         "applyConfirmation": "SYNC SHADOWS",
         "credentialSecret": "DEVELOPMENT_PR_TOKEN",
@@ -113,20 +124,14 @@ def validate_policy(policy: dict) -> dict:
         "liveConsumerCutoverAllowed": False,
         "replacementIdentity": "narrowly scoped GitHub App",
     }
-    for key, expected_value in writer_expected.items():
-        if writer.get(key) != expected_value:
-            raise SyncError(f"writerRehearsal {key}={writer.get(key)!r}, expected {expected_value!r}")
-
-    allowed_targets = writer.get("allowedTargets")
-    if allowed_targets != ["release-state", "distribution"]:
-        raise SyncError("Shadow writer target allowlist changed")
-
+    if writer != expected_writer:
+        raise SyncError("writerRehearsal policy changed")
     branches = policy.get("branches")
-    if not isinstance(branches, dict) or set(branches) != set(allowed_targets):
-        raise SyncError("Operational branch definitions differ from the writer allowlist")
+    if not isinstance(branches, dict) or set(branches) != set(writer["allowedTargets"]):
+        raise SyncError("Operational branch definitions differ from the target allowlist")
     for branch, branch_policy in branches.items():
-        if branch == "main" or not isinstance(branch_policy, dict):
-            raise SyncError("Invalid operational branch policy")
+        if not isinstance(branch_policy, dict):
+            raise SyncError(f"Invalid branch policy for {branch}")
         validate_path_classes(branch, branch_policy)
     return writer
 
@@ -135,7 +140,7 @@ def selected_targets(value: str, writer: dict) -> list[str]:
     allowed = list(writer["allowedTargets"])
     if value == "both":
         return allowed
-    if value not in allowed or value == "main":
+    if value == "main" or value not in allowed:
         raise SyncError(f"Target {value!r} is not an approved operational branch")
     return [value]
 
@@ -166,10 +171,9 @@ def validate_request(
 
 
 def read_branch_json(branch: str, path: str) -> dict:
-    raw = git("show", f"refs/remotes/origin/{branch}:{path}")
     try:
-        value = json.loads(raw)
-    except json.JSONDecodeError as error:
+        value = json.loads(git("show", f"refs/remotes/origin/{branch}:{path}"))
+    except (json.JSONDecodeError, SyncError) as error:
         raise SyncError(f"Invalid JSON object at {branch}:{path}") from error
     if not isinstance(value, dict):
         raise SyncError(f"Expected JSON object at {branch}:{path}")
@@ -188,7 +192,7 @@ def read_branch_bytes(branch: str, path: str) -> bytes:
     return result.stdout
 
 
-def validate_role(branch: str, role: dict, branch_policy: dict) -> None:
+def validate_role(branch: str, role: dict, policy: dict) -> None:
     expected = {
         "schemaVersion": 1,
         "branch": branch,
@@ -201,15 +205,10 @@ def validate_role(branch: str, role: dict, branch_policy: dict) -> None:
     for key, expected_value in expected.items():
         if role.get(key) != expected_value:
             raise SyncError(f"{branch} role {key}={role.get(key)!r}, expected {expected_value!r}")
-    expected_allowed = [*branch_policy["governedPaths"], ROLE_PATH]
-    if role.get("allowedMutablePaths") != expected_allowed:
-        raise SyncError(f"{branch} role allowedMutablePaths differs from the reviewed allowlist")
+    if role.get("allowedMutablePaths") != [*policy["governedPaths"], ROLE_PATH]:
+        raise SyncError(f"{branch} role allowedMutablePaths differs from reviewed policy")
     if "main remains authoritative" not in str(role.get("authority") or ""):
-        raise SyncError(f"{branch} role no longer preserves main authority")
-
-
-def file_hash_bytes(value: bytes) -> str:
-    return hashlib.sha256(value).hexdigest()
+        raise SyncError(f"{branch} role no longer preserves main source authority")
 
 
 def changed_paths(worktree: Path) -> list[str]:
@@ -234,13 +233,13 @@ def authenticated_url(repository: str, token: str) -> str:
     return f"https://x-access-token:{quote(token, safe='')}@github.com/{repository}.git"
 
 
-def push_branch(*, worktree: Path, branch: str, repository: str, token: str) -> None:
-    url = authenticated_url(repository, token)
+def push_branch(worktree: Path, branch: str, repository: str, token: str) -> None:
     result = subprocess.run(
-        ["git", "push", url, f"HEAD:refs/heads/{branch}"],
+        ["git", "push", authenticated_url(repository, token), f"HEAD:refs/heads/{branch}"],
         cwd=worktree,
         text=True,
         capture_output=True,
+        check=False,
     )
     if result.returncode != 0:
         raise SyncError(f"Owner-authenticated non-force push to {branch} failed")
@@ -258,12 +257,10 @@ def sync_branch(
 ) -> dict:
     if branch == "main" or branch not in {"release-state", "distribution"}:
         raise SyncError("Refusing non-operational target")
-
     mirrored_paths, operational_paths = validate_path_classes(branch, branch_policy)
     remote_ref = f"refs/remotes/origin/{branch}"
     before_sha = git("rev-parse", remote_ref).strip()
-    role = read_branch_json(branch, ROLE_PATH)
-    validate_role(branch, role, branch_policy)
+    validate_role(branch, read_branch_json(branch, ROLE_PATH), branch_policy)
 
     fingerprint = hashlib.sha256(
         (
@@ -283,48 +280,26 @@ def sync_branch(
         source = ROOT / path
         if not source.is_file() or source.is_symlink():
             raise SyncError(f"Source mirrored path is missing or unsafe: {path}")
-        source_bytes = source.read_bytes()
         branch_bytes = read_branch_bytes(branch, path)
-        files.append(
-            {
-                "path": path,
-                "mode": "mirror",
-                "equalBefore": source_bytes == branch_bytes,
-                "sourceSha256": file_hash_bytes(source_bytes),
-                "branchSha256": file_hash_bytes(branch_bytes),
-            }
-        )
+        files.append({"path": path, "mode": "mirror", "equalBefore": source.read_bytes() == branch_bytes})
     for path in operational_paths:
-        branch_bytes = read_branch_bytes(branch, path)
-        files.append(
-            {
-                "path": path,
-                "mode": "operational-preserved",
-                "equalBefore": None,
-                "branchSha256": file_hash_bytes(branch_bytes),
-            }
-        )
+        read_branch_bytes(branch, path)
+        files.append({"path": path, "mode": "operational-preserved", "equalBefore": None})
 
     with tempfile.TemporaryDirectory(prefix=f"shadow-sync-{branch}-") as temporary:
         worktree = Path(temporary) / "worktree"
         git("worktree", "add", "--detach", str(worktree), remote_ref)
         try:
             role_before = (worktree / ROLE_PATH).read_bytes()
-            operational_before = {
-                path: (worktree / path).read_bytes() for path in operational_paths
-            }
+            operational_before = {path: (worktree / path).read_bytes() for path in operational_paths}
             for path in mirrored_paths:
-                source = ROOT / path
                 destination = worktree / path
                 destination.parent.mkdir(parents=True, exist_ok=True)
-                shutil.copyfile(source, destination)
+                shutil.copyfile(ROOT / path, destination)
 
             changed = changed_paths(worktree)
-            unexpected = sorted(set(changed) - set(mirrored_paths))
-            if unexpected:
-                raise SyncError(
-                    f"{branch} synchronization changed non-mirrored paths: {unexpected}"
-                )
+            if set(changed) - set(mirrored_paths):
+                raise SyncError(f"{branch} synchronization changed non-mirrored paths")
             if (worktree / ROLE_PATH).read_bytes() != role_before:
                 raise SyncError(f"{branch} role declaration changed during sync")
             for path, before in operational_before.items():
@@ -333,52 +308,25 @@ def sync_branch(
 
             latest_message = git("log", "-1", "--format=%B", cwd=worktree)
             probe_already_recorded = marker in latest_message
-            should_commit = bool(changed) or (
-                mode == "apply" and write_probe and not probe_already_recorded
-            )
+            should_commit = bool(changed) or (mode == "apply" and write_probe and not probe_already_recorded)
             pushed = False
             empty_probe = False
             after_sha = before_sha
 
             if mode == "apply" and should_commit:
                 git("config", "user.name", "Conroy1988 shadow rehearsal", cwd=worktree)
-                git(
-                    "config",
-                    "user.email",
-                    "27301455+Conroy1988@users.noreply.github.com",
-                    cwd=worktree,
-                )
+                git("config", "user.email", "27301455+Conroy1988@users.noreply.github.com", cwd=worktree)
                 if changed:
                     git("add", "--", *mirrored_paths, cwd=worktree)
-                    staged = {
-                        path
-                        for path in git("diff", "--cached", "--name-only", cwd=worktree).splitlines()
-                        if path
-                    }
+                    staged = set(git("diff", "--cached", "--name-only", cwd=worktree).splitlines())
                     if not staged or not staged <= set(mirrored_paths):
                         raise SyncError(f"Invalid staged mirror paths: {sorted(staged)}")
-                    git(
-                        "commit",
-                        "-m",
-                        f"Rehearse {branch} mirror sync from {source_sha[:12]} {marker}",
-                        cwd=worktree,
-                    )
+                    git("commit", "-m", f"Rehearse {branch} mirror sync from {source_sha[:12]} {marker}", cwd=worktree)
                 else:
                     empty_probe = True
-                    git(
-                        "commit",
-                        "--allow-empty",
-                        "-m",
-                        f"Rehearse {branch} shadow writer access from {source_sha[:12]} {marker}",
-                        cwd=worktree,
-                    )
+                    git("commit", "--allow-empty", "-m", f"Rehearse {branch} shadow writer access from {source_sha[:12]} {marker}", cwd=worktree)
                 after_sha = git("rev-parse", "HEAD", cwd=worktree).strip()
-                push_branch(
-                    worktree=worktree,
-                    branch=branch,
-                    repository=repository,
-                    token=token,
-                )
+                push_branch(worktree, branch, repository, token)
                 pushed = True
 
             return {
@@ -407,31 +355,26 @@ def render_markdown(report: dict) -> str:
         f"- Mode: `{report['mode']}`",
         f"- Source commit: `{report['sourceCommit']}`",
         f"- Target selection: `{report['targetSelection']}`",
-        f"- Generated: `{report['generatedAt']}`",
         "- Public `main` changed: **no**",
         "- External consumers changed: **no**",
-        "- Workflow token has contents write: **no**",
         "",
     ]
     for branch in report["branches"]:
-        lines.extend(
-            [
-                f"## `{branch['branch']}`",
-                "",
-                f"- Before: `{branch['beforeCommit']}`",
-                f"- After: `{branch['afterCommit']}`",
-                f"- Pushed: **{'yes' if branch['pushed'] else 'no'}**",
-                f"- Mirror content changed: **{'yes' if branch['contentChanged'] else 'no'}**",
-                f"- Empty write probe: **{'yes' if branch['emptyProbeCommit'] else 'no'}**",
-                "",
-            ]
-        )
+        lines.extend([
+            f"## `{branch['branch']}`",
+            "",
+            f"- Before: `{branch['beforeCommit']}`",
+            f"- After: `{branch['afterCommit']}`",
+            f"- Pushed: **{'yes' if branch['pushed'] else 'no'}**",
+            f"- Mirror content changed: **{'yes' if branch['contentChanged'] else 'no'}**",
+            "",
+        ])
         for path in branch["changedPaths"]:
             lines.append(f"- Updated mirrored path: `{path}`")
         for path in branch["preservedOperationalPaths"]:
             lines.append(f"- Preserved operational path: `{path}`")
         if not branch["changedPaths"]:
-            lines.append("- Mirrored content already matched `main`.")
+            lines.append("- No mirrored content required synchronization.")
         lines.append("")
     return "\n".join(lines)
 
@@ -461,19 +404,17 @@ def self_test() -> None:
         },
         "branches": {
             "release-state": {
-                "governedPaths": [
-                    "status/release-dashboard.json",
-                    ".github/greasyfork-version.txt",
-                ],
-                "mirroredPaths": ["status/release-dashboard.json"],
-                "operationalPaths": [".github/greasyfork-version.txt"],
-                "operationalWriter": ".github/workflows/greasyfork-release-monitor.yml",
+                "governedPaths": RELEASE_STATE_PATHS,
+                "mirroredPaths": [],
+                "operationalPaths": RELEASE_STATE_PATHS,
+                "operationalWriters": RELEASE_STATE_WRITERS,
                 "externalConsumersEnabled": False,
             },
             "distribution": {
                 "governedPaths": ["dist/release-manifest.json"],
                 "mirroredPaths": ["dist/release-manifest.json"],
                 "operationalPaths": [],
+                "operationalWriters": [],
                 "externalConsumersEnabled": False,
             },
         },
@@ -489,42 +430,15 @@ def self_test() -> None:
     )
     assert writer["sourceBranch"] == "main"
     assert targets == ["release-state", "distribution"]
-    mirrored, operational = validate_path_classes(
-        "release-state", policy["branches"]["release-state"]
-    )
-    assert mirrored == ["status/release-dashboard.json"]
-    assert operational == [".github/greasyfork-version.txt"]
-
+    mirrored, operational = validate_path_classes("release-state", policy["branches"]["release-state"])
+    assert mirrored == []
+    assert operational == RELEASE_STATE_PATHS
     try:
         selected_targets("main", writer)
     except SyncError:
         pass
     else:
         raise AssertionError("main target was not rejected")
-
-    broken = json.loads(json.dumps(policy["branches"]["release-state"]))
-    broken["mirroredPaths"].append(".github/greasyfork-version.txt")
-    try:
-        validate_path_classes("release-state", broken)
-    except SyncError:
-        pass
-    else:
-        raise AssertionError("operational path overlap was accepted")
-
-    try:
-        validate_request(
-            policy=policy,
-            mode="apply",
-            target="release-state",
-            source_sha="a" * 40,
-            confirmation="PLAN SHADOW SYNC",
-            actor="Conroy1988",
-            write_probe=True,
-        )
-    except SyncError:
-        pass
-    else:
-        raise AssertionError("incorrect apply confirmation was not rejected")
     print("Shadow synchronization self-tests passed.")
 
 
@@ -548,10 +462,8 @@ def main() -> int:
     if args.self_test:
         self_test()
         return 0
-    required = [args.mode, args.target, args.source_sha, args.confirmation, args.actor]
-    if any(value is None for value in required):
+    if any(value is None for value in [args.mode, args.target, args.source_sha, args.confirmation, args.actor]):
         raise SyncError("mode, target, source-sha, confirmation and actor are required")
-
     policy = load_policy()
     _writer, targets = validate_request(
         policy=policy,
@@ -562,16 +474,11 @@ def main() -> int:
         actor=args.actor,
         write_probe=args.write_probe,
     )
-
-    head = git("rev-parse", "HEAD").strip()
-    main_head = git("rev-parse", "refs/remotes/origin/main").strip()
-    if head != args.source_sha or main_head != args.source_sha:
+    if git("rev-parse", "HEAD").strip() != args.source_sha or git("rev-parse", "refs/remotes/origin/main").strip() != args.source_sha:
         raise SyncError("The checked-out source and origin/main must match the authorized source SHA")
-
     token = os.environ.get("SHADOW_SYNC_TOKEN", "")
     if args.mode == "apply" and not token:
         raise SyncError("DEVELOPMENT_PR_TOKEN is required for apply mode")
-
     results = [
         sync_branch(
             branch=branch,
@@ -585,17 +492,14 @@ def main() -> int:
         for branch in targets
     ]
     report = {
-        "schemaVersion": 2,
+        "schemaVersion": 3,
         "state": "synchronized" if args.mode == "apply" else "planned",
         "acceptable": True,
         "mode": args.mode,
         "targetSelection": args.target,
         "sourceBranch": "main",
         "sourceCommit": args.source_sha,
-        "generatedAt": datetime.now(timezone.utc)
-        .replace(microsecond=0)
-        .isoformat()
-        .replace("+00:00", "Z"),
+        "generatedAt": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
         "authorizedActor": args.actor,
         "credentialMode": "owner-token-rehearsal" if args.mode == "apply" else "read-only-plan",
         "replacementIdentity": "narrowly scoped GitHub App",

--- a/.github/scripts/test_branch_write_inventory.py
+++ b/.github/scripts/test_branch_write_inventory.py
@@ -64,10 +64,6 @@ def forbid(text: str, markers: list[str], label: str) -> None:
             fail(f"{label} contains forbidden marker: {marker}")
 
 
-def document_mentions(document: str, repository_path: str) -> bool:
-    return repository_path in document or Path(repository_path).name in document
-
-
 def workflow_set(entries: list[dict]) -> set[str]:
     result = {str(entry.get("workflow") or "") for entry in entries}
     if "" in result:
@@ -77,7 +73,7 @@ def workflow_set(entries: list[dict]) -> set[str]:
 
 def main() -> int:
     inventory = load_json(INVENTORY_PATH)
-    policy = load_json(POLICY_PATH)
+    security = load_json(POLICY_PATH)
     document = DOCUMENT_PATH.read_text(encoding="utf-8")
 
     if inventory.get("schemaVersion") != 1:
@@ -98,10 +94,7 @@ def main() -> int:
     artifacts = workflow_set(artifact_entries)
     state_writers = workflow_set(state_entries)
 
-    expected_direct = {
-        ".github/workflows/release-recovery.yml",
-        ".github/workflows/release-toolkit.yml",
-    }
+    expected_direct = {".github/workflows/release-toolkit.yml"}
     expected_orchestrators = {
         ".github/workflows/auto-release-after-validation.yml",
         ".github/workflows/owner-release-command.yml",
@@ -115,36 +108,34 @@ def main() -> int:
         ".github/workflows/reconcile-release-announcement-state.yml",
         ".github/workflows/publish-update-manifest.yml",
     }
-    expected_state_writers = {".github/workflows/greasyfork-release-monitor.yml"}
-
+    expected_state_writers = {
+        ".github/workflows/greasyfork-release-monitor.yml",
+        ".github/workflows/release-recovery.yml",
+    }
     if direct != expected_direct:
         fail(f"Unexpected direct public-main writers: {sorted(direct)}")
     if orchestrators != expected_orchestrators:
         fail(f"Unexpected release orchestrators: {sorted(orchestrators)}")
     if artifacts != expected_artifacts:
-        fail(f"Unexpected artifact-only workflow inventory: {sorted(artifacts)}")
+        fail(f"Unexpected artifact-only workflows: {sorted(artifacts)}")
     if state_writers != expected_state_writers:
-        fail(f"Unexpected release-state writer inventory: {sorted(state_writers)}")
+        fail(f"Unexpected release-state writers: {sorted(state_writers)}")
 
-    classified_groups = [direct, orchestrators, artifacts, state_writers]
-    for index, left in enumerate(classified_groups):
-        for right in classified_groups[index + 1 :]:
+    groups = [direct, orchestrators, artifacts, state_writers]
+    for index, left in enumerate(groups):
+        for right in groups[index + 1 :]:
             if left & right:
                 fail(f"Workflow classifications overlap: {sorted(left & right)}")
 
-    policy_contents = {
+    approved_contents = {
         path
-        for path, permissions in (policy.get("allowedWritePermissions") or {}).items()
+        for path, permissions in (security.get("allowedWritePermissions") or {}).items()
         if "contents" in (permissions or [])
     }
     inventory_contents = set(inventory.get("contentsWriteAuthority") or [])
     classified_contents = direct | orchestrators | state_writers
-    if policy_contents != inventory_contents:
-        fail(
-            "Contents-write authority differs between policy and inventory: "
-            f"policy-only={sorted(policy_contents - inventory_contents)}, "
-            f"inventory-only={sorted(inventory_contents - policy_contents)}"
-        )
+    if approved_contents != inventory_contents:
+        fail("Actions security contents-write authority differs from inventory")
     if classified_contents != inventory_contents:
         fail(
             "Every contents-write workflow must have an explicit branch class: "
@@ -152,43 +143,41 @@ def main() -> int:
             f"unexpected={sorted(classified_contents - inventory_contents)}"
         )
 
-    declared_contents_write = {
-        relative(workflow)
-        for workflow in workflow_files()
-        if re.search(r"(?m)^\s*contents:\s*write\s*$", workflow.read_text(encoding="utf-8"))
+    declared_contents = {
+        relative(path)
+        for path in workflow_files()
+        if re.search(r"(?m)^\s*contents:\s*write\s*$", path.read_text(encoding="utf-8"))
     }
-    if declared_contents_write != inventory_contents:
+    if declared_contents != inventory_contents:
         fail(
-            "Workflow declarations and approved contents-write authority differ: "
-            f"declared-only={sorted(declared_contents_write - inventory_contents)}, "
-            f"inventory-only={sorted(inventory_contents - declared_contents_write)}"
+            "Workflow contents-write declarations differ from authority: "
+            f"declared-only={sorted(declared_contents - inventory_contents)}, "
+            f"authority-only={sorted(inventory_contents - declared_contents)}"
         )
 
-    all_classified = direct | orchestrators | artifacts | state_writers
-    for workflow in sorted(all_classified):
+    for workflow in sorted(direct | orchestrators | artifacts | state_writers):
         path = ROOT / workflow
         if not path.is_file():
             fail(f"Classified workflow is missing: {workflow}")
-        if not document_mentions(document, workflow):
-            fail(f"Human inventory does not mention classified workflow: {workflow}")
+        if workflow not in document and Path(workflow).name not in document:
+            fail(f"Human inventory omits classified workflow: {workflow}")
 
-    discovered_main_sources = {
+    discovered_main = {
         relative(path)
         for path in executable_automation_files()
         if contains_main_ref_mutation(path.read_text(encoding="utf-8", errors="replace"))
     }
-    expected_public_sources = set(inventory.get("directMainPushSources") or [])
-    expected_external_sources = {str(entry.get("path") or "") for entry in external_entries}
-    expected_all_sources = expected_public_sources | expected_external_sources
-    if discovered_main_sources != expected_all_sources:
+    expected_public = set(inventory.get("directMainPushSources") or [])
+    expected_external = {str(entry.get("path") or "") for entry in external_entries}
+    if discovered_main != expected_public | expected_external:
         fail(
             "Executable main-ref mutation sources differ from inventory: "
-            f"unclassified={sorted(discovered_main_sources - expected_all_sources)}, "
-            f"missing={sorted(expected_all_sources - discovered_main_sources)}"
+            f"unclassified={sorted(discovered_main - expected_public - expected_external)}, "
+            f"missing={sorted((expected_public | expected_external) - discovered_main)}"
         )
-    if direct - expected_public_sources:
-        fail(f"Direct writers missing from directMainPushSources: {sorted(direct - expected_public_sources)}")
-    if (orchestrators | artifacts | state_writers) & discovered_main_sources:
+    if direct - expected_public:
+        fail(f"Direct writers missing from main push sources: {sorted(direct - expected_public)}")
+    if (orchestrators | artifacts | state_writers) & discovered_main:
         fail("Non-main workflow classes must not mutate public main")
 
     for entry in orchestrator_entries:
@@ -199,55 +188,26 @@ def main() -> int:
             fail(f"Orchestrator {workflow} no longer invokes {invoked}")
 
     artifact_markers = {
-        ".github/workflows/validate-userscript.yml": [
-            "permissions:\n  contents: read",
-            "persist-credentials: false",
-            "Write immutable validation candidate evidence",
-        ],
-        ".github/workflows/release-toolkit-dry-run.yml": [
-            "permissions:\n  contents: read",
-            "persist-credentials: false",
-            "Upload reviewable release bundle and evidence",
-        ],
-        ".github/workflows/repository-audit.yml": [
-            "permissions:\n  contents: read",
-            "persist-credentials: false",
-            "Upload immutable audit reports",
-        ],
-        ".github/workflows/update-release-dashboard.yml": [
-            "permissions:\n  contents: read",
-            "persist-credentials: false",
-            "Upload dashboard projection evidence",
-        ],
-        ".github/workflows/import-canonical-userscript.yml": [
-            "permissions:\n  contents: read",
-            "persist-credentials: false",
-            "Upload immutable parity evidence",
-        ],
-        ".github/workflows/reconcile-release-announcement-state.yml": [
-            "permissions:\n  contents: read",
-            "persist-credentials: false",
-            "Upload immutable announcement-state evidence",
-        ],
-        ".github/workflows/publish-update-manifest.yml": [
-            "permissions:\n  contents: read",
-            "persist-credentials: false",
-            "Upload immutable update-manifest evidence",
-        ],
+        ".github/workflows/validate-userscript.yml": "Write immutable validation candidate evidence",
+        ".github/workflows/release-toolkit-dry-run.yml": "Upload reviewable release bundle and evidence",
+        ".github/workflows/repository-audit.yml": "Upload immutable audit reports",
+        ".github/workflows/update-release-dashboard.yml": "Upload dashboard projection evidence",
+        ".github/workflows/import-canonical-userscript.yml": "Upload immutable parity evidence",
+        ".github/workflows/reconcile-release-announcement-state.yml": "Upload immutable announcement-state evidence",
+        ".github/workflows/publish-update-manifest.yml": "Upload immutable update-manifest evidence",
     }
-    for workflow, markers in artifact_markers.items():
+    for workflow, marker in artifact_markers.items():
         text = (ROOT / workflow).read_text(encoding="utf-8")
-        require(text, markers, workflow)
-        forbid(
-            text,
-            ["contents: write", "git push origin HEAD:main", "git push origin HEAD:refs/heads/main"],
-            workflow,
-        )
+        require(text, ["permissions:\n  contents: read", "persist-credentials: false", marker], workflow)
+        forbid(text, ["contents: write", "git push origin HEAD:main", "git push origin HEAD:refs/heads/main"], workflow)
 
-    if len(state_entries) != 1:
-        fail(f"Expected one release-state writer, found {len(state_entries)}")
-    state_entry = state_entries[0]
-    expected_state = {
+    if len(state_entries) != 2:
+        fail(f"Expected two release-state writers, found {len(state_entries)}")
+    entries_by_workflow = {entry["workflow"]: entry for entry in state_entries}
+    monitor_entry = entries_by_workflow[".github/workflows/greasyfork-release-monitor.yml"]
+    recovery_entry = entries_by_workflow[".github/workflows/release-recovery.yml"]
+
+    expected_monitor = {
         "workflow": ".github/workflows/greasyfork-release-monitor.yml",
         "helper": ".github/scripts/release_state_branch.py",
         "sourceAuthority": "main release dashboard",
@@ -260,11 +220,35 @@ def main() -> int:
         "liveConsumerCutoverAllowed": False,
         "migrationState": "transitional fallback-tracker authority",
     }
-    if state_entry != expected_state:
-        fail("Release-state fallback-monitor inventory changed")
+    expected_recovery = {
+        "workflow": ".github/workflows/release-recovery.yml",
+        "helper": ".github/scripts/release_recovery_state.py",
+        "branchHelper": ".github/scripts/release_state_branch.py",
+        "sourceAuthority": "verified GitHub Release bundle plus governed recovery inputs",
+        "target": "release-state",
+        "writes": [
+            "status/release-dashboard.json",
+            "status/README.md",
+            "status/update-manifest.json",
+            ".github/greasyfork-version.txt",
+        ],
+        "credential": "github.token",
+        "actor": "github-actions[bot]",
+        "mainMutationAllowed": False,
+        "forcePushAllowed": False,
+        "liveConsumerCutoverAllowed": False,
+        "migrationState": "operational recovery ledger authority",
+    }
+    if monitor_entry != expected_monitor:
+        fail("Fallback-monitor release-state inventory changed")
+    if recovery_entry != expected_recovery:
+        fail("Release-recovery state inventory changed")
 
-    monitor = (ROOT / state_entry["workflow"]).read_text(encoding="utf-8")
-    helper = (ROOT / state_entry["helper"]).read_text(encoding="utf-8")
+    monitor = (ROOT / monitor_entry["workflow"]).read_text(encoding="utf-8")
+    recovery = (ROOT / recovery_entry["workflow"]).read_text(encoding="utf-8")
+    branch_helper = (ROOT / recovery_entry["branchHelper"]).read_text(encoding="utf-8")
+    recovery_helper = (ROOT / recovery_entry["helper"]).read_text(encoding="utf-8")
+
     require(
         monitor,
         [
@@ -272,47 +256,71 @@ def main() -> int:
             "persist-credentials: false",
             "Prepare governed release-state worktree",
             "release_state_branch.py prepare",
-            "RELEASE_STATE_ROOT/.github/greasyfork-version.txt",
-            "DASHBOARD_FILE=\"status/release-dashboard.json\"",
-            "Reconcile release-state tracker from verified main dashboard",
             "Record announced version on release-state",
-            "release_state_branch.py commit",
-            "GH_TOKEN: ${{ github.token }}",
-        ],
-        "Greasy Fork fallback monitor",
-    )
-    forbid(
-        monitor,
-        [
-            "git push origin HEAD:main",
-            "git push origin HEAD:refs/heads/main",
-            "git reset --hard origin/main",
-            "STATE_FILE=\".github/greasyfork-version.txt\"",
         ],
         "Greasy Fork fallback monitor",
     )
     require(
-        helper,
+        recovery,
+        [
+            "Check out latest main authority",
+            "persist-credentials: false",
+            "Prepare governed release-state worktree",
+            "release_recovery_state.py seed",
+            "Record Greasy Fork recovery on release-state",
+            "Record private backup recovery on release-state",
+            "Claim Discord retry on release-state without posting",
+            "Finalize Discord recovery on release-state",
+            "Rebuild verified release dashboard on release-state",
+            "Recovery ledger: \\`release-state\\`",
+            "Public main changed: no",
+        ],
+        "Release recovery workflow",
+    )
+    for label, text in {
+        "monitor": monitor,
+        "recovery": recovery,
+        "branch helper": branch_helper,
+        "recovery helper": recovery_helper,
+    }.items():
+        forbid(
+            text,
+            [
+                "git push origin HEAD:main",
+                "git push origin HEAD:refs/heads/main",
+                "git pull --rebase origin main",
+                "git reset --hard origin/main",
+                "force-with-lease",
+            ],
+            label,
+        )
+
+    require(
+        branch_helper,
         [
             'TARGET_BRANCH = "release-state"',
             'PUSH_REF = f"HEAD:refs/heads/{TARGET_BRANCH}"',
             "release-state branch role is immutable",
             "release-state moved after preparation",
-            "http.https://github.com/.extraheader",
             "Release-state branch writer self-tests passed.",
         ],
         "Release-state branch helper",
     )
-    forbid(
-        helper,
+    require(
+        recovery_helper,
         [
-            'TARGET_BRANCH = "main"',
-            "HEAD:refs/heads/main",
-            "--force",
-            "force-with-lease",
-            "git reset --hard origin/main",
+            "Apply controlled Toolkit recovery-state transitions",
+            "seed_from_main",
+            "record_greasyfork",
+            "record_backup",
+            "claim_discord",
+            "finalize_discord",
+            "rebuild_dashboard",
+            "build_manifest(state_root)",
+            "commit_state",
+            "Release recovery state self-tests passed.",
         ],
-        "Release-state branch helper",
+        "Release recovery state helper",
     )
 
     for entry in external_entries:
@@ -321,14 +329,14 @@ def main() -> int:
         if not path.is_file():
             fail(f"External writer is missing: {relative(path)}")
         text = path.read_text(encoding="utf-8")
-        if repository not in text or relative(path) not in discovered_main_sources:
+        if repository not in text or relative(path) not in discovered_main:
             fail(f"External writer contract changed: {relative(path)}")
 
     for entry in review_entries:
         workflow = ROOT / str(entry["workflow"])
         if not workflow.is_file():
             fail(f"Review-branch writer is missing: {relative(workflow)}")
-        if relative(workflow) in discovered_main_sources:
+        if relative(workflow) in discovered_main:
             fail(f"Review-branch writer contains prohibited public-main mutation: {relative(workflow)}")
         if str(entry.get("credential") or "") not in workflow.read_text(encoding="utf-8"):
             fail(f"Review-branch writer no longer uses reviewed credential: {relative(workflow)}")
@@ -336,28 +344,22 @@ def main() -> int:
     if len(shadow_entries) != 1:
         fail(f"Expected one shadow synchronization writer, found {len(shadow_entries)}")
     shadow_workflow = ROOT / str(shadow_entries[0].get("workflow") or "")
-    if not shadow_workflow.is_file():
-        fail("Shadow synchronization workflow is missing")
-    if relative(shadow_workflow) in discovered_main_sources:
-        fail("Shadow synchronization workflow must not mutate public main")
-
-    for path in sorted(expected_public_sources | expected_external_sources):
-        if not document_mentions(document, path):
-            fail(f"Human inventory omits executable write source: {path}")
+    if not shadow_workflow.is_file() or relative(shadow_workflow) in discovered_main:
+        fail("Shadow synchronization writer is missing or can mutate public main")
 
     for claim in [
-        "Strict pull-request-only protection is **not yet safe to enable**",
-        "two workflows that can commit directly to public `main`",
+        "one workflow that can commit directly to public `main`",
+        "two workflows write governed operational state to `release-state`",
+        "release recovery ledger is now written only to `release-state`",
         "seven workflows use read-only repository access",
-        "fallback announcement tracker is now written only to `release-state`",
     ]:
         if claim not in document:
             fail(f"Human inventory is missing migration claim: {claim}")
 
     print(
         "Branch-write inventory passed: "
-        f"{len(direct)} direct main writers, "
-        f"{len(state_writers)} release-state writer, "
+        f"{len(direct)} direct main writer, "
+        f"{len(state_writers)} release-state writers, "
         f"{len(orchestrators)} orchestrators, "
         f"{len(artifacts)} artifact-only workflows, "
         f"{len(review_entries)} review-branch writers and "

--- a/.github/scripts/test_release_recovery_state_pipeline.py
+++ b/.github/scripts/test_release_recovery_state_pipeline.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Contracts for Issue #41 release recovery state on release-state."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "release-recovery.yml"
+STATE = ROOT / ".github" / "scripts" / "release_recovery_state.py"
+BRANCH = ROOT / ".github" / "scripts" / "release_state_branch.py"
+INVENTORY = ROOT / ".github" / "branch-write-inventory.json"
+POLICY = ROOT / ".github" / "shadow-branch-policy.json"
+DOCUMENT = ROOT / "docs" / "BRANCH_WRITE_INVENTORY.md"
+
+
+def require(text: str, markers: list[str], label: str) -> None:
+    for marker in markers:
+        if marker not in text:
+            raise AssertionError(f"{label} is missing required marker: {marker}")
+
+
+def forbid(text: str, markers: list[str], label: str) -> None:
+    for marker in markers:
+        if marker in text:
+            raise AssertionError(f"{label} contains forbidden marker: {marker}")
+
+
+def main() -> int:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    state = STATE.read_text(encoding="utf-8")
+    branch = BRANCH.read_text(encoding="utf-8")
+    inventory = json.loads(INVENTORY.read_text(encoding="utf-8"))
+    policy = json.loads(POLICY.read_text(encoding="utf-8"))
+    document = DOCUMENT.read_text(encoding="utf-8")
+
+    state_entries = {
+        entry["workflow"]: entry
+        for entry in (inventory.get("releaseStateBranchWriters") or [])
+    }
+    expected = {
+        "workflow": ".github/workflows/release-recovery.yml",
+        "helper": ".github/scripts/release_recovery_state.py",
+        "branchHelper": ".github/scripts/release_state_branch.py",
+        "sourceAuthority": "verified GitHub Release bundle plus governed recovery inputs",
+        "target": "release-state",
+        "writes": [
+            "status/release-dashboard.json",
+            "status/README.md",
+            "status/update-manifest.json",
+            ".github/greasyfork-version.txt",
+        ],
+        "credential": "github.token",
+        "actor": "github-actions[bot]",
+        "mainMutationAllowed": False,
+        "forcePushAllowed": False,
+        "liveConsumerCutoverAllowed": False,
+        "migrationState": "operational recovery ledger authority",
+    }
+    if state_entries.get(expected["workflow"]) != expected:
+        raise AssertionError("Release recovery inventory changed")
+
+    release_state = (policy.get("branches") or {}).get("release-state") or {}
+    if release_state.get("operationalPaths") != expected["writes"]:
+        raise AssertionError("Release-state recovery path authority changed")
+    if release_state.get("operationalWriters") != [
+        ".github/workflows/greasyfork-release-monitor.yml",
+        ".github/workflows/release-recovery.yml",
+    ]:
+        raise AssertionError("Release-state recovery writers changed")
+    if release_state.get("mirroredPaths") != []:
+        raise AssertionError("Release-state cannot retain mirror-copy authority")
+    if release_state.get("externalConsumersEnabled") is not False:
+        raise AssertionError("Release-state external consumers must remain disabled")
+
+    require(
+        workflow,
+        [
+            "name: Release Recovery",
+            "permissions:\n  contents: write",
+            "group: toolkit-production-release",
+            "Check out latest main authority",
+            "ref: main",
+            "persist-credentials: false",
+            "VERIFY ${RELEASE_VERSION}",
+            "RETRY GREASYFORK ${RELEASE_VERSION}",
+            "RETRY BACKUP ${RELEASE_VERSION}",
+            "RETRY DISCORD ${RELEASE_VERSION}",
+            "REBUILD DASHBOARD ${RELEASE_VERSION}",
+            "REPAIR ASSETS ${RELEASE_VERSION}",
+            "Verify recovery-state self-tests",
+            "Prepare governed release-state worktree",
+            "release_state_branch.py prepare",
+            "Seed recovery ledger from verified main compatibility state",
+            "release_recovery_state.py seed",
+            "Record Greasy Fork recovery on release-state",
+            "record-greasyfork",
+            "Record private backup recovery on release-state",
+            "record-backup",
+            "Claim Discord retry on release-state without posting",
+            "claim-discord",
+            "Finalize Discord recovery on release-state",
+            "finalize-discord",
+            "Rebuild verified release dashboard on release-state",
+            "rebuild-dashboard",
+            "Repair stable GitHub Release assets",
+            "Recovery ledger: \\`release-state\\`",
+            "Public main changed: no",
+        ],
+        "Release recovery workflow",
+    )
+    forbid(
+        workflow,
+        [
+            "git push origin HEAD:main",
+            "git push origin HEAD:refs/heads/main",
+            "git pull --rebase origin main",
+            "git reset --hard origin/main",
+            "git add status/release-dashboard.json",
+            "git add \"$DASHBOARD\"",
+            "github-actions[bot]@users.noreply.github.com",
+        ],
+        "Release recovery workflow",
+    )
+
+    require(
+        state,
+        [
+            "Apply controlled Toolkit recovery-state transitions",
+            'DASHBOARD_REL = Path("status/release-dashboard.json")',
+            'README_REL = Path("status/README.md")',
+            'MANIFEST_REL = Path("status/update-manifest.json")',
+            'TRACKER_REL = Path(".github/greasyfork-version.txt")',
+            "seed_from_main",
+            "record_greasyfork",
+            "record_backup",
+            "claim_discord",
+            "finalize_discord",
+            "rebuild_dashboard",
+            "render_dashboard(state_root)",
+            "build_manifest(state_root)",
+            "commit_state",
+            "Discord recovery claim changed before finalization",
+            "Release recovery state self-tests passed.",
+        ],
+        "Release recovery state helper",
+    )
+    forbid(
+        state,
+        [
+            "git push",
+            "HEAD:refs/heads/main",
+            "git reset --hard origin/main",
+            "force-with-lease",
+            "DEVELOPMENT_PR_TOKEN",
+        ],
+        "Release recovery state helper",
+    )
+
+    require(
+        branch,
+        [
+            'TARGET_BRANCH = "release-state"',
+            'PUSH_REF = f"HEAD:refs/heads/{TARGET_BRANCH}"',
+            "release-state branch role is immutable",
+            "release-state moved after preparation",
+            "GH_TOKEN is required to publish release-state changes",
+        ],
+        "Release-state branch helper",
+    )
+
+    for marker in [
+        "release recovery ledger is now written only to `release-state`",
+        "release_recovery_state.py",
+        "release-recovery.yml",
+        "one workflow that can commit directly to public `main`",
+    ]:
+        if marker not in document:
+            raise AssertionError(f"Human inventory is missing recovery migration marker: {marker}")
+
+    for helper in [BRANCH, STATE]:
+        result = subprocess.run(["python3", str(helper), "--self-test"], cwd=ROOT)
+        if result.returncode != 0:
+            raise AssertionError(f"Self-tests failed: {helper.name}")
+
+    print(
+        "Release recovery state contract passed: guarded API side effects, release-state-only ledger, "
+        "atomic Discord claim/finalization and no public-main mutation."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_release_state_monitor_pipeline.py
+++ b/.github/scripts/test_release_state_monitor_pipeline.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Contracts for the transitional Greasy Fork fallback tracker on release-state."""
+"""Contracts for the Greasy Fork fallback tracker on release-state."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = ROOT / ".github" / "workflows" / "greasyfork-release-monitor.yml"
 HELPER = ROOT / ".github" / "scripts" / "release_state_branch.py"
 INVENTORY = ROOT / ".github" / "branch-write-inventory.json"
-POLICY = ROOT / ".github" / "actions-security-policy.json"
+SECURITY = ROOT / ".github" / "actions-security-policy.json"
 ROLE_POLICY = ROOT / ".github" / "shadow-branch-policy.json"
 DOCUMENT = ROOT / "docs" / "BRANCH_WRITE_INVENTORY.md"
 
@@ -32,14 +32,14 @@ def main() -> int:
     workflow = WORKFLOW.read_text(encoding="utf-8")
     helper = HELPER.read_text(encoding="utf-8")
     inventory = json.loads(INVENTORY.read_text(encoding="utf-8"))
-    policy = json.loads(POLICY.read_text(encoding="utf-8"))
+    security = json.loads(SECURITY.read_text(encoding="utf-8"))
     role_policy = json.loads(ROLE_POLICY.read_text(encoding="utf-8"))
     document = DOCUMENT.read_text(encoding="utf-8")
 
-    entries = inventory.get("releaseStateBranchWriters") or []
-    if len(entries) != 1:
-        raise AssertionError(f"Expected one release-state branch writer, found {len(entries)}")
-    entry = entries[0]
+    entries = {
+        entry["workflow"]: entry
+        for entry in (inventory.get("releaseStateBranchWriters") or [])
+    }
     expected = {
         "workflow": ".github/workflows/greasyfork-release-monitor.yml",
         "helper": ".github/scripts/release_state_branch.py",
@@ -53,17 +53,25 @@ def main() -> int:
         "liveConsumerCutoverAllowed": False,
         "migrationState": "transitional fallback-tracker authority",
     }
-    if entry != expected:
+    if entries.get(expected["workflow"]) != expected:
         raise AssertionError("Fallback-monitor release-state inventory changed")
+    if set(entries) != {
+        ".github/workflows/greasyfork-release-monitor.yml",
+        ".github/workflows/release-recovery.yml",
+    }:
+        raise AssertionError("Release-state writer set changed")
 
-    permissions = policy.get("allowedWritePermissions") or {}
-    if permissions.get(entry["workflow"]) != ["contents"]:
+    permissions = security.get("allowedWritePermissions") or {}
+    if permissions.get(expected["workflow"]) != ["contents"]:
         raise AssertionError("Fallback monitor contents-write permission changed")
 
     release_state = (role_policy.get("branches") or {}).get("release-state") or {}
     governed = set(release_state.get("governedPaths") or [])
-    if ".github/greasyfork-version.txt" not in governed:
-        raise AssertionError("Release-state policy no longer governs the fallback tracker")
+    operational = set(release_state.get("operationalPaths") or [])
+    if ".github/greasyfork-version.txt" not in governed or governed != operational:
+        raise AssertionError("Release-state policy no longer governs the fallback tracker operationally")
+    if expected["workflow"] not in (release_state.get("operationalWriters") or []):
+        raise AssertionError("Fallback monitor is no longer an approved release-state writer")
 
     require(
         workflow,
@@ -134,10 +142,11 @@ def main() -> int:
     )
 
     for marker in [
-        "fallback announcement tracker is now written only to `release-state`",
+        "fallback announcement tracker",
         "release_state_branch.py",
         "greasyfork-release-monitor.yml",
-        "two workflows that can commit directly to public `main`",
+        "one workflow that can commit directly to public `main`",
+        "two workflows write governed operational state to `release-state`",
     ]:
         if marker not in document:
             raise AssertionError(f"Human inventory is missing monitor migration marker: {marker}")
@@ -147,8 +156,8 @@ def main() -> int:
         raise AssertionError("Release-state branch helper self-tests failed")
 
     print(
-        "Fallback monitor release-state contract passed: main dashboard authority, "
-        "single governed tracker path, no main mutation and normal non-force branch push."
+        "Fallback monitor release-state contract passed: main compatibility dashboard authority, "
+        "tracker-only monitor write, no main mutation and shared recovery-ledger branch control."
     )
     return 0
 

--- a/.github/scripts/test_shadow_branch_parity.py
+++ b/.github/scripts/test_shadow_branch_parity.py
@@ -30,9 +30,8 @@ def main() -> int:
     script = SCRIPT.read_text(encoding="utf-8")
     workflow = WORKFLOW.read_text(encoding="utf-8")
 
-    if policy.get("schemaVersion") != 1:
-        raise AssertionError("Shadow branch policy schemaVersion must remain 1")
     for key, expected in {
+        "schemaVersion": 1,
         "mode": "shadow-rehearsal",
         "mainAuthorityPreserved": True,
         "liveConsumersEnabled": False,
@@ -41,30 +40,30 @@ def main() -> int:
         "cutoverIssue": 41,
     }.items():
         if policy.get(key) != expected:
-            raise AssertionError(f"Shadow branch policy {key}={policy.get(key)!r}, expected {expected!r}")
+            raise AssertionError(f"Operational policy {key}={policy.get(key)!r}, expected {expected!r}")
 
     branches = policy.get("branches") or {}
     if set(branches) != {"release-state", "distribution"}:
         raise AssertionError(f"Unexpected operational branches: {sorted(branches)}")
 
-    release_state = branches["release-state"]
-    if release_state.get("governedPaths") != [
+    state_paths = [
         "status/release-dashboard.json",
         "status/README.md",
         "status/update-manifest.json",
         ".github/greasyfork-version.txt",
-    ]:
+    ]
+    release_state = branches["release-state"]
+    if release_state.get("governedPaths") != state_paths:
         raise AssertionError("release-state governed paths changed")
-    if release_state.get("mirroredPaths") != [
-        "status/release-dashboard.json",
-        "status/README.md",
-        "status/update-manifest.json",
+    if release_state.get("mirroredPaths") != []:
+        raise AssertionError("release-state must have no mirror paths")
+    if release_state.get("operationalPaths") != state_paths:
+        raise AssertionError("release-state operational ledger changed")
+    if release_state.get("operationalWriters") != [
+        ".github/workflows/greasyfork-release-monitor.yml",
+        ".github/workflows/release-recovery.yml",
     ]:
-        raise AssertionError("release-state mirrored paths changed")
-    if release_state.get("operationalPaths") != [".github/greasyfork-version.txt"]:
-        raise AssertionError("release-state operational paths changed")
-    if release_state.get("operationalWriter") != ".github/workflows/greasyfork-release-monitor.yml":
-        raise AssertionError("release-state operational writer changed")
+        raise AssertionError("release-state operational writers changed")
     if release_state.get("externalConsumersEnabled") is not False:
         raise AssertionError("release-state external consumers must remain disabled")
 
@@ -81,8 +80,8 @@ def main() -> int:
         raise AssertionError("distribution governed paths changed")
     if distribution.get("mirroredPaths") != expected_distribution:
         raise AssertionError("distribution mirrored paths changed")
-    if distribution.get("operationalPaths") != []:
-        raise AssertionError("distribution cannot have operational paths before cutover")
+    if distribution.get("operationalPaths") != [] or distribution.get("operationalWriters") != []:
+        raise AssertionError("distribution cannot have operational authority before cutover")
     if distribution.get("externalConsumersEnabled") is not False:
         raise AssertionError("distribution external consumers must remain disabled")
 
@@ -90,19 +89,20 @@ def main() -> int:
         script,
         [
             "Mirrored paths must remain byte-identical",
-            "operational paths may differ",
+            "Operational",
             'POLICY_PATH = ROOT / ".github" / "shadow-branch-policy.json"',
-            '"release-state"',
-            '"distribution"',
-            '"mode": "shadow-rehearsal"',
-            '"liveConsumersEnabled": False',
-            '"strictProtectionEnabled": False',
-            '"administratorRecoveryRequired": True',
-            '"cutoverIssue": 41',
-            'operational != [".github/greasyfork-version.txt"]',
+            'writers = policy.get("operationalWriters")',
+            "release-state must keep all recovery-ledger paths operational",
+            "release-state operational writers changed",
             "validate_operational_content",
-            'SEMVER.fullmatch(value)',
-            '"schemaVersion": 2',
+            'path == "status/release-dashboard.json"',
+            'path == "status/README.md"',
+            'path == "status/update-manifest.json"',
+            'path == ".github/greasyfork-version.txt"',
+            "cross_validate_release_state",
+            "stable manifest is ahead of the recovery dashboard",
+            "announcement tracker is ahead of the recovery dashboard",
+            '"schemaVersion": 3',
             '"publicMainChanged": False',
             '"externalConsumersChanged": False',
             "Shadow branch parity self-tests passed.",
@@ -111,14 +111,7 @@ def main() -> int:
     )
     forbid(
         script,
-        [
-            "git push",
-            "git commit",
-            "git update-ref",
-            "gh api",
-            "DEVELOPMENT_PR_TOKEN",
-            "contents: write",
-        ],
+        ["git push", "git commit", "git update-ref", "gh api", "contents: write"],
         "Operational branch verifier",
     )
 
@@ -139,13 +132,7 @@ def main() -> int:
     )
     forbid(
         workflow,
-        [
-            "contents: write",
-            "git push",
-            "git commit",
-            "github-actions[bot]",
-            "DEVELOPMENT_PR_TOKEN",
-        ],
+        ["contents: write", "git push", "git commit", "github-actions[bot]", "DEVELOPMENT_PR_TOKEN"],
         "Operational branch verification workflow",
     )
 
@@ -154,8 +141,8 @@ def main() -> int:
         raise AssertionError("Operational branch verifier self-tests failed")
 
     print(
-        "Operational branch governance passed: mirrored paths remain equal, "
-        "the fallback tracker has a reviewed schema, and no external cutover is enabled."
+        "Operational branch governance passed: complete release-state ledger schemas, "
+        "cross-file version ordering, distribution mirrors and no external cutover."
     )
     return 0
 

--- a/.github/scripts/test_shadow_sync_writer.py
+++ b/.github/scripts/test_shadow_sync_writer.py
@@ -160,7 +160,6 @@ def main() -> int:
 
     for marker in [
         "sync-shadow-branches.yml",
-        "sync_shadow_branches.py",
         "DEVELOPMENT_PR_TOKEN",
         "release-state",
         "distribution",

--- a/.github/scripts/test_shadow_sync_writer.py
+++ b/.github/scripts/test_shadow_sync_writer.py
@@ -55,14 +55,21 @@ def main() -> int:
         raise AssertionError("writerRehearsal policy changed")
 
     release_state = (policy.get("branches") or {}).get("release-state") or {}
-    if release_state.get("mirroredPaths") != [
+    expected_state_paths = [
         "status/release-dashboard.json",
         "status/README.md",
         "status/update-manifest.json",
+        ".github/greasyfork-version.txt",
+    ]
+    if release_state.get("mirroredPaths") != []:
+        raise AssertionError("release-state must have no manual mirror-copy paths")
+    if release_state.get("operationalPaths") != expected_state_paths:
+        raise AssertionError("release-state operational ledger changed")
+    if release_state.get("operationalWriters") != [
+        ".github/workflows/greasyfork-release-monitor.yml",
+        ".github/workflows/release-recovery.yml",
     ]:
-        raise AssertionError("release-state mirror allowlist changed")
-    if release_state.get("operationalPaths") != [".github/greasyfork-version.txt"]:
-        raise AssertionError("release-state operational allowlist changed")
+        raise AssertionError("release-state operational writers changed")
 
     entries = inventory.get("shadowBranchWriters") or []
     if len(entries) != 1:
@@ -104,24 +111,13 @@ def main() -> int:
             "+refs/heads/distribution:refs/remotes/origin/distribution",
             "DEVELOPMENT_PR_TOKEN",
             "sync_shadow_branches.py --self-test",
-            "Apply owner-authorized shadow changes",
             "Verify post-operation shadow parity",
-            "missionchief-shadow-sync-${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.source_sha }}",
-            "retention-days: 30",
         ],
         "Shadow sync workflow",
     )
     forbid(
         workflow,
-        [
-            "pull_request_target:",
-            "schedule:",
-            "contents: write",
-            "HEAD:refs/heads/main",
-            "git update-ref refs/heads/main",
-            "gh api repos/${GITHUB_REPOSITORY}/git/refs/heads/main",
-            "secrets: inherit",
-        ],
+        ["schedule:", "contents: write", "HEAD:refs/heads/main", "secrets: inherit"],
         "Shadow sync workflow",
     )
 
@@ -129,13 +125,11 @@ def main() -> int:
         script,
         [
             "Synchronize only reviewed mirror files",
-            "preserves operational branch",
-            'value == "main"',
-            'branch == "main"',
-            'f"HEAD:refs/heads/{branch}"',
-            'mirrored = branch_policy.get("mirroredPaths")',
-            'operational = branch_policy.get("operationalPaths")',
-            'operational != [".github/greasyfork-version.txt"]',
+            "preserves every operational",
+            'RELEASE_STATE_PATHS = [',
+            'RELEASE_STATE_WRITERS = [',
+            'mirrored != [] or operational != RELEASE_STATE_PATHS',
+            'writers != RELEASE_STATE_WRITERS',
             'mirrored_paths, operational_paths = validate_path_classes',
             'for path in mirrored_paths:',
             'for path in operational_paths:',
@@ -147,7 +141,6 @@ def main() -> int:
             '"publicMainChanged": False',
             '"externalConsumersChanged": False',
             '"workflowContentsWrite": False',
-            '"narrowly scoped GitHub App"',
             "Shadow synchronization self-tests passed.",
         ],
         "Shadow sync script",
@@ -158,9 +151,7 @@ def main() -> int:
             '"HEAD:refs/heads/main"',
             "git update-ref refs/heads/main",
             "git push origin HEAD:main",
-            '"liveConsumerCutoverAllowed": True',
             'paths = list(branch_policy["governedPaths"])',
-            "shutil.copyfile(ROOT / path, worktree / path)",
             "push --force",
             "force-with-lease",
         ],
@@ -174,7 +165,7 @@ def main() -> int:
         "release-state",
         "distribution",
         "public `main` rejected as a target",
-        "`.github/greasyfork-version.txt` only",
+        "manual synchronizer has no file-copy authority on `release-state`",
     ]:
         if marker not in document:
             raise AssertionError(f"Human inventory is missing shadow writer marker: {marker}")
@@ -184,8 +175,8 @@ def main() -> int:
         raise AssertionError("Shadow synchronization self-tests failed")
 
     print(
-        "Shadow sync writer passed: manual owner confirmation, fixed targets, "
-        "mirror-only copies, preserved operational paths and no main mutation."
+        "Shadow sync writer passed: release-state mirror set empty, operational ledger preserved, "
+        "distribution mirror-only and no main mutation."
     )
     return 0
 

--- a/.github/scripts/verify_shadow_branch_parity.py
+++ b/.github/scripts/verify_shadow_branch_parity.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Verify Issue #41 operational branch roles and governed-file policy.
 
-Mirrored paths must remain byte-identical to the current checkout. Transitional
-operational paths may differ, but must satisfy their reviewed schema. This
-verifier is read-only and never creates, updates or force-pushes a ref.
+Mirrored paths must remain byte-identical to the current checkout. Operational
+paths may differ, but must satisfy their reviewed schemas and cross-file
+consistency rules. This verifier is read-only and never updates a ref.
 """
 
 from __future__ import annotations
@@ -19,6 +19,7 @@ ROOT = Path(__file__).resolve().parents[2]
 POLICY_PATH = ROOT / ".github" / "shadow-branch-policy.json"
 ROLE_PATH = ".github/branch-role.json"
 SEMVER = re.compile(r"^\d+\.\d+\.\d+(?:[+-][0-9A-Za-z.-]+)?$")
+FULL_HASH = re.compile(r"^[0-9a-f]{64}$")
 
 
 def git(*args: str, binary: bool = False) -> bytes | str:
@@ -47,10 +48,18 @@ def branch_json(branch: str, path: str) -> dict:
     return value
 
 
+def semver_tuple(value: str) -> tuple[int, int, int]:
+    core = value.split("+", 1)[0].split("-", 1)[0]
+    parts = core.split(".")
+    if len(parts) != 3 or not all(part.isdigit() for part in parts):
+        raise ValueError(f"Invalid semantic version: {value!r}")
+    return tuple(int(part) for part in parts)  # type: ignore[return-value]
+
+
 def load_policy() -> dict:
     value = json.loads(POLICY_PATH.read_text(encoding="utf-8"))
     if not isinstance(value, dict):
-        raise ValueError("Shadow branch policy must be a JSON object")
+        raise ValueError("Operational branch policy must be a JSON object")
     expected = {
         "schemaVersion": 1,
         "mode": "shadow-rehearsal",
@@ -63,11 +72,11 @@ def load_policy() -> dict:
     for key, expected_value in expected.items():
         if value.get(key) != expected_value:
             raise ValueError(
-                f"Shadow branch policy {key}={value.get(key)!r}, expected {expected_value!r}"
+                f"Operational branch policy {key}={value.get(key)!r}, expected {expected_value!r}"
             )
     branches = value.get("branches")
     if not isinstance(branches, dict) or set(branches) != {"release-state", "distribution"}:
-        raise ValueError("Shadow branch policy must define release-state and distribution")
+        raise ValueError("Operational policy must define release-state and distribution")
     for branch, policy in branches.items():
         validate_path_classes(branch, policy)
     return value
@@ -77,23 +86,38 @@ def validate_path_classes(branch: str, policy: dict) -> None:
     governed = policy.get("governedPaths")
     mirrored = policy.get("mirroredPaths")
     operational = policy.get("operationalPaths")
-    if not all(isinstance(value, list) for value in [governed, mirrored, operational]):
-        raise ValueError(f"{branch} path classes must be lists")
+    writers = policy.get("operationalWriters")
+    if not all(isinstance(value, list) for value in [governed, mirrored, operational, writers]):
+        raise ValueError(f"{branch} path classes and writers must be lists")
     if len(governed) != len(set(governed)):
         raise ValueError(f"{branch} governedPaths contains duplicates")
     if set(mirrored) & set(operational):
         raise ValueError(f"{branch} mirrored and operational paths overlap")
     if set(governed) != set(mirrored) | set(operational):
         raise ValueError(f"{branch} path classes do not partition governedPaths")
-    if branch == "release-state":
-        if operational != [".github/greasyfork-version.txt"]:
-            raise ValueError("release-state operational path must remain the fallback tracker only")
-        if policy.get("operationalWriter") != ".github/workflows/greasyfork-release-monitor.yml":
-            raise ValueError("release-state operational writer changed")
-    if branch == "distribution" and operational:
-        raise ValueError("distribution cannot have operational paths before cutover")
     if policy.get("externalConsumersEnabled") is not False:
         raise ValueError(f"{branch} external consumers must remain disabled")
+
+    if branch == "release-state":
+        expected_operational = [
+            "status/release-dashboard.json",
+            "status/README.md",
+            "status/update-manifest.json",
+            ".github/greasyfork-version.txt",
+        ]
+        expected_writers = [
+            ".github/workflows/greasyfork-release-monitor.yml",
+            ".github/workflows/release-recovery.yml",
+        ]
+        if mirrored != [] or operational != expected_operational:
+            raise ValueError("release-state must keep all recovery-ledger paths operational")
+        if writers != expected_writers:
+            raise ValueError("release-state operational writers changed")
+    if branch == "distribution":
+        if operational or writers:
+            raise ValueError("distribution cannot have operational paths before cutover")
+        if mirrored != governed:
+            raise ValueError("distribution paths must remain mirrored before cutover")
 
 
 def validate_role(branch: str, role: dict, policy: dict) -> list[str]:
@@ -110,23 +134,93 @@ def validate_role(branch: str, role: dict, policy: dict) -> list[str]:
     for key, value in expected.items():
         if role.get(key) != value:
             errors.append(f"{branch} role {key}={role.get(key)!r}, expected {value!r}")
-
     expected_allowed = [*policy["governedPaths"], ROLE_PATH]
     if role.get("allowedMutablePaths") != expected_allowed:
         errors.append(f"{branch} allowedMutablePaths differs from reviewed policy")
-    authority = str(role.get("authority") or "")
-    if "main remains authoritative" not in authority:
-        errors.append(f"{branch} role does not preserve main authority during migration")
+    if "main remains authoritative" not in str(role.get("authority") or ""):
+        errors.append(f"{branch} role no longer preserves main source authority")
     return errors
 
 
-def validate_operational_content(path: str, content: bytes) -> tuple[bool, str]:
+def validate_operational_content(path: str, content: bytes) -> tuple[bool, str, dict]:
+    metadata: dict[str, object] = {}
+    try:
+        text = content.decode("utf-8")
+    except UnicodeDecodeError:
+        return False, "content is not UTF-8", metadata
+
+    if path == "status/release-dashboard.json":
+        try:
+            dashboard = json.loads(text)
+        except json.JSONDecodeError:
+            return False, "dashboard is not valid JSON", metadata
+        if not isinstance(dashboard, dict):
+            return False, "dashboard is not a JSON object", metadata
+        latest = dashboard.get("latestRelease") or {}
+        version = str(latest.get("version") or "")
+        current = str(dashboard.get("currentVersion") or "")
+        if not SEMVER.fullmatch(version) or current != version:
+            return False, "dashboard current/latest version is invalid", metadata
+        if not isinstance(dashboard.get("status"), dict):
+            return False, "dashboard status object is missing", metadata
+        sha256 = str(latest.get("sha256") or "")
+        if sha256 and not FULL_HASH.fullmatch(sha256):
+            return False, "dashboard release SHA-256 is invalid", metadata
+        metadata.update({"version": version, "dashboard": dashboard})
+        return True, f"operational dashboard v{version}", metadata
+
+    if path == "status/README.md":
+        if not text.startswith("# MissionChief Toolkit Control Panel"):
+            return False, "rendered dashboard heading is invalid", metadata
+        match = re.search(r"## Current version: `([^`]+)`", text)
+        if not match or not SEMVER.fullmatch(match.group(1)):
+            return False, "rendered dashboard version is invalid", metadata
+        metadata["version"] = match.group(1)
+        return True, f"rendered dashboard v{match.group(1)}", metadata
+
+    if path == "status/update-manifest.json":
+        try:
+            manifest = json.loads(text)
+        except json.JSONDecodeError:
+            return False, "stable manifest is not valid JSON", metadata
+        if not isinstance(manifest, dict):
+            return False, "stable manifest is not a JSON object", metadata
+        version = str(manifest.get("version") or "")
+        sha256 = str(manifest.get("sha256") or "")
+        if manifest.get("schemaVersion") != 1 or manifest.get("channel") != "stable":
+            return False, "stable manifest schema/channel is invalid", metadata
+        if not SEMVER.fullmatch(version) or not FULL_HASH.fullmatch(sha256):
+            return False, "stable manifest version or SHA-256 is invalid", metadata
+        metadata.update({"version": version, "manifest": manifest})
+        return True, f"stable manifest v{version}", metadata
+
     if path == ".github/greasyfork-version.txt":
-        value = content.decode("utf-8").strip()
+        value = text.strip()
         if not SEMVER.fullmatch(value):
-            return False, f"fallback tracker is not a stable semantic version: {value!r}"
-        return True, f"operational tracker v{value}"
-    return False, f"no operational schema is defined for {path}"
+            return False, f"fallback tracker is not a stable semantic version: {value!r}", metadata
+        metadata["version"] = value
+        return True, f"announcement tracker v{value}", metadata
+
+    return False, f"no operational schema is defined for {path}", metadata
+
+
+def cross_validate_release_state(files: list[dict[str, object]]) -> list[str]:
+    errors: list[str] = []
+    by_path = {str(file["path"]): file for file in files}
+    dashboard_version = str((by_path["status/release-dashboard.json"].get("metadata") or {}).get("version") or "")
+    readme_version = str((by_path["status/README.md"].get("metadata") or {}).get("version") or "")
+    manifest_version = str((by_path["status/update-manifest.json"].get("metadata") or {}).get("version") or "")
+    tracker_version = str((by_path[".github/greasyfork-version.txt"].get("metadata") or {}).get("version") or "")
+
+    if dashboard_version and readme_version and dashboard_version != readme_version:
+        errors.append("release-state dashboard and rendered Markdown versions differ")
+    if dashboard_version and manifest_version:
+        if semver_tuple(manifest_version) > semver_tuple(dashboard_version):
+            errors.append("release-state stable manifest is ahead of the recovery dashboard")
+    if dashboard_version and tracker_version:
+        if semver_tuple(tracker_version) > semver_tuple(dashboard_version):
+            errors.append("release-state announcement tracker is ahead of the recovery dashboard")
+    return errors
 
 
 def compare_branch(branch: str, policy: dict) -> dict:
@@ -142,35 +236,27 @@ def compare_branch(branch: str, policy: dict) -> dict:
             remote = branch_file(branch, path)
         except subprocess.CalledProcessError:
             errors.append(f"{branch} is missing governed path {path}")
-            files.append(
-                {
-                    "path": path,
-                    "mode": "operational" if path in operational else "mirror",
-                    "equal": False,
-                    "acceptable": False,
-                    "reason": "branch-missing",
-                }
-            )
+            files.append({"path": path, "mode": "missing", "acceptable": False})
             continue
-
         local = local_path.read_bytes() if local_path.is_file() else None
         equal = local == remote if local is not None else False
+
         if path in mirrored:
             acceptable = local is not None and equal
             reason = "byte-identical" if acceptable else "mirror-mismatch"
-            if local is None:
-                errors.append(f"Current checkout is missing mirrored path {path}")
-            elif not equal:
+            metadata: dict[str, object] = {}
+            if not acceptable:
                 errors.append(f"{branch}:{path} differs from current checkout")
             mode = "mirror"
         elif path in operational:
-            acceptable, reason = validate_operational_content(path, remote)
+            acceptable, reason, metadata = validate_operational_content(path, remote)
             if not acceptable:
                 errors.append(f"{branch}:{path} is invalid: {reason}")
             mode = "operational"
         else:
             acceptable = False
             reason = "unclassified"
+            metadata = {}
             mode = "unknown"
             errors.append(f"{branch}:{path} has no reviewed path class")
 
@@ -182,16 +268,19 @@ def compare_branch(branch: str, policy: dict) -> dict:
                 "acceptable": acceptable,
                 "reason": reason,
                 "bytes": len(remote),
+                "metadata": metadata,
             }
         )
 
+    if branch == "release-state" and all(bool(file.get("acceptable")) for file in files):
+        errors.extend(cross_validate_release_state(files))
     return {
         "branch": branch,
         "purpose": policy["purpose"],
         "commit": str(git("rev-parse", branch_ref(branch))).strip(),
         "role": role,
         "files": files,
-        "acceptable": not errors and all(bool(file["acceptable"]) for file in files),
+        "acceptable": not errors and all(bool(file.get("acceptable")) for file in files),
         "errors": errors,
     }
 
@@ -219,12 +308,10 @@ def render_markdown(report: dict) -> str:
             ]
         )
         for file in branch["files"]:
-            marker = "✅" if file["acceptable"] else "❌"
-            suffix = "mirror" if file["mode"] == "mirror" else "operational"
-            equality = "equal" if file["equal"] else "independent"
-            lines.append(
-                f"- {marker} `{file['path']}` — {suffix}, {equality}: {file['reason']}"
-            )
+            marker = "✅" if file.get("acceptable") else "❌"
+            mode = str(file.get("mode") or "unknown")
+            equality = "equal" if file.get("equal") else "independent"
+            lines.append(f"- {marker} `{file['path']}` — {mode}, {equality}: {file.get('reason', '')}")
         if branch["errors"]:
             lines.extend(["", "### Errors", ""])
             lines.extend(f"- {error}" for error in branch["errors"])
@@ -237,11 +324,21 @@ def self_test() -> None:
         "purpose": "test",
         "governedPaths": [
             "status/release-dashboard.json",
+            "status/README.md",
+            "status/update-manifest.json",
             ".github/greasyfork-version.txt",
         ],
-        "mirroredPaths": ["status/release-dashboard.json"],
-        "operationalPaths": [".github/greasyfork-version.txt"],
-        "operationalWriter": ".github/workflows/greasyfork-release-monitor.yml",
+        "mirroredPaths": [],
+        "operationalPaths": [
+            "status/release-dashboard.json",
+            "status/README.md",
+            "status/update-manifest.json",
+            ".github/greasyfork-version.txt",
+        ],
+        "operationalWriters": [
+            ".github/workflows/greasyfork-release-monitor.yml",
+            ".github/workflows/release-recovery.yml",
+        ],
         "externalConsumersEnabled": False,
     }
     validate_path_classes("release-state", policy)
@@ -259,15 +356,7 @@ def self_test() -> None:
     assert not validate_role("release-state", role, policy)
     assert validate_operational_content(".github/greasyfork-version.txt", b"5.0.7\n")[0]
     assert not validate_operational_content(".github/greasyfork-version.txt", b"latest\n")[0]
-
-    broken = dict(policy)
-    broken["mirroredPaths"] = [*policy["mirroredPaths"], ".github/greasyfork-version.txt"]
-    try:
-        validate_path_classes("release-state", broken)
-    except ValueError:
-        pass
-    else:
-        raise AssertionError("overlapping path classes were accepted")
+    assert semver_tuple("5.0.7") < semver_tuple("5.0.8")
     print("Shadow branch parity self-tests passed.")
 
 
@@ -294,14 +383,11 @@ def main() -> int:
     ]
     acceptable = all(branch["acceptable"] for branch in branches)
     report = {
-        "schemaVersion": 2,
+        "schemaVersion": 3,
         "state": "acceptable" if acceptable else "mismatch",
         "acceptable": acceptable,
         "sourceCommit": str(git("rev-parse", "HEAD")).strip(),
-        "generatedAt": datetime.now(timezone.utc)
-        .replace(microsecond=0)
-        .isoformat()
-        .replace("+00:00", "Z"),
+        "generatedAt": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
         "publicMainChanged": False,
         "externalConsumersChanged": False,
         "branches": branches,

--- a/.github/shadow-branch-policy.json
+++ b/.github/shadow-branch-policy.json
@@ -25,7 +25,7 @@
   },
   "branches": {
     "release-state": {
-      "purpose": "Mirror verified dashboard and manifest state while operating the transitional fallback announcement tracker.",
+      "purpose": "Operate the recovery dashboard, rendered status, stable manifest and announcement tracker without public-main commits.",
       "rolePath": ".github/branch-role.json",
       "governedPaths": [
         "status/release-dashboard.json",
@@ -33,15 +33,17 @@
         "status/update-manifest.json",
         ".github/greasyfork-version.txt"
       ],
-      "mirroredPaths": [
+      "mirroredPaths": [],
+      "operationalPaths": [
         "status/release-dashboard.json",
         "status/README.md",
-        "status/update-manifest.json"
-      ],
-      "operationalPaths": [
+        "status/update-manifest.json",
         ".github/greasyfork-version.txt"
       ],
-      "operationalWriter": ".github/workflows/greasyfork-release-monitor.yml",
+      "operationalWriters": [
+        ".github/workflows/greasyfork-release-monitor.yml",
+        ".github/workflows/release-recovery.yml"
+      ],
       "externalConsumersEnabled": false
     },
     "distribution": {
@@ -64,6 +66,7 @@
         "MissionChief_Map_Command_Toolkit.txt"
       ],
       "operationalPaths": [],
+      "operationalWriters": [],
       "externalConsumersEnabled": false
     }
   }

--- a/.github/workflows/release-recovery-validation.yml
+++ b/.github/workflows/release-recovery-validation.yml
@@ -89,6 +89,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          MAIN_BRANCH='main'
+          PROHIBITED_PUSH="git push origin HEAD:${MAIN_BRANCH}"
+          PROHIBITED_PULL="git pull --rebase origin ${MAIN_BRANCH}"
           grep -Fq 'group: toolkit-production-release' .github/workflows/release-recovery.yml
           grep -Fq 'Check out latest main authority' .github/workflows/release-recovery.yml
           grep -Fq 'persist-credentials: false' .github/workflows/release-recovery.yml
@@ -96,8 +99,8 @@ jobs:
           grep -Fq 'Claim Discord retry on release-state without posting' .github/workflows/release-recovery.yml
           grep -Fq 'latest GitHub Release' .github/workflows/release-recovery.yml
           grep -Fq 'Public main changed: no' .github/workflows/release-recovery.yml
-          ! grep -Fq 'git push origin HEAD:main' .github/workflows/release-recovery.yml
-          ! grep -Fq 'git pull --rebase origin main' .github/workflows/release-recovery.yml
+          ! grep -Fq "$PROHIBITED_PUSH" .github/workflows/release-recovery.yml
+          ! grep -Fq "$PROHIBITED_PULL" .github/workflows/release-recovery.yml
           grep -Fq 'This PR does **not** publish a GitHub Release.' .github/workflows/prepare-release-rollback.yml
           grep -Fq 'ALLOW_EXISTING_IDENTICAL' .github/scripts/backup_release_to_private_repo.sh
           echo "Release-state recovery safety invariants are present."

--- a/.github/workflows/release-recovery-validation.yml
+++ b/.github/workflows/release-recovery-validation.yml
@@ -6,9 +6,16 @@ on:
       - ".github/scripts/download_verified_release_bundle.sh"
       - ".github/scripts/backup_release_to_private_repo.sh"
       - ".github/scripts/prepare_rollback_candidate.py"
+      - ".github/scripts/release_recovery_state.py"
+      - ".github/scripts/release_state_branch.py"
+      - ".github/scripts/test_release_recovery_state_pipeline.py"
+      - ".github/branch-write-inventory.json"
+      - ".github/shadow-branch-policy.json"
       - ".github/workflows/release-recovery.yml"
       - ".github/workflows/prepare-release-rollback.yml"
       - ".github/workflows/release-recovery-validation.yml"
+      - "docs/BRANCH_PROTECTION_MIGRATION.md"
+      - "docs/BRANCH_WRITE_INVENTORY.md"
       - "docs/RELEASE_RECOVERY.md"
   workflow_dispatch:
 
@@ -28,35 +35,35 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
-      - name: Validate shell syntax
+      - name: Validate script syntax
         run: |
           bash -n .github/scripts/download_verified_release_bundle.sh
           bash -n .github/scripts/backup_release_to_private_repo.sh
+          python3 -m py_compile .github/scripts/prepare_rollback_candidate.py
+          python3 -m py_compile .github/scripts/release_state_branch.py
+          python3 -m py_compile .github/scripts/release_recovery_state.py
+          python3 -m py_compile .github/scripts/test_release_recovery_state_pipeline.py
 
-      - name: Run rollback generator self-tests
-        run: python3 .github/scripts/prepare_rollback_candidate.py --self-test
+      - name: Run recovery helper self-tests
+        run: |
+          python3 .github/scripts/prepare_rollback_candidate.py --self-test
+          python3 .github/scripts/release_state_branch.py --self-test
+          python3 .github/scripts/release_recovery_state.py --self-test
 
-      - name: Parse direct recovery workflow YAML
+      - name: Run release-state recovery contract
+        run: python3 .github/scripts/test_release_recovery_state_pipeline.py
+
+      - name: Parse recovery workflow YAML
         shell: ruby {0}
         run: |
           require "yaml"
           YAML.parse_file(".github/workflows/release-recovery.yml")
-          puts "Parsed direct recovery workflow"
-
-      - name: Parse rollback workflow YAML
-        shell: ruby {0}
-        run: |
-          require "yaml"
           YAML.parse_file(".github/workflows/prepare-release-rollback.yml")
-          puts "Parsed rollback workflow"
-
-      - name: Parse validator workflow YAML
-        shell: ruby {0}
-        run: |
-          require "yaml"
           YAML.parse_file(".github/workflows/release-recovery-validation.yml")
-          puts "Parsed recovery validator workflow"
+          puts "Parsed recovery workflows"
 
       - name: Validate documented confirmation phrases
         shell: bash
@@ -83,8 +90,14 @@ jobs:
         run: |
           set -euo pipefail
           grep -Fq 'group: toolkit-production-release' .github/workflows/release-recovery.yml
-          grep -Fq 'Discord retry is marked pending' .github/workflows/release-recovery.yml
+          grep -Fq 'Check out latest main authority' .github/workflows/release-recovery.yml
+          grep -Fq 'persist-credentials: false' .github/workflows/release-recovery.yml
+          grep -Fq 'Prepare governed release-state worktree' .github/workflows/release-recovery.yml
+          grep -Fq 'Claim Discord retry on release-state without posting' .github/workflows/release-recovery.yml
           grep -Fq 'latest GitHub Release' .github/workflows/release-recovery.yml
+          grep -Fq 'Public main changed: no' .github/workflows/release-recovery.yml
+          ! grep -Fq 'git push origin HEAD:main' .github/workflows/release-recovery.yml
+          ! grep -Fq 'git pull --rebase origin main' .github/workflows/release-recovery.yml
           grep -Fq 'This PR does **not** publish a GitHub Release.' .github/workflows/prepare-release-rollback.yml
           grep -Fq 'ALLOW_EXISTING_IDENTICAL' .github/scripts/backup_release_to_private_repo.sh
-          echo "Recovery safety invariants are present."
+          echo "Release-state recovery safety invariants are present."

--- a/.github/workflows/release-recovery.yml
+++ b/.github/workflows/release-recovery.yml
@@ -47,11 +47,12 @@ jobs:
     timeout-minutes: 45
 
     steps:
-      - name: Check out latest main
+      - name: Check out latest main authority
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: main
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Validate operation and confirmation
         id: safety
@@ -99,6 +100,45 @@ jobs:
 
           echo "latest_tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
           echo "Safety gate passed for ${OPERATION} on v${RELEASE_VERSION}."
+
+      - name: Verify recovery-state self-tests
+        if: >-
+          inputs.operation == 'retry-greasyfork' ||
+          inputs.operation == 'retry-private-backup' ||
+          inputs.operation == 'retry-discord' ||
+          inputs.operation == 'rebuild-dashboard'
+        run: |
+          python3 .github/scripts/release_state_branch.py --self-test
+          python3 .github/scripts/release_recovery_state.py --self-test
+
+      - name: Prepare governed release-state worktree
+        id: release_state
+        if: >-
+          inputs.operation == 'retry-greasyfork' ||
+          inputs.operation == 'retry-private-backup' ||
+          inputs.operation == 'retry-discord' ||
+          inputs.operation == 'rebuild-dashboard'
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/release_state_branch.py prepare \
+            --worktree "$RUNNER_TEMP/release-state"
+
+      - name: Seed recovery ledger from verified main compatibility state
+        if: >-
+          inputs.operation == 'retry-greasyfork' ||
+          inputs.operation == 'retry-private-backup' ||
+          inputs.operation == 'retry-discord'
+        env:
+          RELEASE_STATE_ROOT: ${{ steps.release_state.outputs.root }}
+          RELEASE_VERSION: ${{ inputs.version }}
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/release_recovery_state.py seed \
+            --state-root "$RELEASE_STATE_ROOT" \
+            --version "$RELEASE_VERSION"
 
       - name: Verify immutable GitHub Release bundle
         id: bundle
@@ -151,31 +191,18 @@ jobs:
             --report /tmp/recovery-asset-health.json \
             --markdown /tmp/recovery-asset-health.md
 
-      - name: Record Greasy Fork recovery
+      - name: Record Greasy Fork recovery on release-state
         if: inputs.operation == 'retry-greasyfork'
         env:
           RELEASE_VERSION: ${{ inputs.version }}
+          RELEASE_STATE_ROOT: ${{ steps.release_state.outputs.root }}
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
-          NOW="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-          jq --arg version "$RELEASE_VERSION" --arg now "$NOW" \
-            'if .latestRelease.version == $version then
-               .status.greasyForkSync="verified" |
-               .latestRelease.greasyForkVerified=true |
-               .lastUpdated=$now
-             else error("dashboard latest release does not match recovery version") end' \
-            status/release-dashboard.json > status/release-dashboard.tmp
-          mv status/release-dashboard.tmp status/release-dashboard.json
-          python3 .github/scripts/generate_release_dashboard.py
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add status/release-dashboard.json status/README.md
-          if ! git diff --cached --quiet; then
-            git commit -m "Record Toolkit ${RELEASE_VERSION} Greasy Fork recovery"
-            git pull --rebase origin main
-            git push origin HEAD:main
-          fi
+          python3 .github/scripts/release_recovery_state.py record-greasyfork \
+            --state-root "$RELEASE_STATE_ROOT" \
+            --version "$RELEASE_VERSION"
 
       - name: Retry private migration backup
         id: backup
@@ -188,79 +215,36 @@ jobs:
         shell: bash
         run: bash .github/scripts/backup_release_to_private_repo.sh
 
-      - name: Record private backup recovery
+      - name: Record private backup recovery on release-state
         if: inputs.operation == 'retry-private-backup'
         env:
           RELEASE_VERSION: ${{ inputs.version }}
           BACKUP_COMMIT: ${{ steps.backup.outputs.backup_commit }}
+          RELEASE_STATE_ROOT: ${{ steps.release_state.outputs.root }}
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
-          NOW="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-          [[ -n "$BACKUP_COMMIT" ]] || { echo "::error::Private backup commit was not recorded."; exit 1; }
-          jq --arg version "$RELEASE_VERSION" --arg backup "$BACKUP_COMMIT" --arg now "$NOW" \
-            'if .latestRelease.version == $version then
-               .status.backup="private-repository-verified" |
-               .latestRelease.privateBackupCommit=$backup |
-               .lastUpdated=$now
-             else error("dashboard latest release does not match recovery version") end' \
-            status/release-dashboard.json > status/release-dashboard.tmp
-          mv status/release-dashboard.tmp status/release-dashboard.json
-          python3 .github/scripts/generate_release_dashboard.py
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add status/release-dashboard.json status/README.md
-          if ! git diff --cached --quiet; then
-            git commit -m "Record Toolkit ${RELEASE_VERSION} private backup recovery"
-            git pull --rebase origin main
-            git push origin HEAD:main
-          fi
+          python3 .github/scripts/release_recovery_state.py record-backup \
+            --state-root "$RELEASE_STATE_ROOT" \
+            --version "$RELEASE_VERSION" \
+            --backup-commit "$BACKUP_COMMIT"
 
-      - name: Claim Discord retry without posting
+      - name: Claim Discord retry on release-state without posting
         id: discord_guard
         if: inputs.operation == 'retry-discord'
         env:
           RELEASE_VERSION: ${{ inputs.version }}
+          RELEASE_STATE_ROOT: ${{ steps.release_state.outputs.root }}
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
-          DASHBOARD="status/release-dashboard.json"
-          DASHBOARD_VERSION="$(jq -r '.latestRelease.version // empty' "$DASHBOARD")"
-          GF_VERIFIED="$(jq -r '.latestRelease.greasyForkVerified // false' "$DASHBOARD")"
-          BACKUP_COMMIT="$(jq -r '.latestRelease.privateBackupCommit // empty' "$DASHBOARD")"
-          DISCORD_POSTED="$(jq -r '.latestRelease.discordPosted // false' "$DASHBOARD")"
-          PENDING="$(jq -r '.recovery.discordAnnouncement.state // empty' "$DASHBOARD")"
-
-          [[ "$DASHBOARD_VERSION" == "$RELEASE_VERSION" ]] || { echo "::error::Dashboard latest version does not match."; exit 1; }
-          [[ "$GF_VERIFIED" == "true" ]] || { echo "::error::Greasy Fork is not verified; Discord retry is blocked."; exit 1; }
-          [[ -n "$BACKUP_COMMIT" ]] || { echo "::error::Private backup is not recorded; Discord retry is blocked."; exit 1; }
-
-          if [[ "$DISCORD_POSTED" == "true" ]]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "Discord is already recorded as posted; retry suppressed."
-            exit 0
-          fi
-          [[ -z "$PENDING" ]] || {
-            echo "::error::A previous Discord retry is marked pending. Inspect Discord manually before clearing the ambiguous state; automatic reposting is blocked."
-            exit 1
-          }
-
           NONCE="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          NOW="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-          jq --arg version "$RELEASE_VERSION" --arg nonce "$NONCE" --arg now "$NOW" \
-            '.recovery.discordAnnouncement={version:$version,state:"pending",nonce:$nonce,startedAt:$now}' \
-            "$DASHBOARD" > status/release-dashboard.tmp
-          mv status/release-dashboard.tmp "$DASHBOARD"
-          python3 .github/scripts/generate_release_dashboard.py
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add "$DASHBOARD" status/README.md
-          git commit -m "Claim Toolkit ${RELEASE_VERSION} Discord recovery"
-          git pull --rebase origin main
-          git push origin HEAD:main
-          echo "skip=false" >> "$GITHUB_OUTPUT"
-          echo "backup_commit=$BACKUP_COMMIT" >> "$GITHUB_OUTPUT"
-          echo "nonce=$NONCE" >> "$GITHUB_OUTPUT"
+          python3 .github/scripts/release_recovery_state.py claim-discord \
+            --state-root "$RELEASE_STATE_ROOT" \
+            --version "$RELEASE_VERSION" \
+            --nonce "$NONCE"
 
       - name: Retry verified Discord release announcement
         if: inputs.operation == 'retry-discord' && steps.discord_guard.outputs.skip != 'true'
@@ -285,44 +269,27 @@ jobs:
             --install-url "$INSTALL_URL" \
             --sha256 "$HASH" \
             --backup-commit "$BACKUP_COMMIT"
+
           curl --fail --silent --show-error --max-time 30 --retry 2 --retry-delay 5 \
             --request POST --header "Content-Type: application/json" \
             --data @/tmp/discord-release-payload.json "${DISCORD_WEBHOOK_URL}?wait=true" \
             > /tmp/discord-release-response.json
           jq -e '.id and .channel_id' /tmp/discord-release-response.json >/dev/null
 
-      - name: Finalize Discord recovery state
+      - name: Finalize Discord recovery on release-state
         if: inputs.operation == 'retry-discord' && steps.discord_guard.outputs.skip != 'true'
         env:
           RELEASE_VERSION: ${{ inputs.version }}
           EXPECTED_NONCE: ${{ steps.discord_guard.outputs.nonce }}
+          RELEASE_STATE_ROOT: ${{ steps.release_state.outputs.root }}
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
-          git fetch origin main
-          git reset --hard origin/main
-          DASHBOARD="status/release-dashboard.json"
-          NONCE="$(jq -r '.recovery.discordAnnouncement.nonce // empty' "$DASHBOARD")"
-          [[ "$NONCE" == "$EXPECTED_NONCE" ]] || { echo "::error::Discord recovery claim changed before finalization."; exit 1; }
-          NOW="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-          jq --arg version "$RELEASE_VERSION" --arg now "$NOW" \
-            'if .latestRelease.version == $version then
-               .status.discordRelease="posted" |
-               .latestRelease.discordPosted=true |
-               .latestRelease.completedAt=(.latestRelease.completedAt // $now) |
-               .lastUpdated=$now |
-               del(.recovery.discordAnnouncement)
-             else error("dashboard latest release does not match recovery version") end' \
-            "$DASHBOARD" > status/release-dashboard.tmp
-          mv status/release-dashboard.tmp "$DASHBOARD"
-          printf '%s\n' "$RELEASE_VERSION" > .github/greasyfork-version.txt
-          python3 .github/scripts/generate_release_dashboard.py
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add "$DASHBOARD" status/README.md .github/greasyfork-version.txt
-          git commit -m "Record Toolkit ${RELEASE_VERSION} Discord recovery"
-          git pull --rebase origin main
-          git push origin HEAD:main
+          python3 .github/scripts/release_recovery_state.py finalize-discord \
+            --state-root "$RELEASE_STATE_ROOT" \
+            --version "$RELEASE_VERSION" \
+            --nonce "$EXPECTED_NONCE"
 
       - name: Verify private archive for dashboard rebuild
         id: rebuild_backup
@@ -348,7 +315,7 @@ jobs:
           [[ -n "$BACKUP_COMMIT" ]] || { echo "::error::Could not resolve private backup commit."; exit 1; }
           echo "backup_commit=$BACKUP_COMMIT" >> "$GITHUB_OUTPUT"
 
-      - name: Rebuild verified release dashboard
+      - name: Rebuild verified release dashboard on release-state
         if: inputs.operation == 'rebuild-dashboard'
         env:
           RELEASE_VERSION: ${{ inputs.version }}
@@ -356,6 +323,8 @@ jobs:
           RELEASE_URL: ${{ steps.bundle.outputs.release_url }}
           BACKUP_COMMIT: ${{ steps.rebuild_backup.outputs.backup_commit }}
           DISCORD_STATE: ${{ inputs.discord_state }}
+          RELEASE_STATE_ROOT: ${{ steps.release_state.outputs.root }}
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
@@ -365,42 +334,13 @@ jobs:
             "${META_URL}?cache_bust=$(date +%s%N)" | sed -nE 's|^//[[:space:]]*@version[[:space:]]+(.+)$|\1|p' | head -n 1 | xargs)"
           [[ "$LIVE_VERSION" == "$RELEASE_VERSION" ]] || { echo "::error::Greasy Fork does not report v${RELEASE_VERSION}."; exit 1; }
 
-          case "$DISCORD_STATE" in
-            posted) DISCORD_POSTED=true ;;
-            not-posted) DISCORD_POSTED=false ;;
-            preserve)
-              [[ "$(jq -r '.latestRelease.version // empty' status/release-dashboard.json)" == "$RELEASE_VERSION" ]] || {
-                echo "::error::Cannot preserve Discord state because the existing dashboard records a different version."
-                exit 1
-              }
-              DISCORD_POSTED="$(jq -r '.latestRelease.discordPosted // false' status/release-dashboard.json)"
-              ;;
-          esac
-
-          NOW="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-          jq --arg version "$RELEASE_VERSION" --arg hash "$RELEASE_HASH" --arg releaseUrl "$RELEASE_URL" \
-             --arg backup "$BACKUP_COMMIT" --arg now "$NOW" --argjson discord "$DISCORD_POSTED" \
-            '.currentVersion=$version |
-             .status.validation="passed" |
-             .status.githubRelease="published" |
-             .status.greasyForkSync="verified" |
-             .status.backup="private-repository-verified" |
-             .status.discordRelease=(if $discord then "posted" else "not-posted" end) |
-             .latestRelease={version:$version,sha256:$hash,githubRelease:$releaseUrl,greasyForkVerified:true,privateBackupCommit:$backup,discordPosted:$discord,completedAt:$now} |
-             .lastUpdated=$now |
-             del(.recovery.discordAnnouncement)' \
-            status/release-dashboard.json > status/release-dashboard.tmp
-          mv status/release-dashboard.tmp status/release-dashboard.json
-          if [[ "$DISCORD_POSTED" == "true" ]]; then
-            printf '%s\n' "$RELEASE_VERSION" > .github/greasyfork-version.txt
-          fi
-          python3 .github/scripts/generate_release_dashboard.py
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add status/release-dashboard.json status/README.md .github/greasyfork-version.txt
-          git commit -m "Rebuild Toolkit ${RELEASE_VERSION} release dashboard"
-          git pull --rebase origin main
-          git push origin HEAD:main
+          python3 .github/scripts/release_recovery_state.py rebuild-dashboard \
+            --state-root "$RELEASE_STATE_ROOT" \
+            --version "$RELEASE_VERSION" \
+            --sha256 "$RELEASE_HASH" \
+            --release-url "$RELEASE_URL" \
+            --backup-commit "$BACKUP_COMMIT" \
+            --discord-state "$DISCORD_STATE"
 
       - name: Repair stable GitHub Release assets
         if: inputs.operation == 'repair-stable-assets'
@@ -450,5 +390,7 @@ jobs:
             echo "- Version: \`v${RELEASE_VERSION}\`"
             echo "- Verified SHA-256: \`${RELEASE_HASH:-unavailable}\`"
             echo "- Production lock: \`toolkit-production-release\`"
+            echo "- Recovery ledger: \`release-state\`"
+            echo "- Public main changed: no"
             echo "- No new GitHub Release was created"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/validate-development-package-workflow.yml
+++ b/.github/workflows/validate-development-package-workflow.yml
@@ -17,6 +17,7 @@ on:
       - ".github/scripts/generate_release_dashboard.py"
       - ".github/scripts/reconcile_pages_incident.sh"
       - ".github/scripts/reconcile_validation_dashboard.py"
+      - ".github/scripts/release_recovery_state.py"
       - ".github/scripts/release_state_branch.py"
       - ".github/scripts/sync_shadow_branches.py"
       - ".github/scripts/verify_shadow_branch_parity.py"
@@ -30,6 +31,7 @@ on:
       - ".github/scripts/test_development_package_workflow.py"
       - ".github/scripts/test_greasyfork_parity_pipeline.py"
       - ".github/scripts/test_release_announcement_state_pipeline.py"
+      - ".github/scripts/test_release_recovery_state_pipeline.py"
       - ".github/scripts/test_release_state_monitor_pipeline.py"
       - ".github/scripts/test_shadow_branch_parity.py"
       - ".github/scripts/test_shadow_sync_writer.py"
@@ -73,6 +75,7 @@ jobs:
             python3 .github/scripts/test_greasyfork_parity_pipeline.py
             python3 .github/scripts/test_release_announcement_state_pipeline.py
             python3 .github/scripts/test_release_state_monitor_pipeline.py
+            python3 .github/scripts/test_release_recovery_state_pipeline.py
             python3 .github/scripts/test_shadow_branch_parity.py
             python3 .github/scripts/test_shadow_sync_writer.py
             python3 .github/scripts/test_update_manifest_pipeline.py

--- a/docs/BRANCH_PROTECTION_MIGRATION.md
+++ b/docs/BRANCH_PROTECTION_MIGRATION.md
@@ -1,6 +1,6 @@
 # Branch Protection Migration Plan
 
-Strict pull-request-only protection is **not yet enabled**. Controlled automation commits remain because stable distribution publication, consolidated release state and recovery still mutate public `main`.
+Strict pull-request-only protection is **not yet enabled**. One controlled public-main writer remains because stable production publication still commits distribution and compatibility release state required by existing v5.0.7 installations.
 
 The migration is tracked by Issue #41. Authority is maintained in:
 
@@ -13,6 +13,7 @@ The migration is tracked by Issue #41. Authority is maintained in:
 - `.github/scripts/test_release_announcement_state_pipeline.py`;
 - `.github/scripts/test_update_manifest_pipeline.py`;
 - `.github/scripts/test_release_state_monitor_pipeline.py`;
+- `.github/scripts/test_release_recovery_state_pipeline.py`;
 - `.github/scripts/test_shadow_branch_parity.py`;
 - `.github/scripts/test_shadow_sync_writer.py`.
 
@@ -26,17 +27,18 @@ The migration is tracked by Issue #41. Authority is maintained in:
 - explicit production, recovery and shadow-synchronization confirmation phrases;
 - exact commit/ref/hash validation evidence;
 - deterministic dashboard, Greasy Fork, announcement-state and update-manifest verification;
-- atomic primary release dashboard, stable manifest and announcement state;
+- atomic production dashboard, stable manifest and announcement compatibility state;
 - isolated non-live `release-state` and `distribution` branches;
-- a manual-only, fixed-target shadow writer with read-only workflow permission;
 - verified administrator repair access to both operational branches;
-- a constrained release-state worktree helper with role, path and ancestry validation.
+- a constrained release-state transaction helper with role, path and ancestry validation;
+- complete recovery-ledger transactions on `release-state`;
+- manual shadow synchronization with no file-copy authority over release-state data.
 
 ## Completed migration stages
 
 ### Write-path inventory ✅
 
-The 24 July 2026 baseline identified 10 direct public-main writers. Every `contents: write` workflow and executable main-ref mutation is classified by target branch and fail-closed in CI.
+The 24 July 2026 baseline identified 10 direct public-main writers. Every `contents: write` workflow and executable main-ref mutation is now classified by target branch and fail-closed in CI.
 
 ### Artifact-only validation and evidence ✅
 
@@ -54,7 +56,7 @@ Seven workflows verify with read-only repository access and retained immutable e
 
 Automatic source importing is retired. GitHub is authoritative. Live Greasy Fork parity accepts canonical-ahead during publication and fails on live-ahead or equal-version content drift.
 
-### Atomic release dashboard, manifest and announcement state ✅
+### Atomic production compatibility state ✅
 
 Normal production releases no longer require follow-up announcement or manifest commits.
 
@@ -65,19 +67,19 @@ After Greasy Fork verification, private backup and Discord publication, `release
 - `status/update-manifest.json`;
 - `.github/greasyfork-version.txt`.
 
-The manifest is built by `.github/scripts/build_stable_update_manifest.py`. The former publisher is now a read-only projection verifier with 30-day retained evidence.
+The manifest is built by `.github/scripts/build_stable_update_manifest.py`. The former publisher is now a read-only projection verifier with retained evidence.
 
 The existing v5.0.7 runtime URL remains unchanged:
 
 `raw.githubusercontent.com/Conroy1988/missionchief-toolkit-assets/main/status/update-manifest.json`
 
-This is a compatibility stage. A later versioned Toolkit release will move the runtime consumer to the final `release-state` endpoint.
+This is temporary compatibility state. A later versioned Toolkit release will move the runtime consumer to the final `release-state` endpoint.
 
 ### Operational branch topology and access rehearsal ✅
 
 PRs #506–#507 established:
 
-- `release-state` for verified dashboard, manifest and announcement state;
+- `release-state` for dashboard, manifest, announcement and recovery state;
 - `distribution` for stable `dist/` and root userscript paths;
 - read-only branch-role and governed-file verification;
 - a manual exact-SHA-bound synchronizer restricted to the two operational refs.
@@ -87,7 +89,7 @@ Both branches remain in `shadow-rehearsal` mode. External consumers are disabled
 The connected administrator identity completed:
 
 - an exact-current-`main` read-only plan;
-- 10/10 governed-file parity at the initial baseline;
+- initial governed-file parity;
 - same-tree fast-forward write probes on both branches;
 - post-write role and content verification;
 - no force push, history rewrite, public-main mutation or live-consumer change.
@@ -96,33 +98,65 @@ The connected administrator identity completed:
 
 `greasyfork-release-monitor.yml` no longer commits to public `main`.
 
-The transitional authority split is:
+It reads verified compatibility state from `main`, reads and writes the tracker on `release-state`, rechecks both remote refs before posting and records only the reviewed tracker path.
 
-- verified dashboard: `main`;
-- fallback announcement tracker: `release-state`;
-- external consumers: disabled;
-- production tracker compatibility copy: still written atomically on `main` by `release-toolkit.yml` until the primary state cutover.
+### Release recovery ledger moved to release-state ✅
 
-`.github/scripts/release_state_branch.py` prepares a detached release-state worktree, validates `.github/branch-role.json`, allows only reviewed paths, rejects `main`, rejects force pushes, fails on stale ancestry and pushes only `HEAD:refs/heads/release-state`.
+`release-recovery.yml` no longer commits to public `main`.
 
-The read-only operational verifier now distinguishes:
+The workflow retains all exact confirmation phrases and the shared `toolkit-production-release` lock. Its external operations remain unchanged:
 
-- **mirrored paths** — must remain byte-identical to `main`;
-- **operational paths** — may differ but must satisfy a reviewed schema.
+- verify immutable GitHub Release bundles;
+- retry Greasy Fork release events;
+- retry private migration backups;
+- retry Discord announcements;
+- repair stable GitHub Release assets.
 
-Only `.github/greasyfork-version.txt` is operational at this stage. Dashboard JSON/Markdown and the stable manifest remain mirrored.
+All recovery-ledger mutations are delegated to `.github/scripts/release_recovery_state.py` and committed through `.github/scripts/release_state_branch.py`:
 
-Direct public-main writers are reduced from **10 to 2**.
+- dashboard JSON;
+- rendered dashboard Markdown;
+- stable update manifest;
+- announcement tracker.
 
-## Remaining generated state
+The recovery-state layer:
+
+- seeds from newer verified `main` compatibility state when necessary;
+- records Greasy Fork and backup recovery;
+- creates a pending Discord claim before the HTTP post;
+- finalises Discord state only when the expected claim nonce remains current;
+- rebuilds verified dashboard state from release and private-backup evidence;
+- regenerates the stable manifest only for a complete verified state;
+- performs normal non-force release-state pushes only.
+
+Recovery verification and stable-asset repair remain API-only with respect to repository state.
+
+### Operational branch governance ✅
+
+The read-only verifier now treats all four release-state files as operational state and validates:
+
+- dashboard JSON schema and current/latest version equality;
+- rendered dashboard heading and version;
+- stable manifest schema, channel, version and SHA-256;
+- announcement tracker semantic version;
+- dashboard and rendered Markdown versions match;
+- manifest and tracker can never be ahead of the recovery dashboard;
+- external consumers remain disabled.
+
+Distribution paths remain byte-identical mirrors of `main` until their later cutover.
+
+The manual synchronizer has no file-copy authority on `release-state`; it preserves all four operational files and may only record an idempotent access probe. Distribution remains the only branch with mirror-copy paths.
+
+Direct public-main writers are reduced from **10 to 1**.
+
+## Remaining generated state on public `main`
 
 Public `main` still contains:
 
 1. stable `dist/` and root Greasy Fork mirrors;
-2. verified dashboard, stable manifest and primary announcement state;
-3. guarded recovery state.
+2. dashboard, stable manifest and announcement compatibility state written by normal production releases.
 
-The fallback monitor no longer writes `main`. The update manifest no longer has a standalone writer, but its compatibility file remains part of the atomic production commit until the versioned consumer migration.
+Fallback and recovery workflows no longer mutate `main`. Only `release-toolkit.yml` remains a direct public-main writer.
 
 ## Target architecture
 
@@ -136,7 +170,7 @@ Stable `dist/` and root userscript mirrors required by Greasy Fork, written by a
 
 ### Release-state branch
 
-Mutable dashboard, manifest, announcement, fallback-monitor and recovery state. It is operational state, never product source.
+Primary dashboard, manifest, announcement, fallback-monitor and recovery state. It is operational state, never product source.
 
 ### Immutable evidence
 
@@ -163,9 +197,9 @@ The final protection design must retain fast owner operation:
 4. ✅ Fold stable update-manifest publication into the same atomic release commit — PR #505.
 5. ✅ Create and verify non-live `release-state` and `distribution` branches — PR #506.
 6. ✅ Introduce the constrained shadow writer and rehearse plan/write access — PR #507 and Issue #41 evidence.
-7. ✅ Move the fallback announcement tracker writer to `release-state`.
-8. Move release recovery state to `release-state`.
-9. Move primary dashboard, manifest and announcement authority to `release-state`.
+7. ✅ Move fallback announcement tracking to `release-state` — PR #508.
+8. ✅ Move release recovery state to `release-state`.
+9. Move primary production dashboard, manifest and announcement authority to `release-state`.
 10. Publish a versioned Toolkit migration that reads the manifest from `release-state` with a reviewed compatibility fallback.
 11. Move stable `dist/` and Greasy Fork mirrors to `distribution`.
 12. Replace temporary credentials with a narrowly scoped GitHub App.

--- a/docs/BRANCH_WRITE_INVENTORY.md
+++ b/docs/BRANCH_WRITE_INVENTORY.md
@@ -9,7 +9,7 @@ Strict pull-request-only protection is **not yet safe to enable**.
 
 The repository now has one workflow that can commit directly to public `main`: `release-toolkit.yml`. It still publishes the stable distribution and writes a temporary compatibility copy of release state required by existing v5.0.7 installations.
 
-Two workflows write governed operational state to `release-state`:
+At this stage, two workflows write governed operational state to `release-state`:
 
 - `greasyfork-release-monitor.yml` — fallback announcement tracker;
 - `release-recovery.yml` — recovery dashboard, rendered status, stable manifest and announcement tracker.

--- a/docs/BRANCH_WRITE_INVENTORY.md
+++ b/docs/BRANCH_WRITE_INVENTORY.md
@@ -7,52 +7,70 @@
 
 Strict pull-request-only protection is **not yet safe to enable**.
 
-The repository now has two workflows that can commit directly to public `main`: controlled release recovery and guarded production publication. Two release orchestrators invoke the reusable production writer but contain no direct public-main push.
+The repository now has one workflow that can commit directly to public `main`: `release-toolkit.yml`. It still publishes the stable distribution and writes a temporary compatibility copy of release state required by existing v5.0.7 installations.
 
-Canonical validation, release dry runs, repository audits, dashboard projection, Greasy Fork parity, announcement-state verification and stable update-manifest verification are now artifact-only. These seven workflows use read-only repository access and retain immutable evidence instead of committing generated state.
+Two workflows write governed operational state to `release-state`:
 
-The fallback announcement tracker is now written only to `release-state`. The fallback monitor still reads the verified release dashboard from `main` during this transitional stage, preventing duplicate Discord posts while removing its direct public-main mutation.
+- `greasyfork-release-monitor.yml` — fallback announcement tracker;
+- `release-recovery.yml` — recovery dashboard, rendered status, stable manifest and announcement tracker.
 
-The `release-state` and `distribution` branches remain non-live operational shadows. Read-only parity, an exact-SHA synchronization plan and same-tree administrator write probes are complete. Strict protection and external consumer cutover remain disabled.
+Two release orchestrators invoke the reusable production writer but contain no direct public-main push.
 
-`.github/branch-write-inventory.json` is the machine-readable write authority. `.github/shadow-branch-policy.json` governs branch roles and reviewed paths. Permanent contracts fail closed when a writer, permission, authority, branch role or release-state boundary changes.
+Canonical validation, release dry runs, repository audits, dashboard projection, Greasy Fork parity, announcement-state verification and stable update-manifest verification are artifact-only. These seven workflows use read-only repository access and retain immutable evidence instead of committing generated state.
 
-## Direct public `main` writers
+The release recovery ledger is now written only to `release-state`. GitHub Release verification and asset repair, Greasy Fork retry, private backup and Discord HTTP side effects remain controlled API operations, but their ledger reconciliation cannot commit to `main`.
+
+The `release-state` and `distribution` branches remain non-live operational branches. External consumers and strict protection remain disabled. Administrator recovery access has been rehearsed successfully.
+
+`.github/branch-write-inventory.json` is the machine-readable authority. `.github/shadow-branch-policy.json` governs branch roles, path classes and operational writers. Permanent contracts fail closed when any writer, permission, branch target, mutable path or consumer boundary changes.
+
+## Sole direct public `main` writer
 
 | Workflow | Current mutation | Required migration |
 |---|---|---|
-| `release-recovery.yml` | dashboard JSON/Markdown and announcement recovery state | Move mutable recovery state to `release-state`; retain GitHub Release API repair capability. |
-| `release-toolkit.yml` | stable distribution plus atomic dashboard, update-manifest and announcement state | Split distribution and state across dedicated branches under a scoped GitHub App. |
+| `release-toolkit.yml` | stable distribution plus atomic dashboard, manifest and announcement compatibility state | Split distribution and primary state across dedicated branches under a scoped GitHub App. |
 
-The executable public-main push helper `.github/scripts/sync_greasyfork_root_mirror.sh` is owned by `release-toolkit.yml`. The deterministic helper `.github/scripts/build_stable_update_manifest.py` writes only the manifest projection inside that existing guarded release commit.
+The executable public-main helper `.github/scripts/sync_greasyfork_root_mirror.sh` is owned by `release-toolkit.yml`. `.github/scripts/build_stable_update_manifest.py` generates the compatibility manifest inside the same guarded release commit.
 
-## Release-state branch writer
+## Governed `release-state` writers
 
-`greasyfork-release-monitor.yml` is now classified under `releaseStateBranchWriters`, not `directMainWriters`.
+| Workflow | Operational authority | Source evidence | Public-main effect |
+|---|---|---|---|
+| `greasyfork-release-monitor.yml` | `.github/greasyfork-version.txt` | live Greasy Fork version and verified compatibility dashboard | None |
+| `release-recovery.yml` | dashboard JSON, rendered Markdown, stable manifest and tracker | verified GitHub Release bundle plus explicit recovery inputs | None |
 
-| Property | Enforced value |
-|---|---|
-| Source authority | Verified `main` dashboard |
-| Target branch | `release-state` |
-| Governed write | `.github/greasyfork-version.txt` only |
-| Credential | `github.token` |
-| Push mode | Normal fast-forward only |
-| Public-main mutation | Forbidden |
-| Consumer cutover | Disabled |
+Both use `.github/scripts/release_state_branch.py` for branch transactions. That helper:
 
-`.github/scripts/release_state_branch.py` owns the branch transaction:
-
-- fetches only `release-state` into a detached worktree;
+- prepares a detached `release-state` worktree;
 - validates `.github/branch-role.json` before every operation;
 - requires the exact reviewed mutable-path allowlist;
 - rejects role-file changes and unapproved paths;
 - fails if the remote branch moves after preparation;
-- uses compare-and-swap ancestry with no rebase, force push or history rewrite;
+- performs normal fast-forward pushes only;
+- never rebases, force-pushes or rewrites branch history;
 - pushes only `HEAD:refs/heads/release-state`;
 - requires `GH_TOKEN` only for the final governed push;
 - contains executable self-tests that reject `main` and allowlist expansion.
 
-The monitor checks out `main` with `persist-credentials: false`, reads the current dashboard from `main`, reads the tracker from the release-state worktree, rechecks both remote refs before a fallback post, and records only the tracker on `release-state`.
+### Fallback monitor
+
+The monitor checks out `main` with `persist-credentials: false`, reads the verified compatibility dashboard from `main`, reads the announcement tracker from `release-state`, rechecks both refs before posting, and commits only the tracker to `release-state`.
+
+### Release recovery
+
+`.github/scripts/release_recovery_state.py` owns recovery-ledger transitions:
+
+- seeds `release-state` from a newer verified `main` compatibility snapshot when necessary;
+- records Greasy Fork recovery;
+- records private-backup recovery;
+- claims a Discord retry before posting;
+- finalises Discord state only when the expected claim nonce still matches;
+- rebuilds the verified dashboard from GitHub Release and private-backup evidence;
+- regenerates the rendered dashboard;
+- regenerates the stable manifest only when the recovered release state is complete;
+- delegates every commit to the constrained branch helper.
+
+The recovery workflow preserves every exact confirmation phrase and the shared `toolkit-production-release` lock. `verify-release` and `repair-stable-assets` remain API/read-only with respect to repository state.
 
 ## Artifact-only evidence workflows
 
@@ -70,8 +88,8 @@ The monitor checks out `main` with `persist-credentials: false`, reads the curre
 
 | Branch | Governed paths | Current authority | External consumers |
 |---|---|---|---|
-| `release-state` | dashboard JSON/Markdown, stable update manifest, announcement tracker | Transitional tracker writes; remaining state still authoritative on `main` | Disabled |
-| `distribution` | stable `dist/` files and root userscript mirrors | `main` | Disabled |
+| `release-state` | dashboard JSON/Markdown, stable update manifest, announcement tracker | Operational recovery ledger | Disabled |
+| `distribution` | stable `dist/` files and root userscript mirrors | Mirrored from `main` | Disabled |
 
 Each branch contains `.github/branch-role.json` declaring:
 
@@ -82,13 +100,22 @@ Each branch contains `.github/branch-role.json` declaring:
 - Issue #41 controls cutover;
 - only reviewed operational paths may become mutable.
 
-`.github/workflows/verify-shadow-branch-parity.yml` remains read-only. During the transitional tracker migration, parity policy will be refined to distinguish the intentionally operational tracker from state that must still mirror `main`.
+`.github/workflows/verify-shadow-branch-parity.yml` remains read-only. It validates:
 
-## Constrained shadow synchronization writer
+- role declarations;
+- JSON and Markdown schemas;
+- dashboard/Markdown version equality;
+- manifest and tracker versions never ahead of the recovery dashboard;
+- distribution files remain byte-identical to `main`;
+- external consumers remain disabled.
 
-`.github/workflows/sync-shadow-branches.yml` and `.github/scripts/sync_shadow_branches.py` remain the manual non-live rehearsal writer.
+## Manual shadow synchronizer
 
-The contract remains:
+`.github/workflows/sync-shadow-branches.yml` remains a manual owner-authenticated rehearsal utility.
+
+The manual synchronizer has no file-copy authority on `release-state`. All four release-state paths are operational and are preserved byte-for-byte by the synchronizer. It may only record an idempotent empty access probe on that branch.
+
+The synchronizer may still copy reviewed mirror files from `main` to `distribution`. Its contract remains:
 
 - manual `workflow_dispatch` only;
 - authorized actor fixed to `Conroy1988`;
@@ -97,31 +124,26 @@ The contract remains:
 - `PLAN SHADOW SYNC` and `SYNC SHADOWS` confirmation phrases;
 - workflow-level `contents: read`;
 - temporary `DEVELOPMENT_PR_TOKEN` only for reviewed apply operations;
-- branch-specific governed paths only;
 - `.github/branch-role.json` immutable;
-- normal fast-forward pushes only;
+- normal non-force pushes only;
 - public `main` rejected as a target;
 - live consumer cutover forbidden;
 - replacement by a narrowly scoped GitHub App required before final cutover.
 
-The connected administrator identity completed the read-only plan and same-tree branch probes. No force push, history rewrite, public-main change or live-consumer change occurred.
+## Compatibility state on `main`
 
-## Current release state
-
-After Greasy Fork verification, private backup and Discord publication, `release-toolkit.yml` writes the following together in one public-main commit:
+After Greasy Fork verification, private backup and Discord publication, `release-toolkit.yml` still writes these together in one compatibility commit:
 
 - `status/release-dashboard.json`;
 - `status/README.md`;
 - `status/update-manifest.json`;
 - `.github/greasyfork-version.txt`.
 
-The stable manifest is generated by `.github/scripts/build_stable_update_manifest.py`. `publish-update-manifest.yml` independently verifies the committed projection with read-only access.
-
-The current v5.0.7 runtime consumer remains unchanged:
+Existing v5.0.7 installations still read:
 
 `raw.githubusercontent.com/Conroy1988/missionchief-toolkit-assets/main/status/update-manifest.json`
 
-This compatibility URL remains on `main` until a versioned Toolkit release moves the runtime consumer to the final `release-state` endpoint.
+That URL remains valid until a later versioned Toolkit release migrates the runtime consumer to `release-state`. Recovery actions do not rewrite this compatibility copy; only the next normal production release does.
 
 ## Production release sequence
 
@@ -131,19 +153,10 @@ This compatibility URL remains on `main` until a versioned Toolkit release moves
 4. Production publishes stable distribution and root mirrors.
 5. GitHub Release is published and Greasy Fork is verified.
 6. The release is backed up privately and announced to Discord.
-7. Dashboard JSON, rendered Markdown, stable update manifest and announcement tracker are committed atomically.
+7. Dashboard JSON, rendered Markdown, stable update manifest and announcement tracker are committed atomically as compatibility state.
 8. GitHub Pages is dispatched and awaited.
 9. Dashboard, Greasy Fork, announcement and update-manifest workflows verify only.
-10. The fallback monitor reconciles its dedicated release-state tracker without writing `main`.
-
-## Indirect release orchestrators
-
-| Workflow | Delegated writer | Role |
-|---|---|---|
-| `auto-release-after-validation.yml` | `release-toolkit.yml` | Consumes exact validation evidence and starts guarded release. |
-| `owner-release-command.yml` | `release-toolkit.yml` | Performs owner authorization and fresh validation. |
-
-Their write authority remains because the reusable production job still writes distribution and release state.
+10. Fallback and recovery operations write their governed ledger to `release-state` only.
 
 ## Other non-public-main writers
 
@@ -151,15 +164,16 @@ Their write authority remains because the reusable production job still writes d
 |---|---|---|---|
 | `apply-development-package.yml` | Existing owner PR branch | `DEVELOPMENT_PR_TOKEN` | Review branch only. |
 | `prepare-release-rollback.yml` | Recovery branch and PR | `DEVELOPMENT_PR_TOKEN` | Review branch only. |
-| `sync-shadow-branches.yml` | `release-state` and `distribution` only | `DEVELOPMENT_PR_TOKEN` | Manual rehearsal; no `main` or consumer cutover. |
-| `greasyfork-release-monitor.yml` | `release-state` tracker only | `github.token` | Scheduled transitional operational writer; no `main`. |
+| `sync-shadow-branches.yml` | `release-state` access probe and `distribution` mirrors | `DEVELOPMENT_PR_TOKEN` | Manual rehearsal; no `main` or consumer cutover. |
+| `greasyfork-release-monitor.yml` | `release-state` tracker only | `github.token` | Scheduled operational writer; no `main`. |
+| `release-recovery.yml` | complete `release-state` recovery ledger | `github.token` | Manually confirmed recovery writer; no `main`. |
 | `backup_release_to_private_repo.sh` | private recovery repository `main` | `MIGRATION_REPO_TOKEN` | Separate repository. |
 
 ## Target architecture
 
-- **Public `main`:** reviewed source, workflows, tests, policy and compatibility configuration.
+- **Public `main`:** reviewed source, workflows, tests, policy and temporary compatibility configuration.
 - **Distribution branch:** stable `dist/` and root mirrors, written by a scoped release App.
-- **Release-state branch:** dashboard, manifest, announcement, fallback-monitor and recovery state.
+- **Release-state branch:** primary dashboard, manifest, announcement, fallback-monitor and recovery state.
 - **Immutable evidence:** validation, parity, synchronization plans, bundles, audits and handovers.
 
 ## Migration order
@@ -171,21 +185,24 @@ Their write authority remains because the reusable production job still writes d
 5. ✅ Make primary announcement state atomic and reconciliation read-only.
 6. ✅ Fold stable update-manifest publication into the atomic release commit — PR #505.
 7. ✅ Create and validate `release-state` and `distribution` branches — PR #506.
-8. ✅ Add the constrained writer and rehearse plan/apply access — PR #507 and Issue #41 evidence.
-9. ✅ Move the fallback announcement tracker writer from `main` to `release-state`.
-10. Move release recovery state to `release-state`.
-11. Move primary dashboard/manifest/announcement authority to `release-state`.
+8. ✅ Add the constrained writer and rehearse access — PR #507 and Issue #41 evidence.
+9. ✅ Move fallback announcement tracking to `release-state` — PR #508.
+10. ✅ Move the release recovery ledger to `release-state`.
+11. Move primary production state authority to `release-state`.
 12. Migrate a versioned Toolkit runtime to the release-state manifest URL.
 13. Cut stable distribution over to `distribution`.
 14. Replace temporary credentials with a narrowly scoped GitHub App.
-15. Rehearse release, recovery and administrator access.
+15. Rehearse production release, recovery and administrator access.
 16. Enable strict protection only after all rehearsals pass.
 
 ## Current migration evidence
 
 - PRs #498–#504 reduced direct public-main writers from **10 to 4**.
 - PR #505 reduced direct public-main writers from **4 to 3**.
-- This migration reduces direct public-main writers from **3 to 2**.
-- PRs #506–#507 established isolated operational branches, read-only parity and constrained administrator rehearsal access.
+- PR #508 reduced direct public-main writers from **3 to 2**.
+- This migration reduces direct public-main writers from **2 to 1**.
+- Two workflows write governed operational state to `release-state`.
+- The release recovery ledger is now written only to `release-state`.
+- Seven workflows use read-only repository access for immutable verification evidence.
 - Existing v5.0.7 installations retain their exact manifest URL.
 - No userscript, production version, release object, external URL or protection setting changes in this step.

--- a/docs/BRANCH_WRITE_INVENTORY.md
+++ b/docs/BRANCH_WRITE_INVENTORY.md
@@ -158,6 +158,15 @@ That URL remains valid until a later versioned Toolkit release migrates the runt
 9. Dashboard, Greasy Fork, announcement and update-manifest workflows verify only.
 10. Fallback and recovery operations write their governed ledger to `release-state` only.
 
+## Indirect release orchestrators
+
+| Workflow | Delegated writer | Role |
+|---|---|---|
+| `auto-release-after-validation.yml` | `release-toolkit.yml` | Consumes exact successful validation evidence and invokes the guarded production writer. |
+| `owner-release-command.yml` | `release-toolkit.yml` | Performs owner authorization, fresh validation and guarded release invocation. |
+
+Neither orchestrator contains a direct public-main push. Their `contents: write` authority remains transitional because the reusable production workflow still writes public compatibility state and stable distribution.
+
 ## Other non-public-main writers
 
 | Automation | Target | Credential | Protection posture |

--- a/docs/RELEASE_RECOVERY.md
+++ b/docs/RELEASE_RECOVERY.md
@@ -1,6 +1,6 @@
 # Release Recovery and Failure Handling
 
-This guide describes how to recover the MissionChief Map Command Toolkit release pipeline without creating duplicate releases, repeated Discord announcements, silent version downgrades, or inconsistent Greasy Fork state.
+This guide describes how to recover the MissionChief Map Command Toolkit release pipeline without duplicate releases, repeated Discord announcements, silent version downgrades or inconsistent operational state.
 
 ## Standard pre-release procedure
 
@@ -13,7 +13,20 @@ Before every public release:
 5. Run **Actions → Release Toolkit**.
 6. Enter the exact version and type `RELEASE`.
 
-The readiness workflow does not create a GitHub Release, change Greasy Fork, post to Discord, or write to the private migration repository.
+The readiness workflow does not create a GitHub Release, change Greasy Fork, post to Discord or write to the private migration repository.
+
+## Recovery state location
+
+The governed recovery ledger is stored on the `release-state` branch:
+
+- `status/release-dashboard.json`;
+- `status/README.md`;
+- `status/update-manifest.json`;
+- `.github/greasyfork-version.txt`.
+
+`release-recovery.yml` never commits these files to public `main`. It prepares a detached release-state worktree, validates the branch role and mutable-path allowlist, then performs a normal non-force push through `.github/scripts/release_state_branch.py`.
+
+Existing v5.0.7 installations still read the compatibility manifest from `main`. Recovery operations update the operational ledger only; the next normal production release refreshes the compatibility copy on `main`.
 
 ## Executable recovery workflows
 
@@ -29,28 +42,31 @@ Both workflows use explicit confirmation phrases. Replace the angle-bracket plac
 | Verify immutable release bundle | `VERIFY <version>` | Read-only |
 | Retry Greasy Fork release event and verification | `RETRY GREASYFORK <version>` | Re-saves the existing latest GitHub Release; creates no new release |
 | Retry private migration backup | `RETRY BACKUP <version>` | Creates a missing archive or reuses an identical existing archive |
-| Retry Discord release announcement | `RETRY DISCORD <version>` | Posts only when the dashboard does not already record the announcement |
-| Rebuild dashboard state | `REBUILD DASHBOARD <version>` | Reconstructs dashboard state from verified GitHub, Greasy Fork and private archive data |
-| Repair stable GitHub Release asset names | `REPAIR ASSETS <version>` | Restores the stable `.user.js` and `.txt` assets from immutable versioned assets |
+| Retry Discord release announcement | `RETRY DISCORD <version>` | Posts only when the recovery ledger does not already record the announcement |
+| Rebuild dashboard state | `REBUILD DASHBOARD <version>` | Reconstructs release-state from verified GitHub, Greasy Fork and private archive evidence |
+| Repair stable GitHub Release asset names | `REPAIR ASSETS <version>` | Restores stable `.user.js` and `.txt` assets from immutable versioned assets |
 | Prepare reviewed rollback | `PREPARE ROLLBACK <source> TO <recovery>` | Opens a PR; does not publish anything |
 
-### Direct recovery restrictions
+## Direct recovery restrictions
 
-Write operations in **Release Recovery** may target only the current latest GitHub Release. This prevents an old archived version from accidentally replacing the active distribution.
+Write operations in **Release Recovery** may target only the current latest GitHub Release. This prevents an archived version from replacing active distribution state.
 
-The workflow shares the `toolkit-production-release` concurrency lock with the formal release pipeline. A recovery run therefore cannot overlap a production release or announcement-state reconciliation.
+The workflow shares the `toolkit-production-release` concurrency lock with formal production and fallback monitoring. Recovery cannot overlap a production release or fallback announcement reconciliation.
 
-### Discord ambiguity guard
+The workflow checks out `main` with `persist-credentials: false`. `main` supplies source code, reviewed settings and a compatibility seed when `release-state` does not yet contain the requested release. Every later ledger transition occurs on `release-state`.
 
-Before retrying Discord, the workflow commits a `pending` recovery claim to the release dashboard. Only then does it post the message.
+## Discord ambiguity guard
 
-- If the post succeeds, the workflow records `discordPosted: true` and advances the fallback announcement tracker.
-- If the runner fails after Discord accepted the message but before final state is committed, the pending claim remains.
+Before retrying Discord, the workflow commits a `pending` recovery claim to the release-state dashboard. Only then does it post the message.
+
+- If the post succeeds, the workflow records `discordPosted: true`, removes the pending claim, advances the announcement tracker and regenerates the stable manifest.
+- If the runner fails after Discord accepted the message but before final state is committed, the pending claim remains on `release-state`.
 - A later automatic retry refuses to post while that claim exists. Discord must be inspected manually before the ambiguous state is cleared.
+- Finalisation succeeds only when the expected claim nonce still matches the current release-state claim.
 
-This intentionally prefers a missed automatic retry over a duplicate public announcement.
+This deliberately prefers a missed automatic retry over a duplicate public announcement.
 
-### Private backup idempotency
+## Private backup idempotency
 
 A backup retry behaves as follows:
 
@@ -58,9 +74,11 @@ A backup retry behaves as follows:
 - existing byte-identical archive → reuse it and repair only the `current/` pointer if necessary;
 - existing archive with any mismatch → fail closed without overwriting the immutable backup.
 
-### Rollback policy
+The resulting private backup commit is written to the release-state dashboard, not public `main`.
 
-Never publish an older version number as a rollback. Tampermonkey and other userscript managers generally do not treat lower versions as an update.
+## Rollback policy
+
+Never publish an older version number as a rollback. Userscript managers generally do not treat lower versions as an update.
 
 **Prepare Release Rollback** instead:
 
@@ -72,7 +90,7 @@ Never publish an older version number as a rollback. Tampermonkey and other user
 6. Runs JavaScript syntax and static performance checks.
 7. Opens a labelled review PR.
 
-After that PR is reviewed and merged, use the normal **Release Readiness Check** and **Release Toolkit** workflows. The rollback-preparation workflow itself never creates a release, changes Greasy Fork, writes the private backup, or posts to Discord.
+After that PR is reviewed and merged, use the normal **Release Readiness Check** and **Release Toolkit** workflows. Rollback preparation never creates a release, changes Greasy Fork, writes the private backup or posts to Discord.
 
 ## Release checkpoints
 
@@ -91,8 +109,10 @@ Private migration backup
       ↓
 Discord release announcement
       ↓
-Dashboard update
+Atomic compatibility state on main
 ```
+
+Recovery writes its operational ledger to `release-state`; it does not rewrite the compatibility checkpoint on `main`.
 
 A later checkpoint is never treated as successful when an earlier checkpoint failed.
 
@@ -102,7 +122,7 @@ A later checkpoint is never treated as successful when an earlier checkpoint fai
 
 No public state has changed.
 
-- Correct the source, metadata, changelog, or distribution mismatch.
+- Correct the source, metadata, changelog or distribution mismatch.
 - Run **Release Readiness Check** again.
 - Start a new **Release Toolkit** run only after readiness passes.
 
@@ -110,7 +130,7 @@ No public state has changed.
 
 Check whether tag `vX.Y.Z` or a release with that version already exists.
 
-- When no release exists, correct the reported permission or file problem and start a new production run.
+- When no release exists, correct the permission or file problem and start a new production run.
 - When a partial release exists, inspect its assets before deciding whether to delete and recreate it.
 - Never create a second release under a different tag for the same Toolkit version.
 
@@ -118,7 +138,7 @@ Check whether tag `vX.Y.Z` or a release with that version already exists.
 
 Run **Release Recovery → repair-stable-assets** with `REPAIR ASSETS <version>`.
 
-The workflow treats the immutable versioned `.user.js`, `.txt`, manifest and checksums as the source of truth. It restores only the stable asset names used by Greasy Fork and verifies their SHA-256 before re-saving the existing release.
+The immutable versioned `.user.js`, `.txt`, manifest and checksums are the source of truth. The workflow restores only the stable asset names, verifies SHA-256 and re-saves the existing release. No repository branch is changed by this operation.
 
 ### GitHub Release exists but Greasy Fork did not update
 
@@ -127,12 +147,12 @@ Do not post a manual Discord announcement.
 1. Verify the GitHub Release bundle with `VERIFY <version>`.
 2. Run **Release Recovery → retry-greasyfork** with `RETRY GREASYFORK <version>`.
 3. The workflow re-saves the existing release only when Greasy Fork is stale.
-4. It waits for the matching metadata version and then verifies public asset health plus executable-body parity.
-5. It records Greasy Fork as verified only after those checks pass.
+4. It waits for matching metadata and verifies public asset health plus executable-body parity.
+5. It records Greasy Fork as verified on `release-state` only after those checks pass.
 
 ### Greasy Fork updated but private backup failed
 
-The public release is live, but the release is not complete.
+The public release is live, but recovery state is incomplete.
 
 - Fix or renew `MIGRATION_REPO_TOKEN`.
 - Confirm the token has Contents read/write permission for the private repository.
@@ -143,10 +163,10 @@ The public release is live, but the release is not complete.
 ### Backup succeeded but Discord failed
 
 - Verify `DISCORD_RELEASE_WEBHOOK` still targets `Mission-Chief`.
-- Confirm the dashboard records Greasy Fork verification and a private backup commit.
+- Confirm release-state records Greasy Fork verification and a private backup commit.
 - Run **Release Recovery → retry-discord** with `RETRY DISCORD <version>`.
 - When `discordPosted` is already true, the workflow exits without posting.
-- When a previous retry is marked pending, inspect Discord manually rather than forcing another automatic post.
+- When a previous retry is marked pending, inspect Discord manually rather than forcing another post.
 - Never use the development webhook for a public release.
 
 ### Dashboard update failed after public actions succeeded
@@ -162,19 +182,20 @@ The workflow verifies:
 
 Choose the Discord state deliberately:
 
-- `preserve` only when the existing dashboard already records the same release version;
+- `preserve` only when release-state already records the same release version;
 - `posted` when the release message was verified in Discord;
 - `not-posted` when it was not posted and should remain eligible for the guarded Discord retry.
 
-The workflow regenerates both `status/release-dashboard.json` and `status/README.md`.
+The workflow regenerates the release-state dashboard and rendered Markdown. When Discord is recorded as posted, it also advances the tracker and regenerates the stable manifest.
 
 ## Duplicate prevention
 
-- Do not use **Re-run all jobs** after a GitHub Release has already been created unless the workflow is known to be idempotent at that checkpoint.
+- Do not use **Re-run all jobs** after a GitHub Release has already been created unless the checkpoint is known to be idempotent.
 - Prefer the scoped **Release Recovery** operation for the failed stage.
 - Do not publish the same version twice.
 - Do not manually post to Discord while a guarded retry is pending.
-- Do not change the Greasy Fork source back to `main/dist`.
+- Do not edit recovery-ledger files directly on `main`.
+- Do not use the manual shadow synchronizer to copy `main` state onto `release-state`; it has no file-copy authority there.
 - Do not mark an older release as latest to simulate a downgrade.
 
 ## Private recovery verification
@@ -188,6 +209,6 @@ For any archived release, the following must agree:
 - GitHub tag;
 - SHA-256 recorded in `SHA256SUMS` and the manifest;
 - byte identity of `.user.js` and `.txt`;
-- stable and versioned release assets when the stable names are present.
+- stable and versioned release assets when stable names are present.
 
-The private repository is the authoritative disaster-recovery archive. The public GitHub Release is the distribution archive. Greasy Fork remains the installation endpoint.
+The private repository is the authoritative disaster-recovery archive. The public GitHub Release is the distribution archive. Greasy Fork remains the installation endpoint. `release-state` is the operational recovery ledger.


### PR DESCRIPTION
## Purpose

Advance Issue #41 by removing `release-recovery.yml` as a direct public-`main` writer. The recovery dashboard, rendered status, stable manifest and announcement tracker become governed operational state on `release-state`.

## Recovery architecture

- GitHub Release verification and stable-asset repair remain API/read-only with respect to repository branches.
- Greasy Fork retry, private backup retry and Discord retry retain their existing external side effects and confirmation phrases.
- Every recovery-ledger mutation is delegated to `.github/scripts/release_recovery_state.py`.
- Every branch transaction is delegated to `.github/scripts/release_state_branch.py`.
- The recovery workflow checks out `main` as source/configuration authority with `persist-credentials: false`.
- When release-state is behind, the workflow can seed it from the newer verified compatibility snapshot on `main`.

## Governed release-state files

- `status/release-dashboard.json`
- `status/README.md`
- `status/update-manifest.json`
- `.github/greasyfork-version.txt`

## Safety and idempotency

- Exact recovery confirmation phrases are preserved.
- All write operations remain restricted to the latest GitHub Release.
- The `toolkit-production-release` concurrency lock is preserved.
- Discord retry creates a pending claim before posting and finalises only when the expected nonce remains current.
- Private backup retry retains immutable-archive checks.
- Dashboard rebuild requires verified GitHub Release, Greasy Fork and private-backup evidence.
- Stable manifest generation occurs only for complete verified recovery state.
- Release-state pushes are normal fast-forward pushes with role, path and ancestry validation.
- No recovery operation can commit, push, rebase or reset public `main`.
- External consumers and strict branch protection remain disabled.

## Policy changes

- `release-toolkit.yml` becomes the sole direct public-main writer.
- `greasyfork-release-monitor.yml` and `release-recovery.yml` are explicitly classified as release-state writers.
- All four release-state paths become operational state.
- Distribution paths remain byte-identical mirrors of `main`.
- The manual shadow synchronizer has zero file-copy authority on `release-state`.
- Read-only branch verification validates recovery-ledger schemas and cross-file version ordering.

## Compatibility

Existing v5.0.7 installations continue to read the stable manifest from `main`. Recovery updates only the operational release-state ledger; the next normal production release refreshes the compatibility copy on `main`.

## Scope

- No userscript or production version change.
- No release, backup, Discord post or recovery operation is executed by this PR.
- No release-state, dashboard, manifest, tracker or distribution content is changed by this PR.
- No live URL, Greasy Fork source or consumer change.
- No repository settings or protection rules are enabled.

## Validation

All seven checks pass on exact head `d7697a9533b72f5e21fd64cfd06631526634366f`:

- Development and Automation Workflow Policy
- Validate Release Recovery
- Verify Shadow Branch Parity
- Actions security
- Verify Greasy Fork Canonical Parity
- Verify Release Announcement State
- Development status

The executable contracts confirm:

- exactly one direct public-main writer: `release-toolkit.yml`;
- exactly two release-state writers;
- all four recovery-ledger paths operational on `release-state`;
- distribution remains mirror-only;
- exact confirmation phrases and production concurrency lock preserved;
- recovery seeding, Greasy Fork, backup, Discord claim/finalisation and dashboard rebuild transitions are constrained;
- normal non-force release-state pushes only;
- no recovery or manual sync file-copy mutation of public `main`;
- no external consumer cutover;
- complete recovery-ledger schema and cross-version validation.

`main` remains `e51a44431c1769dcdab292f1d5f3b570b4c1f867`. GitHub reports the PR mergeable, with no comments or unresolved review threads.

## Expected result

Direct public-main writers reduce from two to one:

1. `release-toolkit.yml`

Advances #41