### PR TITLE
Fix v7 GitHub Pages production monitor

### DIFF
--- a/.github/pages-monitor-policy.json
+++ b/.github/pages-monitor-policy.json
@@ -1,14 +1,14 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "baseUrl": "https://conroy1988.github.io/missionchief-toolkit-assets/",
   "timeoutSeconds": 25,
   "routes": [
-    {"path": "", "contentType": "text/html", "requiredText": ["MissionChief Map Command Toolkit"]},
-    {"path": "features/", "contentType": "text/html", "requiredText": ["Features", "Mission Age Watch"]},
-    {"path": "themes/", "contentType": "text/html", "requiredText": ["Themes", "Cyberpunk", "Factorio"]},
-    {"path": "docs/", "contentType": "text/html", "requiredText": ["Documentation", "Installation"]},
-    {"path": "changelog/", "contentType": "text/html", "requiredText": ["Changelog"]},
-    {"path": "status/", "contentType": "text/html", "requiredText": ["Status"]},
+    {"path": "", "contentType": "text/html", "requiredText": ["MissionChief Map Command Toolkit", "The One We Knew Before"]},
+    {"path": "features/", "contentType": "text/html", "requiredText": ["Features", "Mission Age map timers", "Patient Transport Sweep", "Mission Value"]},
+    {"path": "themes/", "contentType": "text/html", "requiredText": ["Themes", "Cyberpunk", "Factorio", "Hyrule Command"]},
+    {"path": "docs/", "contentType": "text/html", "requiredText": ["Documentation", "The One We Knew Before", "Installation"]},
+    {"path": "changelog/", "contentType": "text/html", "requiredText": ["Changelog", "Version 7.0.0"]},
+    {"path": "status/", "contentType": "text/html", "requiredText": ["Status", "Current version 7.0.0"]},
     {"path": "assets/site.css", "contentType": "text/css", "minimumBytes": 1000},
     {"path": "assets/site.js", "contentType": "javascript", "minimumBytes": 500}
   ]

--- a/.github/pages-monitor-policy.json
+++ b/.github/pages-monitor-policy.json
@@ -3,7 +3,7 @@
   "baseUrl": "https://conroy1988.github.io/missionchief-toolkit-assets/",
   "timeoutSeconds": 25,
   "routes": [
-    {"path": "", "contentType": "text/html", "requiredText": ["MissionChief Map Command Toolkit", "The One We Knew Before"]},
+    {"path": "", "contentType": "text/html", "requiredText": ["MissionChief Map Command Toolkit"]},
     {"path": "features/", "contentType": "text/html", "requiredText": ["Features", "Mission Age map timers", "Patient Transport Sweep", "Mission Value"]},
     {"path": "themes/", "contentType": "text/html", "requiredText": ["Themes", "Cyberpunk", "Factorio", "Hyrule Command"]},
     {"path": "docs/", "contentType": "text/html", "requiredText": ["Documentation", "The One We Knew Before", "Installation"]},


### PR DESCRIPTION
## Post-release monitor reconciliation

Issue #86 is failing against obsolete expectations from the retired v6 feature set. The live monitor still requires Mission Age Watch and therefore rejects the correct v7 feature catalogue.

This change:

- advances the Pages monitor policy schema;
- retains the dashboard-backed current-version check;
- replaces retired feature expectations with v7-native markers;
- verifies Mission Age map timers, Mission Value and native Patient Transport Sweep;
- verifies v7 documentation, changelog and status markers;
- preserves all route, content-type and minimum-size checks.

No userscript or distribution code changes.

Closes #86 when the post-merge live production monitor passes.