### PR TITLE
Rebuild README imagery as a realistic UK emergency command suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <div align="center">
 
-<img src="docs/media/readme-hero.svg" alt="MissionChief Map Command Toolkit cinematic UK emergency command console" width="100%">
+<img src="docs/media/readme-hero.svg" alt="MissionChief Map Command Toolkit realistic UK multi-agency emergency response scene" width="100%">
 
 # MissionChief Map Command Toolkit
 
-### **A cinematic emergency-command network for the MissionChief map**
+### **A realistic UK emergency-command network for the MissionChief map**
 
 **Incident command · Mission intelligence · Fleet identity · Native transport · Geographic control · Financial reconciliation**
 
@@ -13,7 +13,7 @@
 [![Explore interfaces](https://img.shields.io/badge/EXPLORE-7_COMMAND_INTERFACES-D49B24?style=for-the-badge&logo=palette&logoColor=white)](https://conroy1988.github.io/missionchief-toolkit-assets/themes/)
 [![Release control](https://img.shields.io/badge/OPEN-RELEASE_CONTROL-22272E?style=for-the-badge&logo=githubactions&logoColor=white)](status/README.md)
 
-## **Current verified release: `v7.1.5` · Development candidate: `v7.1.6`**
+## **Current verified release: `v7.1.6`**
 ### **Native Discharge patient confirmation handling**
 
 [![GitHub release](https://img.shields.io/github/v/release/Conroy1988/missionchief-toolkit-assets?display_name=release&label=RELEASE&color=2563eb)](https://github.com/Conroy1988/missionchief-toolkit-assets/releases/latest)
@@ -24,7 +24,7 @@
 [![Canonical validation](https://github.com/Conroy1988/missionchief-toolkit-assets/actions/workflows/validate-userscript.yml/badge.svg)](https://github.com/Conroy1988/missionchief-toolkit-assets/actions/workflows/validate-userscript.yml)
 [![Licence](https://img.shields.io/badge/LICENCE-MIT-111827)](#licence-and-attribution)
 
-[**Command briefing**](#command-network-briefing) · [**Current release**](#current-release-signal--v714) · [**Incident Wire**](#incident-command-wire) · [**Systems**](#native-command-divisions) · [**Interfaces**](#seven-complete-interface-systems) · [**Devices**](#field-terminal-coverage) · [**Install**](#deployment-channel) · [**Release control**](#release--recovery-control)
+[**Command briefing**](#command-network-briefing) · [**Current release**](#current-release-signal--v716) · [**Incident Wire**](#incident-command-wire) · [**Systems**](#native-command-divisions) · [**Interfaces**](#seven-complete-interface-systems) · [**Devices**](#field-terminal-coverage) · [**Install**](#deployment-channel) · [**Release control**](#release--recovery-control)
 
 </div>
 
@@ -51,7 +51,7 @@ MissionChief distributes operational information across the map, opened incident
 
 <div align="center">
 
-<img src="docs/media/readme-command-board.svg" alt="MissionChief Toolkit cinematic emergency systems board" width="100%">
+<img src="docs/media/readme-command-board.svg" alt="MissionChief Toolkit realistic United Kingdom multi-agency operational picture" width="100%">
 
 </div>
 
@@ -64,31 +64,30 @@ MissionChief distributes operational information across the map, opened incident
 | Control channel | State | Evidence |
 |---|:---:|---|
 | **Canonical source** | 🟢 | Validated `src/MissionChief_Map_Command_Toolkit.user.js` |
-| **Production release** | 🟢 | GitHub Release `v7.1.4` published |
+| **Production release** | 🟢 | GitHub Release `v7.1.6` published |
 | **Public distribution** | 🟢 | Greasy Fork version and metadata verified |
 | **Private recovery** | 🟢 | Versioned recovery commit retained |
 | **Discord release signal** | 🟢 | Verified release announcement posted |
-| **Hosted media** | 🟢 | v7.1.4 release snapshot: 37 discovered · 33 referenced · 0 missing |
+| **Hosted media** | 🟢 | Current release snapshot: 37 discovered · 33 referenced · 0 missing |
 | **Responsive command** | 🟢 | Desktop · Tablet/iPad · iPhone/iPad Safari |
 
 The [Release Control Panel](status/README.md) is machine-backed from the current release ledger rather than manually asserted.
 
 ---
 
-# Current release signal — v7.1.4
+# Current release signal — v7.1.6
 
-> **CHANNEL UPDATE // PATIENT TRANSPORT SWEEP MISSION PROGRESS**
+> **CHANNEL UPDATE // NATIVE DISCHARGE PATIENT CONFIRMATION**
 
-Version 7.1.4 synchronises one canonical mission-position state across the persistent HUD, Toolkit panel and final summary.
+Version 7.1.6 handles MissionChief's intermittent **Discharge patient** confirmation only while a Patient Transport Sweep-owned discharge action is armed.
 
-- Active sweeps begin at `1 / total`.
-- The numerator advances once at each mission queue boundary, never for individual patients or vehicle candidates.
-- Skipped missions and recoverable mission-level errors finalise exactly once before the queue continues.
-- Cancellation preserves the last accurate mission position.
-- Normal completion visibly reaches `total / total` before the HUD is dismissed.
-- Static and runtime contracts cover repeated rendering, multiple patient releases, skips, mission errors, cancellation and completion.
+- The exact **Yes, discharge!** action is selected immediately and during the existing bounded release-evidence wait.
+- **Abort** and **discharge and disable confirmation** remain untouched, preserving the user's MissionChief confirmation preference.
+- Unrelated dialogs, manual discharges, inactive sweeps and mismatched release identities are ignored.
+- Idempotent confirmation ownership prevents repeated scans from double-clicking the dialog.
+- Static and executable regressions cover immediate, delayed, absent, unrelated and repeated confirmation scans.
 
-The release fixes presentation drift without weakening the existing native vehicle-window, ownership, confirmation or discharge safeguards.
+The release advances native transport handling without weakening ownership checks, user preferences, mission progress, skipped-patient accounting or verified release evidence.
 
 ---
 
@@ -261,7 +260,7 @@ Responsive behaviour is part of the feature contract—not a cosmetic patch appl
 
 <div align="center">
 
-<img src="docs/media/readme-release-control.svg" alt="MissionChief Toolkit cinematic release and recovery control board" width="100%">
+<img src="docs/media/readme-release-control.svg" alt="MissionChief Toolkit realistic UK release and recovery operations centre" width="100%">
 
 </div>
 
@@ -269,15 +268,15 @@ Responsive behaviour is part of the feature contract—not a cosmetic patch appl
 
 | Field | Verified value |
 |---|---|
-| **Version** | `7.1.4` |
-| **Release focus** | Patient Transport Sweep mission-progress synchronization |
+| **Version** | `7.1.6` |
+| **Release focus** | Native Discharge patient confirmation handling |
 | **Canonical source** | `src/MissionChief_Map_Command_Toolkit.user.js` |
-| **Validated SHA-256** | `3385c059be08141659e88ae3280b8302a5bbc0d33b8af75312ec97b25a434cbe` |
-| **GitHub Release** | [`v7.1.4`](https://github.com/Conroy1988/missionchief-toolkit-assets/releases/tag/v7.1.4) |
+| **Validated SHA-256** | `6358f5b25b6b278fac409a78d2b7b1c0bfd88bb808810dbf484dcd86f1f99386` |
+| **GitHub Release** | [`v7.1.6`](https://github.com/Conroy1988/missionchief-toolkit-assets/releases/tag/v7.1.6) |
 | **Greasy Fork** | Verified against the stable release |
-| **Private backup** | `3dca3b0136989226012f23a349b026603d82929d` |
+| **Private backup** | `e4b2617762ca4a09c569966861660cab55712f32` |
 | **Discord release delivery** | Posted |
-| **Hosted media audit** | v7.1.4 release snapshot: 37 discovered · 33 referenced · 0 missing |
+| **Hosted media audit** | Current release snapshot: 37 discovered · 33 referenced · 0 missing |
 
 ## Governed release topology
 

--- a/docs/media/readme-command-board.svg
+++ b/docs/media/readme-command-board.svg
@@ -1,149 +1,191 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" role="img" aria-labelledby="title desc">
-<title id="title">MissionChief Toolkit Emergency Systems Board</title>
-<desc id="desc">Native command divisions for incident, mission, fleet, map, finance and transport systems.</desc>
-
+<title id="title">MissionChief Toolkit United Kingdom operational picture</title>
+<desc id="desc">A realistic multi-agency UK command board showing fire, ambulance, police and coastguard response around a live operational map with mission, fleet, transport, map and finance intelligence.</desc>
 <defs>
   <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-    <stop offset="0" stop-color="#02060a"/>
-    <stop offset=".42" stop-color="#07141e"/>
-    <stop offset="1" stop-color="#12080b"/>
+    <stop offset="0" stop-color="#03070c"/><stop offset=".48" stop-color="#071724"/><stop offset="1" stop-color="#16070b"/>
   </linearGradient>
-  <linearGradient id="steel" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#36434d"/>
-    <stop offset=".12" stop-color="#141c22"/>
-    <stop offset=".52" stop-color="#080d11"/>
-    <stop offset=".88" stop-color="#1b252c"/>
-    <stop offset="1" stop-color="#05080a"/>
+  <radialGradient id="mapGlow" cx=".5" cy=".45" r=".6">
+    <stop offset="0" stop-color="#1a789d" stop-opacity=".32"/><stop offset=".6" stop-color="#072336" stop-opacity=".1"/><stop offset="1" stop-color="#02070c" stop-opacity="0"/>
+  </radialGradient>
+  <linearGradient id="panel" x1="0" y1="0" x2="1" y2="1">
+    <stop offset="0" stop-color="#17242c" stop-opacity=".97"/><stop offset=".45" stop-color="#071018" stop-opacity=".96"/><stop offset="1" stop-color="#03070b" stop-opacity=".98"/>
   </linearGradient>
-  <linearGradient id="steel2" x1="0" y1="0" x2="1" y2="1">
-    <stop offset="0" stop-color="#26343e"/>
-    <stop offset=".25" stop-color="#0b1217"/>
-    <stop offset=".72" stop-color="#131d24"/>
-    <stop offset="1" stop-color="#04070a"/>
-  </linearGradient>
-  <linearGradient id="blue" x1="0" y1="0" x2="1" y2="1">
-    <stop offset="0" stop-color="#0a537d"/>
-    <stop offset=".45" stop-color="#0b2b41"/>
-    <stop offset="1" stop-color="#07131c"/>
-  </linearGradient>
-  <linearGradient id="green" x1="0" y1="0" x2="1" y2="1">
-    <stop offset="0" stop-color="#225b2a"/>
-    <stop offset=".45" stop-color="#15351c"/>
-    <stop offset="1" stop-color="#08130b"/>
-  </linearGradient>
-  <linearGradient id="amber" x1="0" y1="0" x2="1" y2="1">
-    <stop offset="0" stop-color="#6c4d0b"/>
-    <stop offset=".45" stop-color="#3a2a0e"/>
-    <stop offset="1" stop-color="#151006"/>
-  </linearGradient>
-  <linearGradient id="red" x1="0" y1="0" x2="1" y2="1">
-    <stop offset="0" stop-color="#6d161e"/>
-    <stop offset=".45" stop-color="#391218"/>
-    <stop offset="1" stop-color="#16080b"/>
-  </linearGradient>
-  <linearGradient id="cyan" x1="0" y1="0" x2="1" y2="1">
-    <stop offset="0" stop-color="#0c6573"/>
-    <stop offset=".45" stop-color="#0a3540"/>
-    <stop offset="1" stop-color="#061519"/>
-  </linearGradient>
-  <linearGradient id="goldText" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#fff2a8"/>
-    <stop offset=".28" stop-color="#f6c84f"/>
-    <stop offset=".7" stop-color="#b87512"/>
-    <stop offset="1" stop-color="#f4bc2d"/>
-  </linearGradient>
-  <linearGradient id="whiteText" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#ffffff"/>
-    <stop offset=".55" stop-color="#e7e1d4"/>
-    <stop offset="1" stop-color="#a9a49a"/>
-  </linearGradient>
-  <linearGradient id="edge" x1="0" y1="0" x2="1" y2="0">
-    <stop offset="0" stop-color="#16b9ff"/>
-    <stop offset=".48" stop-color="#5dd9ff"/>
-    <stop offset=".52" stop-color="#ff805c"/>
-    <stop offset="1" stop-color="#e2242f"/>
-  </linearGradient>
-  <pattern id="grid" width="42" height="42" patternUnits="userSpaceOnUse">
-    <path d="M42 0H0V42" fill="none" stroke="#66d1ff" stroke-opacity=".055"/>
-  </pattern>
-  <pattern id="scan" width="4" height="4" patternUnits="userSpaceOnUse">
-    <rect width="4" height="1.2" fill="#fff" opacity=".025"/>
-  </pattern>
-  <pattern id="micro" width="12" height="12" patternUnits="userSpaceOnUse">
-    <circle cx="1.5" cy="1.5" r=".7" fill="#7fdfff" opacity=".12"/>
-  </pattern>
-  <filter id="shadow" x="-30%" y="-30%" width="160%" height="160%">
-    <feDropShadow dx="0" dy="16" stdDeviation="16" flood-color="#000" flood-opacity=".7"/>
-  </filter>
-  <filter id="glowB" x="-120%" y="-120%" width="340%" height="340%">
-    <feGaussianBlur stdDeviation="7" result="b"/>
-    <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
-  </filter>
-  <filter id="glowR" x="-120%" y="-120%" width="340%" height="340%">
-    <feGaussianBlur stdDeviation="8" result="b"/>
-    <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
-  </filter>
-  <filter id="grit" x="-20%" y="-20%" width="140%" height="140%">
-    <feTurbulence type="fractalNoise" baseFrequency=".7" numOctaves="2" seed="9" result="noise"/>
-    <feColorMatrix in="noise" type="saturate" values="0" result="mono"/>
-    <feComponentTransfer in="mono" result="soft">
-      <feFuncA type="table" tableValues="0 0 .08"/>
-    </feComponentTransfer>
-    <feBlend in="SourceGraphic" in2="soft" mode="screen"/>
-  </filter>
+  <linearGradient id="redVehicle" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#f22a3a"/><stop offset=".45" stop-color="#8e0713"/><stop offset="1" stop-color="#2a0206"/></linearGradient>
+  <linearGradient id="whiteVehicle" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#ffffff"/><stop offset=".5" stop-color="#c6cfce"/><stop offset="1" stop-color="#59666a"/></linearGradient>
+  <linearGradient id="glass" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#8fdbff"/><stop offset=".35" stop-color="#22516a"/><stop offset="1" stop-color="#03090d"/></linearGradient>
+  <linearGradient id="yellow" x1="0" y1="0" x2="1" y2="0"><stop stop-color="#fbff4a"/><stop offset=".6" stop-color="#d4e600"/><stop offset="1" stop-color="#737e00"/></linearGradient>
+  <linearGradient id="green" x1="0" y1="0" x2="1" y2="0"><stop stop-color="#31da59"/><stop offset=".55" stop-color="#07852d"/><stop offset="1" stop-color="#013f12"/></linearGradient>
+  <linearGradient id="blue" x1="0" y1="0" x2="1" y2="0"><stop stop-color="#31afff"/><stop offset=".55" stop-color="#126ac8"/><stop offset="1" stop-color="#032e66"/></linearGradient>
+  <linearGradient id="steel" x1="0" y1="0" x2="0" y2="1"><stop stop-color="#657985"/><stop offset=".12" stop-color="#17232a"/><stop offset=".7" stop-color="#070b0e"/><stop offset="1" stop-color="#25333b"/></linearGradient>
+  <pattern id="grid" width="36" height="36" patternUnits="userSpaceOnUse"><path d="M36 0H0V36" fill="none" stroke="#62d1ff" stroke-opacity=".055"/></pattern>
+  <pattern id="scan" width="5" height="5" patternUnits="userSpaceOnUse"><rect width="5" height="1" fill="#fff" opacity=".02"/></pattern>
+  <filter id="shadow" x="-40%" y="-40%" width="180%" height="190%"><feDropShadow dx="0" dy="18" stdDeviation="15" flood-color="#000" flood-opacity=".82"/></filter>
+  <filter id="glow" x="-250%" y="-250%" width="600%" height="600%"><feGaussianBlur stdDeviation="9" result="g"/><feMerge><feMergeNode in="g"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+  <filter id="grain" x="-20%" y="-20%" width="140%" height="140%"><feTurbulence type="fractalNoise" baseFrequency=".8" numOctaves="2" seed="11"/><feColorMatrix type="saturate" values="0"/><feComponentTransfer><feFuncA type="table" tableValues="0 0 .05"/></feComponentTransfer><feBlend in="SourceGraphic" mode="screen"/></filter>
+  <clipPath id="clip"><rect x="18" y="18" width="1564" height="864" rx="28"/></clipPath>
 </defs>
+<g clip-path="url(#clip)">
+  <rect width="1600" height="900" fill="url(#bg)"/>
+  <rect width="1600" height="900" fill="url(#grid)"/>
+  <rect width="1600" height="900" fill="url(#scan)"/>
+  <rect width="1600" height="900" fill="url(#mapGlow)"/>
 
-<rect width="1600" height="900" rx="28" fill="url(#bg)"/><rect width="1600" height="900" rx="28" fill="url(#grid)"/><rect width="1600" height="900" rx="28" fill="url(#scan)"/>
-<path d="M20 10H1580l10 10v860l-10 10H20L10 880V20z" fill="none" stroke="url(#steel)" stroke-width="18"/>
-<rect x="24" y="24" width="1552" height="852" rx="18" fill="none" stroke="#62727c" stroke-opacity=".45" stroke-width="2"/>
-<g filter="url(#shadow)">
-<path d="M30 28h1540v62H30z" fill="url(#steel)" stroke="#50616b" stroke-width="2"/>
-<g transform="translate(42 38)">
-<rect width="64" height="42" rx="5" fill="#0a1116" stroke="#4f6470"/>
-<path d="M0 0 64 42M64 0 0 42" stroke="#fff" stroke-width="11"/><path d="M0 0 64 42M64 0 0 42" stroke="#c92632" stroke-width="4"/>
-<path d="M32 0v42M0 21h64" stroke="#fff" stroke-width="12"/><path d="M32 0v42M0 21h64" stroke="#c92632" stroke-width="6"/>
+  <!-- Header -->
+  <g transform="translate(38 34)" filter="url(#shadow)">
+    <path d="M0 0h1524l18 18v94l-18 18H0l-18-18V18z" fill="url(#panel)" stroke="#657b86" stroke-width="2"/>
+    <g transform="translate(18 18)">
+      <rect width="78" height="48" rx="4" fill="#080e12" stroke="#697b84"/>
+      <path d="M0 0 78 48M78 0 0 48" stroke="#fff" stroke-width="12"/><path d="M0 0 78 48M78 0 0 48" stroke="#c71f31" stroke-width="5"/>
+      <path d="M39 0v48M0 24h78" stroke="#fff" stroke-width="14"/><path d="M39 0v48M0 24h78" stroke="#c71f31" stroke-width="7"/>
+    </g>
+    <text x="120" y="49" fill="#6cd8ff" font-family="Arial,sans-serif" font-size="15" font-weight="900" letter-spacing="4">MISSIONCHIEF TOOLKIT // UK MULTI-AGENCY COMMAND</text>
+    <text x="120" y="91" fill="#fff" font-family="Arial Black,Arial,sans-serif" font-size="40" font-weight="900" letter-spacing="1.5">UNITED KINGDOM OPERATIONAL PICTURE</text>
+    <g transform="translate(1172 22)" font-family="Arial,sans-serif">
+      <text x="0" y="15" fill="#81939d" font-size="11" font-weight="800" letter-spacing="2">COMMAND STATE</text>
+      <circle cx="21" cy="52" r="8" fill="#36dc7b" filter="url(#glow)"/>
+      <text x="43" y="59" fill="#dffff0" font-size="19" font-weight="900" letter-spacing="2">OPERATIONAL</text>
+      <text x="0" y="91" fill="#8fa0aa" font-size="11" letter-spacing="1.6">DESKTOP · TABLET · iOS</text>
+    </g>
+  </g>
+
+  <!-- Central UK map -->
+  <g transform="translate(535 178)" filter="url(#shadow)">
+    <path d="M0 0h530l18 18v590l-18 18H0l-18-18V18z" fill="#03090e" stroke="#4f6774" stroke-width="2"/>
+    <rect x="12" y="12" width="506" height="602" rx="10" fill="#06121b" stroke="#172d39"/>
+    <text x="28" y="44" fill="#6ed8ff" font-family="Arial,sans-serif" font-size="13" font-weight="900" letter-spacing="3">LIVE INCIDENT MAP // NATIVE MISSION CONTEXT</text>
+    <path d="M28 58h472" stroke="#1c94c7" stroke-opacity=".65"/>
+
+    <!-- stylised GB landmass -->
+    <g transform="translate(72 68)">
+      <path d="M196 0l-30 24-14 46-37 26-8 46-35 35 5 41-22 38 12 35-18 43 12 54 39 13 22 43 45-5 31 34 45-6 26-38 43-9 18-46 42-28-8-52 24-43-8-45-34-26-7-38-37-20 10-39-27-32-37 11-27-37z" fill="#0a2635" stroke="#50c9ff" stroke-width="4"/>
+      <path d="M76 176l60-68 64-32 57 31 48 67 29 93-26 91-64 67-78 8-63-44-31-104z" fill="none" stroke="#2ea7d8" stroke-opacity=".35" stroke-width="2"/>
+      <g fill="none" stroke="#2cc0ef" stroke-opacity=".24" stroke-width="2">
+        <path d="M103 150l178 247M127 99l212 212M63 257l282 36M108 375l212-196M150 70l82 359"/>
+      </g>
+      <g filter="url(#glow)">
+        <circle cx="165" cy="110" r="8" fill="#ff3f4a"/><circle cx="133" cy="196" r="7" fill="#ffbd34"/>
+        <circle cx="196" cy="252" r="9" fill="#26b9ff"/><circle cx="154" cy="327" r="7" fill="#ff3f4a"/>
+        <circle cx="224" cy="375" r="8" fill="#22d271"/><circle cx="272" cy="297" r="7" fill="#ffbd34"/>
+        <circle cx="301" cy="205" r="8" fill="#27baff"/>
+      </g>
+      <g fill="#dff7ff" font-family="Arial,sans-serif" font-size="11" font-weight="800">
+        <text x="178" y="101">EDINBURGH</text><text x="71" y="194">BELFAST</text><text x="210" y="246">MANCHESTER</text>
+        <text x="87" y="326">CARDIFF</text><text x="240" y="372">LONDON</text><text x="314" y="202">NORTH SEA</text>
+      </g>
+      <path d="M27 212l-17 24 6 35 23 8 15-22-5-33z" fill="#0a2635" stroke="#50c9ff" stroke-width="3"/>
+    </g>
+
+    <g transform="translate(28 526)" font-family="Arial,sans-serif">
+      <rect width="472" height="62" rx="8" fill="#07141c" stroke="#1c4b61"/>
+      <circle cx="22" cy="31" r="6" fill="#ff414b"/><text x="39" y="35" fill="#fff" font-size="12" font-weight="800">PRIORITY</text>
+      <circle cx="128" cy="31" r="6" fill="#ffbc36"/><text x="145" y="35" fill="#fff" font-size="12" font-weight="800">WATCH</text>
+      <circle cx="227" cy="31" r="6" fill="#25b9ff"/><text x="244" y="35" fill="#fff" font-size="12" font-weight="800">RESOURCE</text>
+      <circle cx="349" cy="31" r="6" fill="#29d273"/><text x="366" y="35" fill="#fff" font-size="12" font-weight="800">VERIFIED</text>
+    </g>
+  </g>
+
+  <!-- Fire panel -->
+  <g transform="translate(40 178)" filter="url(#shadow)">
+    <path d="M0 0h455l16 16v270l-16 16H0l-16-16V16z" fill="url(#panel)" stroke="#a72d36" stroke-width="2"/>
+    <text x="25" y="40" fill="#ff5963" font-family="Arial,sans-serif" font-size="13" font-weight="900" letter-spacing="3">FIRE &amp; RESCUE // RESPONSE CHANNEL</text>
+    <path d="M25 53h402" stroke="#9f2b34" stroke-opacity=".72"/>
+    <g transform="translate(30 74)">
+      <ellipse cx="196" cy="176" rx="190" ry="25" fill="#000" opacity=".64"/>
+      <path d="M12 70 58 24h239l62 44 53 28 31 65-25 22H24L0 154z" fill="url(#redVehicle)" stroke="#48050b" stroke-width="4"/>
+      <path d="M56 29h235l56 42H24z" fill="#7d0711"/>
+      <path d="M274 35h32l43 34h-70z" fill="url(#glass)" stroke="#283943" stroke-width="3"/>
+      <path d="M33 79h367v17H25z" fill="url(#yellow)"/><path d="M33 98h367v9H25z" fill="#173783"/>
+      <g fill="#9b0b17" stroke="#dc414b"><rect x="47" y="119" width="64" height="39"/><rect x="117" y="119" width="64" height="39"/><rect x="187" y="119" width="64" height="39"/></g>
+      <rect x="278" y="112" width="118" height="48" fill="#20282c" stroke="#a9222d"/>
+      <text x="337" y="141" text-anchor="middle" fill="#fff" font-family="Arial,sans-serif" font-size="14" font-weight="900">FIRE &amp; RESCUE</text>
+      <circle cx="89" cy="166" r="34" fill="#06090b" stroke="#303a3f" stroke-width="6"/><circle cx="89" cy="166" r="16" fill="#8c989e"/>
+      <circle cx="334" cy="166" r="34" fill="#06090b" stroke="#303a3f" stroke-width="6"/><circle cx="334" cy="166" r="16" fill="#8c989e"/>
+      <rect x="252" y="14" width="88" height="12" rx="5" fill="#168cff" stroke="#8bdeff"/><circle cx="274" cy="20" r="6" fill="#29b8ff" filter="url(#glow)"/>
+    </g>
+    <text x="28" y="284" fill="#cbd9df" font-family="Arial,sans-serif" font-size="12">Mission age · value · commitment · incident wire</text>
+  </g>
+
+  <!-- Ambulance panel -->
+  <g transform="translate(40 505)" filter="url(#shadow)">
+    <path d="M0 0h455l16 16v270l-16 16H0l-16-16V16z" fill="url(#panel)" stroke="#2b9e4c" stroke-width="2"/>
+    <text x="25" y="40" fill="#55db78" font-family="Arial,sans-serif" font-size="13" font-weight="900" letter-spacing="3">AMBULANCE // PATIENT TRANSPORT CHANNEL</text>
+    <path d="M25 53h402" stroke="#2b9e4c" stroke-opacity=".68"/>
+    <g transform="translate(28 73)">
+      <ellipse cx="200" cy="177" rx="191" ry="25" fill="#000" opacity=".64"/>
+      <path d="M13 70 61 24h248l73 43 45 65-14 50H24L0 156z" fill="url(#whiteVehicle)" stroke="#4b5659" stroke-width="4"/>
+      <path d="M61 29h240l64 40H27z" fill="#e9eee9"/>
+      <path d="M299 36h35l36 32h-69z" fill="url(#glass)" stroke="#394b52" stroke-width="3"/>
+      <path d="M34 78h373v20H25z" fill="url(#yellow)"/><path d="M34 99h373v21H25z" fill="url(#green)"/>
+      <text x="168" y="61" text-anchor="middle" fill="#0d6d32" font-family="Arial,sans-serif" font-size="17" font-weight="900" letter-spacing="2">AMBULANCE</text>
+      <path d="M41 123h50l-17 49H24zM93 123h50l-17 49H76zM145 123h50l-17 49H128zM197 123h50l-17 49H180z" fill="#e9f12c"/>
+      <path d="M67 123h50l-17 49H50zM119 123h50l-17 49H102zM171 123h50l-17 49H154zM223 123h50l-17 49H206z" fill="#087e30"/>
+      <path d="M313 107h86v56h-86z" fill="#d6dfda" stroke="#73807d"/><path d="M356 114v42M335 135h42" stroke="#0a8337" stroke-width="6"/>
+      <circle cx="91" cy="168" r="34" fill="#06090b" stroke="#303a3f" stroke-width="6"/><circle cx="91" cy="168" r="16" fill="#8c989e"/>
+      <circle cx="340" cy="168" r="34" fill="#06090b" stroke="#303a3f" stroke-width="6"/><circle cx="340" cy="168" r="16" fill="#8c989e"/>
+      <rect x="72" y="12" width="82" height="12" rx="5" fill="#168cff"/><rect x="286" y="12" width="82" height="12" rx="5" fill="#168cff"/>
+      <circle cx="95" cy="18" r="6" fill="#29b8ff" filter="url(#glow)"/><circle cx="342" cy="18" r="6" fill="#29b8ff" filter="url(#glow)"/>
+    </g>
+    <text x="28" y="284" fill="#cbd9df" font-family="Arial,sans-serif" font-size="12">Transport watcher · native discharge · progress integrity</text>
+  </g>
+
+  <!-- Police panel -->
+  <g transform="translate(1105 178)" filter="url(#shadow)">
+    <path d="M0 0h455l16 16v270l-16 16H0l-16-16V16z" fill="url(#panel)" stroke="#257fc5" stroke-width="2"/>
+    <text x="25" y="40" fill="#4cbaff" font-family="Arial,sans-serif" font-size="13" font-weight="900" letter-spacing="3">POLICE // INCIDENT CONTROL CHANNEL</text>
+    <path d="M25 53h402" stroke="#257fc5" stroke-opacity=".68"/>
+    <g transform="translate(26 82)">
+      <ellipse cx="199" cy="149" rx="190" ry="24" fill="#000" opacity=".64"/>
+      <path d="M13 83 71 39h176l86 38 58 43-14 41H28L0 139z" fill="url(#whiteVehicle)" stroke="#3e4d55" stroke-width="4"/>
+      <path d="M85 44h148l76 34H48z" fill="#dce6e9"/>
+      <path d="M91 49h65v31H63zM163 49h67l61 31H164z" fill="url(#glass)" stroke="#334851" stroke-width="3"/>
+      <path d="M35 89h326v20H27z" fill="url(#yellow)"/><path d="M35 110h326v20H27z" fill="url(#blue)"/>
+      <g fill="#eef32c"><path d="M55 88h43l-16 42H39z"/><path d="M141 88h43l-16 42H125z"/><path d="M227 88h43l-16 42H211z"/><path d="M313 88h43l-16 42H297z"/></g>
+      <g fill="#116cc8"><path d="M98 88h43l-16 42H82z"/><path d="M184 88h43l-16 42H168z"/><path d="M270 88h43l-16 42H254z"/></g>
+      <rect x="162" y="90" width="76" height="23" rx="4" fill="#f6f9fa"/><text x="200" y="107" text-anchor="middle" fill="#145694" font-family="Arial,sans-serif" font-size="14" font-weight="900">POLICE</text>
+      <circle cx="86" cy="146" r="31" fill="#06090b" stroke="#303a3f" stroke-width="6"/><circle cx="86" cy="146" r="14" fill="#8c989e"/>
+      <circle cx="306" cy="146" r="31" fill="#06090b" stroke="#303a3f" stroke-width="6"/><circle cx="306" cy="146" r="14" fill="#8c989e"/>
+      <rect x="139" y="29" width="103" height="12" rx="5" fill="#168cff"/><circle cx="164" cy="35" r="6" fill="#29b8ff" filter="url(#glow)"/><circle cx="218" cy="35" r="6" fill="#29b8ff" filter="url(#glow)"/>
+    </g>
+    <text x="28" y="284" fill="#cbd9df" font-family="Arial,sans-serif" font-size="12">Priority incidents · direct navigation · native dispatch context</text>
+  </g>
+
+  <!-- Coastguard panel -->
+  <g transform="translate(1105 505)" filter="url(#shadow)">
+    <path d="M0 0h455l16 16v270l-16 16H0l-16-16V16z" fill="url(#panel)" stroke="#d05533" stroke-width="2"/>
+    <text x="25" y="40" fill="#ff7b53" font-family="Arial,sans-serif" font-size="13" font-weight="900" letter-spacing="3">HM COASTGUARD // SEARCH &amp; RESCUE CHANNEL</text>
+    <path d="M25 53h402" stroke="#d05533" stroke-opacity=".68"/>
+    <g transform="translate(35 73) rotate(-2)">
+      <ellipse cx="191" cy="177" rx="165" ry="22" fill="#000" opacity=".55"/>
+      <path d="M30 91c22-38 70-57 127-48 55 8 92 35 111 68l-18 32-72 13-105-7-54-27z" fill="#f4f2e8" stroke="#7d8a90" stroke-width="4"/>
+      <path d="M67 82c24-25 57-32 89-27 31 4 58 20 76 44l-58 8-88-5z" fill="url(#glass)"/>
+      <path d="M20 120h224l-12 29H73z" fill="#d31f2a"/>
+      <path d="M221 100l112-24 8 10-95 38z" fill="#ecebe4" stroke="#78848a" stroke-width="3"/>
+      <path d="M325 76l45-33 9 7-30 39z" fill="#d31f2a"/>
+      <path d="M115 51l20-35 14 3-4 35z" fill="#b8c2c6"/>
+      <path d="M62 151h155" stroke="#222a2e" stroke-width="5"/>
+      <text x="133" y="137" text-anchor="middle" fill="#fff" font-family="Arial,sans-serif" font-size="15" font-weight="900" letter-spacing="1.5">HM COASTGUARD</text>
+      <path d="M136 18H14M132 14l-100-26M135 13l-92 30M141 16l90-35" stroke="#b4bdc1" stroke-width="5" stroke-linecap="round"/>
+      <circle cx="29" cy="119" r="6" fill="#29b8ff" filter="url(#glow)"/><circle cx="241" cy="133" r="6" fill="#29b8ff" filter="url(#glow)"/>
+    </g>
+    <text x="28" y="284" fill="#cbd9df" font-family="Arial,sans-serif" font-size="12">Coverage rings · location intelligence · responsive field control</text>
+  </g>
+
+  <!-- Command domains footer -->
+  <g transform="translate(40 830)" filter="url(#shadow)" font-family="Arial,sans-serif">
+    <path d="M0 0h1520l16 16-16 42H0l-16-42z" fill="#040a0e" stroke="#4d626d"/>
+    <g font-weight="900" font-size="13" letter-spacing="1.5">
+      <circle cx="28" cy="29" r="6" fill="#ff4854"/><text x="44" y="34" fill="#fff">MISSION INTELLIGENCE</text>
+      <circle cx="323" cy="29" r="6" fill="#26b9ff"/><text x="339" y="34" fill="#fff">FLEET IDENTITY</text>
+      <circle cx="556" cy="29" r="6" fill="#2ed274"/><text x="572" y="34" fill="#fff">NATIVE TRANSPORT</text>
+      <circle cx="844" cy="29" r="6" fill="#ffd145"/><text x="860" y="34" fill="#fff">GEOGRAPHIC CONTROL</text>
+      <circle cx="1162" cy="29" r="6" fill="#ba7cff"/><text x="1178" y="34" fill="#fff">FINANCIAL RECONCILIATION</text>
+    </g>
+  </g>
+
+  <rect width="1600" height="900" fill="none" stroke="#748a95" stroke-width="3"/>
+  <rect x="12" y="12" width="1576" height="876" rx="30" fill="none" stroke="url(#steel)" stroke-width="20"/>
+  <rect x="24" y="24" width="1552" height="852" rx="22" fill="none" stroke="#6f828b" stroke-opacity=".55" stroke-width="2"/>
+  <rect width="1600" height="900" fill="none" filter="url(#grain)"/>
 </g>
-<text x="120" y="64" fill="#5ed2ff" font-family="Courier New,monospace" font-size="14" font-weight="900" letter-spacing="2">UK EMERGENCY COMMAND NETWORK</text>
-<g transform="translate(410 38)"><rect width="205" height="42" rx="6" fill="#07131f" stroke="#168ddd"/><circle cx="24" cy="21" r="10" fill="#179ee8"/><text x="48" y="27" fill="#e9f8ff" font-size="16" font-weight="900" letter-spacing="2">VERIFIED v7.1.4</text></g>
-<g transform="translate(630 38)"><rect width="238" height="42" rx="6" fill="#270a0c" stroke="#d3342f"/><circle cx="24" cy="21" r="10" fill="#e9443b"/><text x="48" y="27" fill="#ffd9d2" font-size="14" font-weight="900" letter-spacing="1.7">7 INTERFACE SYSTEMS</text></g>
-<g transform="translate(880 38)"><rect width="255" height="42" rx="6" fill="#251a05" stroke="#d99a16"/><rect x="16" y="10" width="23" height="17" rx="2" fill="none" stroke="#ffd64d" stroke-width="3"/><text x="54" y="27" fill="#ffe39b" font-size="16" font-weight="900" letter-spacing="1.8">DESKTOP · TABLET · iOS</text></g>
-<text x="1515" y="59" text-anchor="end" fill="#88949b" font-size="12" letter-spacing="2">SYSTEM STATUS</text><text x="1515" y="78" text-anchor="end" fill="#37c6ff" font-size="14" font-weight="900" letter-spacing="2">OPERATIONAL</text><circle cx="1538" cy="70" r="6" fill="#49e080"/>
-</g>
-<g filter="url(#grit)">
-<text x="68" y="235" fill="url(#whiteText)" font-family="Impact,Arial Black,sans-serif" font-size="101" letter-spacing="2">EMERGENCY</text>
-<text x="68" y="330" fill="url(#whiteText)" font-family="Impact,Arial Black,sans-serif" font-size="101" letter-spacing="2">SYSTEMS BOARD</text>
-</g>
-<text x="78" y="382" fill="url(#goldText)" font-family="Impact,Arial Black,sans-serif" font-size="41" letter-spacing="8">NATIVE COMMAND DIVISIONS</text>
-<path d="M68 398h820" stroke="#20b9ff" stroke-width="4"/>
-<g transform="translate(65 -45) scale(.82)" opacity=".95">
-<path d="M1098 136 l-29 13 -10 32 -27 12 -10 33 -34 13 -2 30 -23 24 7 29 -25 28 10 29 -18 24 4 36 24 9 12 33 31 -3 22 26 38 -4 19 -25 32 -5 14 -31 31 -18 -6 -36 20 -29 -4 -36 -26 -18 -4 -26 -27 -17 8 -25 -19 -26 -27 8 -18 -22 z" fill="#06121a" stroke="#27b7ff" stroke-width="4"/>
-<g fill="#ff3e35" filter="url(#glowR)"><circle cx="1046" cy="238" r="7"/><circle cx="1080" cy="286" r="6"/><circle cx="1096" cy="350" r="8"/><circle cx="1134" cy="426" r="7"/></g>
-<g fill="#ffba2e" filter="url(#glowB)"><circle cx="1062" cy="315" r="7"/><circle cx="1122" cy="382" r="6"/><circle cx="1160" cy="462" r="7"/></g>
-<g fill="#29b7ff" filter="url(#glowB)"><circle cx="1018" cy="270" r="6"/><circle cx="1106" cy="330" r="6"/><circle cx="1148" cy="400" r="6"/></g>
-<g stroke="#36c9ff" stroke-opacity=".25"><path d="M990 210 1170 490M1030 190 1200 420M970 300 1180 340M1010 430 1170 250"/></g>
-</g>
-<g transform="translate(1260 104)" filter="url(#shadow)">
-<path d="M0 0h290l16 16v610l-16 16H0l-16-16V16z" fill="url(#steel2)" stroke="#5f737d" stroke-width="3"/>
-<rect x="14" y="14" width="262" height="614" rx="8" fill="#05090c" stroke="#27343b"/>
-<circle cx="36" cy="54" r="7" fill="#ef4238"/><text x="58" y="63" fill="#fff" font-family="Impact,Arial Black,sans-serif" font-size="25" letter-spacing="2">LIVE DISPATCH</text>
-<text x="30" y="103" fill="#ff5b4d" font-family="Arial Narrow,Arial,sans-serif" font-size="16" font-weight="900" letter-spacing="3">PRIORITY INCIDENTS</text>
-<g font-family="Arial Narrow,Arial,sans-serif">
-<g transform="translate(22 126)"><rect width="246" height="72" rx="6" fill="#0c0e10" stroke="#453033"/><circle cx="30" cy="36" r="18" fill="#4b1010" stroke="#e13c31"/><text x="60" y="27" fill="#fff" font-size="14" font-weight="900">MAJOR FIRE</text><text x="60" y="48" fill="#a8b0b4" font-size="11">12:47 · MANCHESTER</text><rect x="192" y="25" width="42" height="22" rx="4" fill="#3e0b0e" stroke="#d52e2f"/><text x="213" y="40" text-anchor="middle" fill="#ff766a" font-size="9" font-weight="900">HIGH</text></g>
-<g transform="translate(22 208)"><rect width="246" height="72" rx="6" fill="#0c0e10" stroke="#263c49"/><circle cx="30" cy="36" r="18" fill="#0a3150" stroke="#168fe1"/><text x="60" y="27" fill="#fff" font-size="13" font-weight="900">MEDICAL EMERGENCY</text><text x="60" y="48" fill="#a8b0b4" font-size="11">12:14 · LEEDS</text><rect x="184" y="25" width="50" height="22" rx="4" fill="#3c2d05" stroke="#d49b16"/><text x="209" y="40" text-anchor="middle" fill="#ffd85b" font-size="8" font-weight="900">MEDIUM</text></g>
-<g transform="translate(22 290)"><rect width="246" height="72" rx="6" fill="#0c0e10" stroke="#55451b"/><circle cx="30" cy="36" r="18" fill="#4b3705" stroke="#e0a81d"/><text x="60" y="27" fill="#fff" font-size="13" font-weight="900">RTC – MULTI VEHICLE</text><text x="60" y="48" fill="#a8b0b4" font-size="11">12:01 · BIRMINGHAM</text><rect x="192" y="25" width="42" height="22" rx="4" fill="#3e0b0e" stroke="#d52e2f"/><text x="213" y="40" text-anchor="middle" fill="#ff766a" font-size="9" font-weight="900">HIGH</text></g>
-<g transform="translate(22 372)"><rect width="246" height="72" rx="6" fill="#0c0e10" stroke="#263c49"/><circle cx="30" cy="36" r="18" fill="#0a3150" stroke="#168fe1"/><text x="60" y="27" fill="#fff" font-size="13" font-weight="900">SECURITY INCIDENT</text><text x="60" y="48" fill="#a8b0b4" font-size="11">11:59 · LONDON</text><rect x="184" y="25" width="50" height="22" rx="4" fill="#3c2d05" stroke="#d49b16"/><text x="209" y="40" text-anchor="middle" fill="#ffd85b" font-size="8" font-weight="900">MEDIUM</text></g>
-</g>
-<path d="M26 492h238" stroke="#1a4a63"/><path d="M26 530q12-25 24 0t24 0 24 0 24 0 24 0 24 0 24 0 24 0 24 0" fill="none" stroke="#1faee8"/>
-<rect x="22" y="552" width="120" height="58" rx="6" fill="#08120d" stroke="#23442d"/><text x="36" y="576" fill="#7d8c82" font-size="10">CHANNEL STATUS</text><text x="36" y="599" fill="#43d86e" font-size="15" font-weight="900">ENCRYPTED</text>
-<rect x="150" y="552" width="118" height="58" rx="6" fill="#081118" stroke="#263b48"/><text x="164" y="576" fill="#7d8c82" font-size="10">UNITS ONLINE</text><text x="164" y="599" fill="#46c9ff" font-size="21" font-weight="900">128</text>
-</g>
-<g transform="translate(36 432)" filter="url(#shadow)" font-family="Arial Narrow,Arial,sans-serif">
-  <g><rect width="194" height="314" rx="12" fill="url(#red)" stroke="#df4038" stroke-width="2"/><circle cx="38" cy="42" r="22" fill="#481112" stroke="#ef4a40"/><path d="M38 25v35M24 34c-12 12-12 25 0 36M52 34c12 12 12 25 0 36" fill="none" stroke="#ff6255" stroke-width="3"/><text x="72" y="31" fill="#ff6255" font-family="Impact,Arial Black,sans-serif" font-size="17">INCIDENT</text><text x="72" y="51" fill="#ff6255" font-family="Impact,Arial Black,sans-serif" font-size="17">COMMAND</text><text x="72" y="71" fill="#ff6255" font-family="Impact,Arial Black,sans-serif" font-size="17">WIRE</text><text x="20" y="112" fill="#fff" font-size="13">• continuous priority reel</text><text x="20" y="138" fill="#fff" font-size="13">• map jump</text><text x="20" y="164" fill="#fff" font-size="13">• queue tracking</text><path d="M20 254h154" stroke="#812128"/><path d="M20 278h20v-20h12v14h12v-35h12v41h12v-26h12v26h12v-53h12v53h12v-31h12v31h26" fill="none" stroke="#f03d3d" stroke-width="3"/></g>
-  <g transform="translate(206)"><rect width="194" height="314" rx="12" fill="url(#blue)" stroke="#2db9ff" stroke-width="2"/><circle cx="38" cy="42" r="22" fill="#08233a" stroke="#32baff"/><circle cx="38" cy="42" r="10" fill="none" stroke="#45c5ff" stroke-width="3"/><path d="M38 17v13M38 54v13M13 42h13M50 42h13" stroke="#45c5ff" stroke-width="3"/><text x="72" y="38" fill="#4bc7ff" font-family="Impact,Arial Black,sans-serif" font-size="23">MISSION</text><text x="72" y="63" fill="#4bc7ff" font-family="Impact,Arial Black,sans-serif" font-size="23">CONTROL</text><text x="20" y="104" fill="#fff" font-size="14">Age · Value · Commitment</text><path d="M20 168h154M20 195h120M20 222h145" stroke="#256a91" stroke-width="8" opacity=".5"/><path d="M20 275h154" stroke="#1f6c9d"/><path d="M20 294h40M67 294h48M122 294h52" stroke="#30aeea" stroke-width="6"/></g>
-  <g transform="translate(412)"><rect width="194" height="314" rx="12" fill="url(#green)" stroke="#50bc55" stroke-width="2"/><path d="M38 18 60 27v17c0 18-10 28-22 37-12-9-22-19-22-37V27z" fill="#173d1e" stroke="#5ed067" stroke-width="2"/><text x="72" y="38" fill="#62d063" font-family="Impact,Arial Black,sans-serif" font-size="23">FLEET</text><text x="72" y="63" fill="#62d063" font-family="Impact,Arial Black,sans-serif" font-size="23">CONTROL</text><text x="20" y="104" fill="#fff" font-size="14">Codes · Badges · Gap</text><path d="M25 220h45l15-22h43l18 22h23v27H25z" fill="#194927" stroke="#51c761" stroke-width="2"/><circle cx="56" cy="250" r="12" fill="#07120a" stroke="#52cb62"/><circle cx="141" cy="250" r="12" fill="#07120a" stroke="#52cb62"/><path d="M20 294h36M62 294h48M116 294h58" stroke="#45bd55" stroke-width="6"/></g>
-  <g transform="translate(618)"><rect width="194" height="314" rx="12" fill="url(#amber)" stroke="#dca522" stroke-width="2"/><path d="M38 19c-14 0-25 11-25 24 0 20 25 42 25 42s25-22 25-42c0-13-11-24-25-24z" fill="#553b08" stroke="#f1bd38" stroke-width="2"/><circle cx="38" cy="42" r="8" fill="#ffd052"/><text x="72" y="38" fill="#f0bb34" font-family="Impact,Arial Black,sans-serif" font-size="23">MAP</text><text x="72" y="63" fill="#f0bb34" font-family="Impact,Arial Black,sans-serif" font-size="23">CONTROL</text><text x="20" y="104" fill="#fff" font-size="14">Coverage · Places · Profiles</text><path d="M20 170c35-25 55 12 82-10s46 18 72-16M25 210c22-20 40 9 65-7s43 18 72-8M35 250c30-14 53 3 83-12s36 8 55-10" fill="none" stroke="#c89420" stroke-width="3" opacity=".75"/><path d="M20 294h36M62 294h48M116 294h58" stroke="#d7a726" stroke-width="6"/></g>
-  <g transform="translate(824)"><rect width="194" height="314" rx="12" fill="url(#red)" stroke="#dc3b40" stroke-width="2"/><text x="18" y="68" fill="#ef544f" font-family="Georgia,serif" font-size="58" font-weight="900">£</text><text x="72" y="38" fill="#ef514c" font-family="Impact,Arial Black,sans-serif" font-size="20">FINANCIAL</text><text x="72" y="63" fill="#ef514c" font-family="Impact,Arial Black,sans-serif" font-size="20">CONTROL</text><text x="20" y="104" fill="#fff" font-size="14">Income · Spend · Variance</text><path d="m18 250 28-38 25 11 34-61 28 20 41-75" fill="none" stroke="#f04444" stroke-width="4"/><path d="M20 294h36M62 294h48M116 294h58" stroke="#e03a3a" stroke-width="6"/></g>
-  <g transform="translate(1030)"><rect width="194" height="314" rx="12" fill="url(#cyan)" stroke="#31c5d6" stroke-width="2"/><path d="M18 31h43l13 18v25H9V49z" fill="#0c4f59" stroke="#42d1df" stroke-width="2"/><circle cx="26" cy="76" r="9" fill="#061316" stroke="#42d1df"/><circle cx="58" cy="76" r="9" fill="#061316" stroke="#42d1df"/><text x="82" y="38" fill="#48d3e0" font-family="Impact,Arial Black,sans-serif" font-size="20">TRANSPORT</text><text x="82" y="63" fill="#48d3e0" font-family="Impact,Arial Black,sans-serif" font-size="20">WATCH</text><text x="20" y="104" fill="#fff" font-size="14">Patients · Prisoners · Sweep</text><path d="M20 168h154M20 195h120M20 222h145" stroke="#2d6f78" stroke-width="8" opacity=".55"/><path d="M20 294h36M62 294h48M116 294h58" stroke="#36becb" stroke-width="6"/></g>
-</g>
-<g transform="translate(24 780)"><path d="M0 0h1552l14 14v72l-14 14H0L-14 86V14z" fill="url(#steel)" stroke="#586872" stroke-width="2"/><circle cx="54" cy="50" r="31" fill="#18110e" stroke="#c6a14d" stroke-width="2"/><path d="m54 19 8 22 23 1-18 15 6 23-19-12-19 12 6-23-18-15 23-1z" fill="#d1a841"/><text x="778" y="60" text-anchor="middle" fill="#d2dde2" font-family="Arial Narrow,Arial,sans-serif" font-size="18" font-weight="900" letter-spacing="4">SEE THE MISSION  •  READ THE FLEET  •  COMMAND THE MAP  •  RECONCILE THE OPERATION</text><g transform="translate(1405 25)"><text x="0" y="10" fill="#819099" font-size="9">COMMS</text><circle cx="18" cy="35" r="6" fill="#e33131"/><text x="54" y="10" fill="#819099" font-size="9">DATA</text><circle cx="68" cy="35" r="6" fill="#e2a72f"/><text x="104" y="10" fill="#819099" font-size="9">LINK</text><circle cx="116" cy="35" r="6" fill="#3fdb70"/></g></g>
 </svg>

--- a/docs/media/readme-hero.svg
+++ b/docs/media/readme-hero.svg
@@ -1,180 +1,313 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="720" viewBox="0 0 1600 720" role="img" aria-labelledby="title desc">
-<title id="title">MissionChief Map Command Toolkit cinematic emergency command console</title>
-<desc id="desc">Verified v7.1.4 UK emergency command network with live incident wire, mission, fleet, map and finance systems.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="760" viewBox="0 0 1600 760" role="img" aria-labelledby="title desc">
+<title id="title">MissionChief Map Command Toolkit — UK emergency response command scene</title>
+<desc id="desc">A cinematic night-time United Kingdom emergency response scene with a fire appliance, ambulance, police car and coastguard helicopter linked by a digital incident command overlay.</desc>
 <defs>
-  <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-    <stop offset="0" stop-color="#02060a"/>
-    <stop offset=".42" stop-color="#07141e"/>
-    <stop offset="1" stop-color="#12080b"/>
+  <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0" stop-color="#020713"/>
+    <stop offset=".55" stop-color="#07172a"/>
+    <stop offset="1" stop-color="#14222b"/>
   </linearGradient>
-  <linearGradient id="steel" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#36434d"/>
-    <stop offset=".12" stop-color="#141c22"/>
-    <stop offset=".52" stop-color="#080d11"/>
-    <stop offset=".88" stop-color="#1b252c"/>
-    <stop offset="1" stop-color="#05080a"/>
+  <radialGradient id="horizon" cx=".56" cy=".52" r=".62">
+    <stop offset="0" stop-color="#29435a" stop-opacity=".75"/>
+    <stop offset=".5" stop-color="#0a1b2c" stop-opacity=".22"/>
+    <stop offset="1" stop-color="#020713" stop-opacity="0"/>
+  </radialGradient>
+  <linearGradient id="road" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0" stop-color="#1e2930"/>
+    <stop offset=".45" stop-color="#0c1115"/>
+    <stop offset="1" stop-color="#020405"/>
   </linearGradient>
-  <linearGradient id="steel2" x1="0" y1="0" x2="1" y2="1">
-    <stop offset="0" stop-color="#26343e"/>
-    <stop offset=".25" stop-color="#0b1217"/>
-    <stop offset=".72" stop-color="#131d24"/>
-    <stop offset="1" stop-color="#04070a"/>
+  <linearGradient id="wet" x1="0" y1="0" x2="1" y2="0">
+    <stop offset="0" stop-color="#071d2d"/>
+    <stop offset=".28" stop-color="#1b2631"/>
+    <stop offset=".5" stop-color="#101418"/>
+    <stop offset=".72" stop-color="#261412"/>
+    <stop offset="1" stop-color="#07131d"/>
   </linearGradient>
-  <linearGradient id="blue" x1="0" y1="0" x2="1" y2="1">
-    <stop offset="0" stop-color="#0a537d"/>
-    <stop offset=".45" stop-color="#0b2b41"/>
-    <stop offset="1" stop-color="#07131c"/>
+  <linearGradient id="fireBody" x1="0" y1="0" x2="1" y2=".7">
+    <stop offset="0" stop-color="#ff3949"/>
+    <stop offset=".25" stop-color="#b30e1e"/>
+    <stop offset=".62" stop-color="#64050e"/>
+    <stop offset="1" stop-color="#250207"/>
   </linearGradient>
-  <linearGradient id="green" x1="0" y1="0" x2="1" y2="1">
-    <stop offset="0" stop-color="#225b2a"/>
-    <stop offset=".45" stop-color="#15351c"/>
-    <stop offset="1" stop-color="#08130b"/>
+  <linearGradient id="fireSide" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0" stop-color="#b70d1d"/>
+    <stop offset=".6" stop-color="#6d0610"/>
+    <stop offset="1" stop-color="#2a0307"/>
   </linearGradient>
-  <linearGradient id="amber" x1="0" y1="0" x2="1" y2="1">
-    <stop offset="0" stop-color="#6c4d0b"/>
-    <stop offset=".45" stop-color="#3a2a0e"/>
-    <stop offset="1" stop-color="#151006"/>
+  <linearGradient id="ambulanceBody" x1="0" y1="0" x2="1" y2=".8">
+    <stop offset="0" stop-color="#fffef0"/>
+    <stop offset=".34" stop-color="#e6eadf"/>
+    <stop offset=".7" stop-color="#aeb7b0"/>
+    <stop offset="1" stop-color="#626b68"/>
   </linearGradient>
-  <linearGradient id="red" x1="0" y1="0" x2="1" y2="1">
-    <stop offset="0" stop-color="#6d161e"/>
-    <stop offset=".45" stop-color="#391218"/>
-    <stop offset="1" stop-color="#16080b"/>
-  </linearGradient>
-  <linearGradient id="goldText" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#fff2a8"/>
-    <stop offset=".28" stop-color="#f6c84f"/>
-    <stop offset=".7" stop-color="#b87512"/>
-    <stop offset="1" stop-color="#f4bc2d"/>
-  </linearGradient>
-  <linearGradient id="whiteText" x1="0" y1="0" x2="0" y2="1">
+  <linearGradient id="policeBody" x1="0" y1="0" x2="1" y2="1">
     <stop offset="0" stop-color="#ffffff"/>
-    <stop offset=".55" stop-color="#e7e1d4"/>
-    <stop offset="1" stop-color="#a9a49a"/>
+    <stop offset=".42" stop-color="#c8d2d8"/>
+    <stop offset=".72" stop-color="#768590"/>
+    <stop offset="1" stop-color="#2c3942"/>
   </linearGradient>
-  <linearGradient id="edge" x1="0" y1="0" x2="1" y2="0">
-    <stop offset="0" stop-color="#16b9ff"/>
-    <stop offset=".48" stop-color="#5dd9ff"/>
-    <stop offset=".52" stop-color="#ff805c"/>
-    <stop offset="1" stop-color="#e2242f"/>
+  <linearGradient id="glass" x1="0" y1="0" x2="1" y2="1">
+    <stop offset="0" stop-color="#8dd7ff" stop-opacity=".9"/>
+    <stop offset=".28" stop-color="#1d4a64" stop-opacity=".82"/>
+    <stop offset=".65" stop-color="#071822" stop-opacity=".96"/>
+    <stop offset="1" stop-color="#02070b"/>
   </linearGradient>
-  <pattern id="grid" width="42" height="42" patternUnits="userSpaceOnUse">
-    <path d="M42 0H0V42" fill="none" stroke="#66d1ff" stroke-opacity=".055"/>
+  <linearGradient id="chrome" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0" stop-color="#f8fbff"/>
+    <stop offset=".22" stop-color="#778791"/>
+    <stop offset=".48" stop-color="#172128"/>
+    <stop offset=".73" stop-color="#a6b0b4"/>
+    <stop offset="1" stop-color="#222a2e"/>
+  </linearGradient>
+  <linearGradient id="blueLamp" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0" stop-color="#c9f4ff"/>
+    <stop offset=".28" stop-color="#2ac6ff"/>
+    <stop offset=".72" stop-color="#0069df"/>
+    <stop offset="1" stop-color="#022057"/>
+  </linearGradient>
+  <linearGradient id="yellow" x1="0" y1="0" x2="1" y2="0">
+    <stop offset="0" stop-color="#f9ff44"/>
+    <stop offset=".55" stop-color="#d8e800"/>
+    <stop offset="1" stop-color="#7e8c00"/>
+  </linearGradient>
+  <linearGradient id="greenBat" x1="0" y1="0" x2="1" y2="0">
+    <stop offset="0" stop-color="#1dcc49"/>
+    <stop offset=".55" stop-color="#078427"/>
+    <stop offset="1" stop-color="#024411"/>
+  </linearGradient>
+  <linearGradient id="blueBat" x1="0" y1="0" x2="1" y2="0">
+    <stop offset="0" stop-color="#2ea2ff"/>
+    <stop offset=".55" stop-color="#075ebd"/>
+    <stop offset="1" stop-color="#032f6d"/>
+  </linearGradient>
+  <linearGradient id="hud" x1="0" y1="0" x2="1" y2="1">
+    <stop offset="0" stop-color="#07111a" stop-opacity=".96"/>
+    <stop offset=".65" stop-color="#0a1720" stop-opacity=".84"/>
+    <stop offset="1" stop-color="#13070b" stop-opacity=".9"/>
+  </linearGradient>
+  <pattern id="rain" width="28" height="28" patternUnits="userSpaceOnUse" patternTransform="rotate(18)">
+    <path d="M2 0v15" stroke="#b9e9ff" stroke-opacity=".16" stroke-width="1.2"/>
+    <path d="M18 10v12" stroke="#b9e9ff" stroke-opacity=".08" stroke-width="1"/>
   </pattern>
-  <pattern id="scan" width="4" height="4" patternUnits="userSpaceOnUse">
-    <rect width="4" height="1.2" fill="#fff" opacity=".025"/>
+  <pattern id="screenGrid" width="34" height="34" patternUnits="userSpaceOnUse">
+    <path d="M34 0H0V34" fill="none" stroke="#4dd0ff" stroke-opacity=".06"/>
   </pattern>
-  <pattern id="micro" width="12" height="12" patternUnits="userSpaceOnUse">
-    <circle cx="1.5" cy="1.5" r=".7" fill="#7fdfff" opacity=".12"/>
-  </pattern>
-  <filter id="shadow" x="-30%" y="-30%" width="160%" height="160%">
-    <feDropShadow dx="0" dy="16" stdDeviation="16" flood-color="#000" flood-opacity=".7"/>
+  <filter id="shadow" x="-40%" y="-40%" width="180%" height="180%">
+    <feDropShadow dx="0" dy="18" stdDeviation="16" flood-color="#000" flood-opacity=".88"/>
   </filter>
-  <filter id="glowB" x="-120%" y="-120%" width="340%" height="340%">
-    <feGaussianBlur stdDeviation="7" result="b"/>
-    <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+  <filter id="vehicleShadow" x="-50%" y="-50%" width="200%" height="220%">
+    <feDropShadow dx="0" dy="20" stdDeviation="12" flood-color="#000" flood-opacity=".85"/>
   </filter>
-  <filter id="glowR" x="-120%" y="-120%" width="340%" height="340%">
-    <feGaussianBlur stdDeviation="8" result="b"/>
-    <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+  <filter id="blueGlow" x="-250%" y="-250%" width="600%" height="600%">
+    <feGaussianBlur stdDeviation="11" result="g"/>
+    <feMerge><feMergeNode in="g"/><feMergeNode in="g"/><feMergeNode in="SourceGraphic"/></feMerge>
   </filter>
-  <filter id="grit" x="-20%" y="-20%" width="140%" height="140%">
-    <feTurbulence type="fractalNoise" baseFrequency=".7" numOctaves="2" seed="9" result="noise"/>
-    <feColorMatrix in="noise" type="saturate" values="0" result="mono"/>
-    <feComponentTransfer in="mono" result="soft">
-      <feFuncA type="table" tableValues="0 0 .08"/>
-    </feComponentTransfer>
-    <feBlend in="SourceGraphic" in2="soft" mode="screen"/>
+  <filter id="redGlow" x="-250%" y="-250%" width="600%" height="600%">
+    <feGaussianBlur stdDeviation="12" result="g"/>
+    <feMerge><feMergeNode in="g"/><feMergeNode in="SourceGraphic"/></feMerge>
   </filter>
+  <filter id="soft" x="-30%" y="-30%" width="160%" height="160%">
+    <feGaussianBlur stdDeviation="3"/>
+  </filter>
+  <filter id="grain" x="-20%" y="-20%" width="140%" height="140%">
+    <feTurbulence type="fractalNoise" baseFrequency=".75" numOctaves="2" seed="17" result="n"/>
+    <feColorMatrix in="n" type="saturate" values="0"/>
+    <feComponentTransfer><feFuncA type="table" tableValues="0 0 .055"/></feComponentTransfer>
+    <feBlend in="SourceGraphic" mode="screen"/>
+  </filter>
+  <clipPath id="frameClip"><rect x="18" y="18" width="1564" height="724" rx="30"/></clipPath>
 </defs>
-<rect width="1600" height="720" rx="28" fill="url(#bg)"/>
-<rect width="1600" height="720" rx="28" fill="url(#grid)"/>
-<rect width="1600" height="720" rx="28" fill="url(#scan)"/>
-<path d="M22 10H1578l12 12v676l-12 12H22L10 698V22z" fill="none" stroke="url(#steel)" stroke-width="18"/>
-<rect x="24" y="24" width="1552" height="672" rx="18" fill="none" stroke="#6b7b84" stroke-opacity=".45" stroke-width="2"/>
-<g fill="#aeb8bd" opacity=".5">
-  <circle cx="35" cy="35" r="4"/><circle cx="1565" cy="35" r="4"/><circle cx="35" cy="685" r="4"/><circle cx="1565" cy="685" r="4"/>
-</g>
-<g filter="url(#shadow)">
-  <path d="M34 30H1566v66H34z" fill="url(#steel)" stroke="#4c5c65" stroke-width="2"/>
-  <g transform="translate(48 40)">
-    <rect width="72" height="46" rx="6" fill="#0a1116" stroke="#4f6470"/>
-    <path d="M0 0 72 46M72 0 0 46" stroke="#fff" stroke-width="12" opacity=".9"/>
-    <path d="M0 0 72 46M72 0 0 46" stroke="#c92632" stroke-width="5"/>
-    <path d="M36 0v46M0 23h72" stroke="#fff" stroke-width="14"/>
-    <path d="M36 0v46M0 23h72" stroke="#c92632" stroke-width="7"/>
+
+<g clip-path="url(#frameClip)">
+  <rect width="1600" height="760" fill="url(#sky)"/>
+  <rect width="1600" height="760" fill="url(#horizon)"/>
+
+  <g opacity=".55" filter="url(#soft)">
+    <path d="M-70 180C60 90 200 115 288 170c85-88 246-86 345 2 99-56 235-33 292 41 111-79 273-63 348 34 124-37 270 12 350 110v93H-70z" fill="#203443"/>
+    <path d="M-60 103c151-85 281-65 386 14 104-55 249-48 331 25 98-48 245-29 322 51 121-65 265-34 354 51 83-21 185 12 267 79V0H-60z" fill="#101c29"/>
   </g>
-  <text x="134" y="68" fill="#5ed2ff" font-family="Courier New,monospace" font-size="13" font-weight="900" letter-spacing="2.1">UK EMERGENCY COMMAND NETWORK</text>
-  <g transform="translate(436 40)">
-    <path d="M0 0h230l10 10v26l-10 10H0l-10-10V10z" fill="#07131f" stroke="#168ddd"/>
-    <path d="M22 9 35 14v12c0 9-6 14-13 18-7-4-13-9-13-18V14z" fill="#159eff"/>
-    <path d="m16 26 5 5 9-11" fill="none" stroke="#031019" stroke-width="4"/>
-    <text x="52" y="29" fill="#e5f7ff" font-family="Arial Narrow,Arial,sans-serif" font-size="17" font-weight="900" letter-spacing="2">VERIFIED v7.1.4</text>
+
+  <g opacity=".95">
+    <rect y="345" width="1600" height="110" fill="#050b10"/>
+    <g fill="#0a1117">
+      <path d="M0 345h115v-92h40v92h80v-138h42v138h74v-82h32v82h68v-125h49v125h75v-179h34v179h48v-91h34v91h76v-140h42v140h66v-103h34v103h87v-158h42v158h73v-118h34v118h58v-88h44v88h63v-165h31v165h72v-118h46v118h72v-72h41v72h116V455H0z"/>
+    </g>
+    <g fill="#101820">
+      <path d="M1060 346v-190h18v190zm-14-192h46l-8-22h-30z"/>
+      <circle cx="1069" cy="119" r="7" fill="#18232c"/>
+      <path d="M1210 346v-130h20v130zm-22-130h64l-10-18h-44z"/>
+      <path d="M1305 346v-94h26v94zm-11-94h48l-7-14h-34z"/>
+    </g>
+    <g fill="#e8c56a" opacity=".75">
+      <rect x="86" y="296" width="5" height="8"/><rect x="201" y="250" width="6" height="8"/>
+      <rect x="464" y="269" width="6" height="8"/><rect x="616" y="224" width="6" height="8"/>
+      <rect x="838" y="281" width="6" height="8"/><rect x="1098" y="260" width="6" height="8"/>
+      <rect x="1358" y="225" width="6" height="8"/><rect x="1490" y="292" width="6" height="8"/>
+    </g>
   </g>
-  <g transform="translate(698 40)">
-    <path d="M0 0h230l10 10v26l-10 10H0l-10-10V10z" fill="#270a0c" stroke="#d3342f"/>
-    <circle cx="24" cy="23" r="10" fill="#e9443b"/>
-    <path d="m19 23 4 4 7-9" fill="none" stroke="#250408" stroke-width="3"/>
-    <text x="48" y="29" fill="#ffd9d2" font-family="Arial Narrow,Arial,sans-serif" font-size="17" font-weight="900" letter-spacing="2">INCIDENT COMMAND</text>
+
+  <path d="M0 430H1600v330H0z" fill="url(#road)"/>
+  <path d="M0 495c305-25 588-18 867 4 271 22 497 19 733-12v273H0z" fill="url(#wet)" opacity=".84"/>
+  <path d="M0 532c290-25 592-13 862 9 268 22 515 19 738-17" fill="none" stroke="#9db1ba" stroke-opacity=".25" stroke-width="3"/>
+  <path d="M0 668h1600" stroke="#d9e2e6" stroke-opacity=".18" stroke-width="3"/>
+  <g opacity=".44" filter="url(#soft)">
+    <path d="M130 563l145 0-63 197H83z" fill="#ff2038"/>
+    <path d="M526 560h178l69 200H461z" fill="#c8ff38"/>
+    <path d="M1030 574h210l157 186H946z" fill="#148cff"/>
   </g>
-  <g transform="translate(960 40)">
-    <path d="M0 0h255l10 10v26l-10 10H0l-10-10V10z" fill="#251a05" stroke="#d99a16"/>
-    <rect x="15" y="11" width="22" height="17" rx="2" fill="none" stroke="#ffd64d" stroke-width="3"/>
-    <path d="M12 33h28" stroke="#ffd64d" stroke-width="3"/>
-    <text x="54" y="29" fill="#ffe39b" font-family="Arial Narrow,Arial,sans-serif" font-size="17" font-weight="900" letter-spacing="1.8">DESKTOP · TABLET · iOS</text>
+  <g stroke="#f5f2d6" stroke-width="9" stroke-linecap="round" opacity=".72">
+    <path d="M27 641h110"/><path d="M208 641h110"/><path d="M389 641h110"/>
+    <path d="M1281 641h105"/><path d="M1454 641h105"/>
   </g>
-  <text x="1518" y="60" text-anchor="end" fill="#8f9aa2" font-family="Courier New,monospace" font-size="12" letter-spacing="2">SYSTEM STATUS</text>
-  <text x="1518" y="82" text-anchor="end" fill="#37c6ff" font-family="Courier New,monospace" font-size="14" font-weight="900" letter-spacing="2">OPERATIONAL</text>
-  <circle cx="1540" cy="76" r="6" fill="#49e080" filter="url(#glowB)"/>
-</g>
-<g transform="translate(30 104)" filter="url(#glowR)">
-  <path d="M0 40h68L58 0H10z" fill="#6a1711" stroke="#ff6a43" stroke-width="2"/>
-  <rect x="10" y="36" width="48" height="10" rx="4" fill="#fa5a2b"/>
-  <ellipse cx="34" cy="17" rx="22" ry="13" fill="#ff8b45" opacity=".75"/>
-  <path d="M10 17H-8M58 17h18M34-4v-14" stroke="#ff6a43" stroke-width="4"/>
-</g>
-<g filter="url(#grit)">
-  <text x="72" y="245" fill="url(#whiteText)" font-family="Impact,Arial Black,Arial,sans-serif" font-size="118" letter-spacing="2">MISSIONCHIEF</text>
-  <text x="74" y="324" fill="url(#goldText)" font-family="Impact,Arial Black,Arial,sans-serif" font-size="64" letter-spacing="3.5">MAP COMMAND TOOLKIT</text>
-</g>
-<path d="M80 346h870" stroke="#20b9ff" stroke-width="4"/>
-<path d="M85 358h150l16 12H70zM795 358h150l16 12H779z" fill="#159fdf" opacity=".8"/>
-<text x="512" y="380" text-anchor="middle" fill="#65cfff" font-family="Arial Narrow,Arial,sans-serif" font-size="22" font-weight="900" letter-spacing="8">EMERGENCY COMMAND CONSOLE</text>
-<g transform="translate(52 -2) scale(.92)" opacity=".94">
-  <path d="M1098 136 l-29 13 -10 32 -27 12 -10 33 -34 13 -2 30 -23 24 7 29 -25 28 10 29 -18 24 4 36 24 9 12 33 31 -3 22 26 38 -4 19 -25 32 -5 14 -31 31 -18 -6 -36 20 -29 -4 -36 -26 -18 -4 -26 -27 -17 8 -25 -19 -26 -27 8 -18 -22 z" fill="#06121a" stroke="#27b7ff" stroke-width="3"/>
-  <path d="M1098 136 l-29 13 -10 32 -27 12 -10 33 -34 13 -2 30 -23 24 7 29 -25 28 10 29 -18 24 4 36 24 9 12 33 31 -3 22 26 38 -4 19 -25 32 -5 14 -31 31 -18 -6 -36 20 -29 -4 -36 -26 -18 -4 -26 -27 -17 8 -25 -19 -26 -27 8 -18 -22 z" fill="url(#micro)" opacity=".8"/>
-  <g stroke="#3ad1ff" stroke-opacity=".22"><path d="M990 210 1170 490M1030 190 1200 420M970 300 1180 340M1010 430 1170 250"/></g>
-  <g fill="#ff3f36" filter="url(#glowR)"><circle cx="1046" cy="238" r="6"/><circle cx="1080" cy="286" r="5"/><circle cx="1096" cy="350" r="7"/><circle cx="1134" cy="426" r="6"/></g>
-  <g fill="#ffb82e" filter="url(#glowB)"><circle cx="1062" cy="315" r="6"/><circle cx="1122" cy="382" r="5"/><circle cx="1160" cy="462" r="6"/></g>
-  <g fill="#29b7ff" filter="url(#glowB)"><circle cx="1018" cy="270" r="5"/><circle cx="1106" cy="330" r="5"/><circle cx="1148" cy="400" r="5"/></g>
-  <g stroke="#fff" stroke-opacity=".45" fill="none"><circle cx="1096" cy="350" r="45"/><circle cx="1096" cy="350" r="85"/><circle cx="1096" cy="350" r="125"/></g>
-</g>
-<g transform="translate(1180 118)" filter="url(#shadow)">
-  <path d="M0 0h365l18 18v458l-18 18H0l-18-18V18z" fill="url(#steel2)" stroke="#6a7c86" stroke-width="3"/>
-  <rect x="16" y="16" width="333" height="462" rx="9" fill="#05090c" stroke="#24333c"/>
-  <text x="36" y="48" fill="#c7d0d5" font-family="Arial Narrow,Arial,sans-serif" font-size="13" font-weight="900" letter-spacing="4">INCIDENT COMMAND WIRE</text>
-  <circle cx="42" cy="80" r="7" fill="#ef4238" filter="url(#glowR)"/>
-  <text x="64" y="88" fill="#fff" font-family="Impact,Arial Black,sans-serif" font-size="26" letter-spacing="2">LIVE DISPATCH</text>
-  <rect x="30" y="104" width="305" height="36" rx="5" fill="#0b1115" stroke="#3e1a1c"/>
-  <text x="48" y="128" fill="#ff5b4d" font-family="Arial Narrow,Arial,sans-serif" font-size="16" font-weight="900" letter-spacing="3">PRIORITY INCIDENTS</text>
-  <g font-family="Arial Narrow,Arial,sans-serif">
-    <g transform="translate(30 154)"><rect width="305" height="62" rx="6" fill="#0c0e10" stroke="#453033"/><rect x="10" y="10" width="42" height="42" rx="6" fill="#4b1010" stroke="#e13c31"/><path d="M31 17c11 13 4 19 11 26-5 8-17 10-24 0 9-7 4-16 13-26z" fill="#f05241"/><text x="66" y="24" fill="#9ba5aa" font-size="11">12:47</text><text x="110" y="25" fill="#fff" font-size="15" font-weight="900">MAJOR FIRE</text><text x="110" y="45" fill="#a8b0b4" font-size="11">MANCHESTER, M1</text><rect x="252" y="17" width="42" height="22" rx="4" fill="#3e0b0e" stroke="#d52e2f"/><text x="273" y="32" text-anchor="middle" fill="#ff766a" font-size="10" font-weight="900">HIGH</text></g>
-    <g transform="translate(30 226)"><rect width="305" height="62" rx="6" fill="#0c0e10" stroke="#263c49"/><rect x="10" y="10" width="42" height="42" rx="6" fill="#0a3150" stroke="#168fe1"/><path d="M23 17h16v8h8v16h-8v8H23v-8h-8V25h8z" fill="#5bc4ff"/><text x="66" y="24" fill="#9ba5aa" font-size="11">12:44</text><text x="110" y="25" fill="#fff" font-size="14" font-weight="900">MEDICAL EMERGENCY</text><text x="110" y="45" fill="#a8b0b4" font-size="11">LEEDS, LS1</text><rect x="244" y="17" width="50" height="22" rx="4" fill="#3c2d05" stroke="#d49b16"/><text x="269" y="32" text-anchor="middle" fill="#ffd85b" font-size="9" font-weight="900">MEDIUM</text></g>
-    <g transform="translate(30 298)"><rect width="305" height="62" rx="6" fill="#0c0e10" stroke="#55451b"/><rect x="10" y="10" width="42" height="42" rx="6" fill="#4b3705" stroke="#e0a81d"/><path d="M31 15 48 47H14z" fill="#f3bd35"/><rect x="29" y="25" width="4" height="12" fill="#3f2c03"/><circle cx="31" cy="42" r="2" fill="#3f2c03"/><text x="66" y="24" fill="#9ba5aa" font-size="11">12:41</text><text x="110" y="25" fill="#fff" font-size="14" font-weight="900">RTC – MULTI VEHICLE</text><text x="110" y="45" fill="#a8b0b4" font-size="11">BIRMINGHAM, M6</text><rect x="252" y="17" width="42" height="22" rx="4" fill="#3e0b0e" stroke="#d52e2f"/><text x="273" y="32" text-anchor="middle" fill="#ff766a" font-size="10" font-weight="900">HIGH</text></g>
-    <g transform="translate(30 370)"><rect width="305" height="62" rx="6" fill="#0c0e10" stroke="#263c49"/><rect x="10" y="10" width="42" height="42" rx="6" fill="#0a3150" stroke="#168fe1"/><path d="M31 16 43 21v10c0 9-6 14-12 18-6-4-12-9-12-18V21z" fill="#48b9ff"/><text x="66" y="24" fill="#9ba5aa" font-size="11">12:39</text><text x="110" y="25" fill="#fff" font-size="14" font-weight="900">SECURITY INCIDENT</text><text x="110" y="45" fill="#a8b0b4" font-size="11">LONDON, SE1</text><rect x="244" y="17" width="50" height="22" rx="4" fill="#3c2d05" stroke="#d49b16"/><text x="269" y="32" text-anchor="middle" fill="#ffd85b" font-size="9" font-weight="900">MEDIUM</text></g>
+
+  <g transform="translate(1160 118) rotate(-4)" filter="url(#vehicleShadow)">
+    <ellipse cx="112" cy="151" rx="125" ry="22" fill="#000" opacity=".4"/>
+    <path d="M31 104c18-36 60-56 118-49 54 7 95 33 119 67l-15 30-62 14-116-3-58-24z" fill="#f4f3eb" stroke="#8c969c" stroke-width="3"/>
+    <path d="M64 95c23-25 54-34 90-29 34 4 57 19 77 44l-56 8-93-4z" fill="url(#glass)"/>
+    <path d="M20 134h222l-11 29H77z" fill="#d21c25"/>
+    <path d="M218 112l110-23 8 9-93 39z" fill="#e8e8e2" stroke="#78848b" stroke-width="3"/>
+    <path d="M318 88l44-34 10 6-31 41z" fill="#d11e28"/>
+    <path d="M328 91l62 22-3 9-69-15z" fill="#f3f1ea"/>
+    <path d="M106 63l22-37 15 2-4 38z" fill="#bfc7ca"/>
+    <path d="M54 163h154" stroke="#222c31" stroke-width="5"/>
+    <path d="M72 169h116" stroke="#11181c" stroke-width="7"/>
+    <circle cx="18" cy="127" r="5" fill="#258dff" filter="url(#blueGlow)"/>
+    <circle cx="237" cy="139" r="5" fill="#258dff" filter="url(#blueGlow)"/>
+    <text x="128" y="147" text-anchor="middle" fill="#fff" font-family="Arial,sans-serif" font-size="18" font-weight="900" letter-spacing="2">HM COASTGUARD</text>
+    <path d="M130 28H8M120 22l-96-26M124 20 37 48M130 23l88-35" stroke="#b8c1c5" stroke-width="5" stroke-linecap="round"/>
   </g>
+
+  <g transform="translate(55 382)" filter="url(#vehicleShadow)">
+    <ellipse cx="303" cy="260" rx="300" ry="40" fill="#000" opacity=".75"/>
+    <path d="M28 97 84 28h287l70 63 105 26 38 115-44 30H37L0 230z" fill="url(#fireBody)" stroke="#340208" stroke-width="5"/>
+    <path d="M82 32h280l64 60H42z" fill="url(#fireSide)"/>
+    <path d="M325 42h66l45 53h-103z" fill="url(#glass)" stroke="#17242b" stroke-width="4"/>
+    <path d="M97 43h209v57H51z" fill="#211417" stroke="#5f1d24" stroke-width="4"/>
+    <path d="M50 105h485v21H41z" fill="url(#yellow)"/>
+    <path d="M49 130h486v13H43z" fill="#17367d"/>
+    <g fill="#8a0c18" stroke="#d72b36" stroke-width="2">
+      <rect x="65" y="153" width="74" height="62" rx="4"/>
+      <rect x="148" y="153" width="74" height="62" rx="4"/>
+      <rect x="231" y="153" width="74" height="62" rx="4"/>
+    </g>
+    <g stroke="#ed5a63" stroke-width="3" opacity=".65">
+      <path d="M73 163h58M73 174h58M73 185h58M73 196h58"/>
+      <path d="M156 163h58M156 174h58M156 185h58M156 196h58"/>
+      <path d="M239 163h58M239 174h58M239 185h58M239 196h58"/>
+    </g>
+    <path d="M326 116h206v114H306z" fill="#850913" stroke="#e2424c" stroke-width="3"/>
+    <path d="M331 124h186v22H325z" fill="#efe8d5"/>
+    <text x="423" y="141" text-anchor="middle" fill="#b20b18" font-family="Arial,sans-serif" font-size="15" font-weight="900" letter-spacing="2">FIRE &amp; RESCUE</text>
+    <path d="M345 154h161v52H332z" fill="#1b2125"/>
+    <g fill="#8e989e"><rect x="350" y="165" width="145" height="8"/><rect x="350" y="181" width="145" height="8"/></g>
+    <path d="M36 222h526l-24 32H44z" fill="#181d20"/>
+    <path d="M413 208h138l16 22-29 19H405z" fill="url(#chrome)"/>
+    <circle cx="113" cy="235" r="49" fill="#06090b" stroke="#273239" stroke-width="8"/>
+    <circle cx="113" cy="235" r="26" fill="url(#chrome)"/>
+    <circle cx="430" cy="235" r="49" fill="#06090b" stroke="#273239" stroke-width="8"/>
+    <circle cx="430" cy="235" r="26" fill="url(#chrome)"/>
+    <path d="M306 25h92l11 14H295z" fill="#222b30"/>
+    <rect x="309" y="14" width="97" height="16" rx="5" fill="url(#blueLamp)" stroke="#80dfff"/>
+    <rect x="18" y="192" width="20" height="20" rx="3" fill="#fff59b"/>
+    <rect x="534" y="192" width="24" height="20" rx="3" fill="#ffb7a3"/>
+    <circle cx="326" cy="22" r="8" fill="#24a9ff" filter="url(#blueGlow)"/>
+    <circle cx="388" cy="22" r="8" fill="#24a9ff" filter="url(#blueGlow)"/>
+  </g>
+
+  <g transform="translate(505 425)" filter="url(#vehicleShadow)">
+    <ellipse cx="300" cy="224" rx="285" ry="35" fill="#000" opacity=".72"/>
+    <path d="M30 74 78 25h327l94 53 60 83-25 55H39L0 180z" fill="url(#ambulanceBody)" stroke="#4d5757" stroke-width="5"/>
+    <path d="M80 28h319l84 49H43z" fill="#e8eee5"/>
+    <path d="M378 40h37l61 38h-88z" fill="url(#glass)" stroke="#43545b" stroke-width="4"/>
+    <path d="M290 38h77v48h-80z" fill="url(#glass)" stroke="#43545b" stroke-width="4"/>
+    <path d="M52 89h455v30H38z" fill="url(#yellow)"/>
+    <path d="M52 119h455v29H38z" fill="url(#greenBat)"/>
+    <g fill="url(#yellow)">
+      <path d="M67 152h52l-22 56H45z"/><path d="M121 152h52l-22 56H99z"/>
+      <path d="M175 152h52l-22 56H153z"/><path d="M229 152h52l-22 56H207z"/>
+    </g>
+    <g fill="url(#greenBat)">
+      <path d="M94 152h52l-22 56H72z"/><path d="M148 152h52l-22 56H126z"/>
+      <path d="M202 152h52l-22 56H180z"/><path d="M256 152h52l-22 56H234z"/>
+    </g>
+    <rect x="72" y="50" width="178" height="32" rx="4" fill="#f7faf4" stroke="#838d89"/>
+    <text x="161" y="73" text-anchor="middle" fill="#0c5a2d" font-family="Arial,sans-serif" font-size="21" font-weight="900" letter-spacing="2">AMBULANCE</text>
+    <path d="M322 108h154v82H310z" fill="#dae1dc" stroke="#7d8784" stroke-width="3"/>
+    <path d="M342 122h117v43" fill="none" stroke="#0e7c38" stroke-width="7"/>
+    <path d="M400 112v62M368 143h64" stroke="#0e7c38" stroke-width="7"/>
+    <path d="M32 188h510l-20 27H41z" fill="#313a3d"/>
+    <circle cx="111" cy="200" r="44" fill="#070a0c" stroke="#313d41" stroke-width="7"/>
+    <circle cx="111" cy="200" r="23" fill="url(#chrome)"/>
+    <circle cx="430" cy="200" r="44" fill="#070a0c" stroke="#313d41" stroke-width="7"/>
+    <circle cx="430" cy="200" r="23" fill="url(#chrome)"/>
+    <rect x="78" y="13" width="326" height="14" rx="6" fill="#27353a"/>
+    <rect x="96" y="6" width="82" height="16" rx="5" fill="url(#blueLamp)" stroke="#8fe4ff"/>
+    <rect x="320" y="6" width="82" height="16" rx="5" fill="url(#blueLamp)" stroke="#8fe4ff"/>
+    <circle cx="120" cy="14" r="8" fill="#28afff" filter="url(#blueGlow)"/>
+    <circle cx="375" cy="14" r="8" fill="#28afff" filter="url(#blueGlow)"/>
+  </g>
+
+  <g transform="translate(1030 482)" filter="url(#vehicleShadow)">
+    <ellipse cx="244" cy="165" rx="235" ry="29" fill="#000" opacity=".7"/>
+    <path d="M23 95 92 43h213l93 48 59 50-16 34H34L0 147z" fill="url(#policeBody)" stroke="#37464f" stroke-width="5"/>
+    <path d="M105 50h183l84 42H58z" fill="#dce6e9"/>
+    <path d="M112 56h76v38H79zM195 56h85l70 38H196z" fill="url(#glass)" stroke="#314851" stroke-width="3"/>
+    <path d="M44 101h362v25H31z" fill="url(#yellow)"/>
+    <path d="M44 126h362v25H31z" fill="url(#blueBat)"/>
+    <g fill="#f4f22e"><path d="M64 100h45l-18 50H46z"/><path d="M154 100h45l-18 50H136z"/><path d="M244 100h45l-18 50H226z"/><path d="M334 100h45l-18 50H316z"/></g>
+    <g fill="#126dd8"><path d="M109 100h45l-18 50H91z"/><path d="M199 100h45l-18 50H181z"/><path d="M289 100h45l-18 50H271z"/></g>
+    <rect x="197" y="103" width="88" height="27" rx="4" fill="#f5f8f9" stroke="#5f6c73"/>
+    <text x="241" y="123" text-anchor="middle" fill="#124d89" font-family="Arial,sans-serif" font-size="16" font-weight="900" letter-spacing="2">POLICE</text>
+    <path d="M31 151h407l-15 23H39z" fill="#1b2429"/>
+    <circle cx="101" cy="161" r="38" fill="#05080a" stroke="#2c373d" stroke-width="7"/>
+    <circle cx="101" cy="161" r="20" fill="url(#chrome)"/>
+    <circle cx="357" cy="161" r="38" fill="#05080a" stroke="#2c373d" stroke-width="7"/>
+    <circle cx="357" cy="161" r="20" fill="url(#chrome)"/>
+    <rect x="164" y="35" width="126" height="14" rx="5" fill="url(#blueLamp)" stroke="#8be2ff"/>
+    <circle cx="190" cy="42" r="7" fill="#29b7ff" filter="url(#blueGlow)"/>
+    <circle cx="264" cy="42" r="7" fill="#29b7ff" filter="url(#blueGlow)"/>
+    <path d="M407 102h35l14 18-38 7z" fill="#f8fbff"/>
+  </g>
+
+  <g opacity=".55" filter="url(#soft)">
+    <path d="M92 405l215 0 85 355H0z" fill="#ff1631" opacity=".14"/>
+    <path d="M602 431h267l104 329H488z" fill="#16a7ff" opacity=".16"/>
+    <path d="M1110 480h272l218 280H965z" fill="#087aff" opacity=".15"/>
+  </g>
+  <rect width="1600" height="760" fill="url(#rain)"/>
+
+  <g transform="translate(46 38)" filter="url(#shadow)">
+    <path d="M0 0h1005l26 26v270l-26 26H0l-26-26V26z" fill="url(#hud)" stroke="#5c7683" stroke-width="2"/>
+    <path d="M0 0h1005l26 26H-26l26-26z" fill="#102331"/>
+    <path d="M-11 17h730" stroke="#36c8ff" stroke-width="3"/>
+    <g transform="translate(16 24)">
+      <rect width="104" height="56" rx="5" fill="#081119" stroke="#5c6d77"/>
+      <path d="M0 0 104 56M104 0 0 56" stroke="#fff" stroke-width="15" opacity=".93"/>
+      <path d="M0 0 104 56M104 0 0 56" stroke="#c51f31" stroke-width="6"/>
+      <path d="M52 0v56M0 28h104" stroke="#fff" stroke-width="17"/>
+      <path d="M52 0v56M0 28h104" stroke="#c51f31" stroke-width="8"/>
+    </g>
+    <text x="142" y="50" fill="#6fd7ff" font-family="Arial,sans-serif" font-size="14" font-weight="800" letter-spacing="4">UNITED KINGDOM OPERATIONAL COMMAND</text>
+    <text x="18" y="147" fill="#ffffff" font-family="Arial Black,Arial,sans-serif" font-size="71" font-weight="900" letter-spacing="1">MISSIONCHIEF</text>
+    <text x="18" y="215" fill="#ffd24e" font-family="Arial Black,Arial,sans-serif" font-size="47" font-weight="900" letter-spacing="3">MAP COMMAND TOOLKIT</text>
+    <path d="M19 235h930" stroke="#25baff" stroke-width="4"/>
+    <text x="20" y="273" fill="#d7e7ed" font-family="Arial,sans-serif" font-size="19" font-weight="700" letter-spacing="2">INCIDENT INTELLIGENCE · FLEET CONTROL · TRANSPORT · MAP · FINANCE</text>
+  </g>
+
+  <g transform="translate(48 684)" filter="url(#shadow)">
+    <path d="M0 0h1504l16 16-16 40H0l-16-40z" fill="#050b10" fill-opacity=".94" stroke="#425864"/>
+    <g font-family="Arial,sans-serif" font-weight="900" font-size="14" letter-spacing="1.5">
+      <circle cx="28" cy="28" r="7" fill="#2fd274"/><text x="47" y="33" fill="#dfffea">NATIVE MISSIONCHIEF CONTROL</text>
+      <circle cx="355" cy="28" r="7" fill="#22b8ff"/><text x="374" y="33" fill="#e1f7ff">DESKTOP · TABLET · iOS</text>
+      <circle cx="681" cy="28" r="7" fill="#ffd348"/><text x="700" y="33" fill="#fff3bd">SEVEN COMPLETE INTERFACES</text>
+      <circle cx="1066" cy="28" r="7" fill="#ff4a55"/><text x="1085" y="33" fill="#ffe4e6">BOUNDED · RECOVERABLE · FAIL-SAFE</text>
+    </g>
+  </g>
+
+  <rect width="1600" height="760" fill="url(#screenGrid)" opacity=".24"/>
+  <rect width="1600" height="760" fill="none" stroke="#70838d" stroke-width="3"/>
+  <rect x="12" y="12" width="1576" height="736" rx="30" fill="none" stroke="#17242b" stroke-width="20"/>
+  <rect x="22" y="22" width="1556" height="716" rx="24" fill="none" stroke="#5b707b" stroke-opacity=".58" stroke-width="2"/>
 </g>
-<g transform="translate(66 448)" filter="url(#shadow)">
-  <g><rect width="260" height="142" rx="12" fill="url(#blue)" stroke="#2db9ff" stroke-width="2"/><circle cx="42" cy="45" r="25" fill="#08233a" stroke="#32baff" stroke-width="2"/><circle cx="42" cy="45" r="12" fill="none" stroke="#45c5ff" stroke-width="3"/><path d="M42 15v12M42 63v12M12 45h12M60 45h12" stroke="#45c5ff" stroke-width="3"/><text x="82" y="42" fill="#4bc7ff" font-family="Impact,Arial Black,sans-serif" font-size="29">MISSION</text><text x="82" y="67" fill="#f3f6f8" font-family="Arial Narrow,Arial,sans-serif" font-size="15">Age · Value · Commitment</text><path d="M20 105h220" stroke="#1f6c9d"/><path d="M20 118h72M104 118h40M160 118h80" stroke="#30aeea" stroke-width="5"/></g>
-  <g transform="translate(278)"><rect width="260" height="142" rx="12" fill="url(#green)" stroke="#50bc55" stroke-width="2"/><path d="M42 18 65 27v18c0 18-11 29-23 38-12-9-23-20-23-38V27z" fill="#173d1e" stroke="#5ed067" stroke-width="2"/><path d="m42 31 5 10 11 2-8 8 2 11-10-5-10 5 2-11-8-8 11-2z" fill="#6bd36b"/><text x="82" y="42" fill="#62d063" font-family="Impact,Arial Black,sans-serif" font-size="29">FLEET</text><text x="82" y="67" fill="#f3f6f8" font-family="Arial Narrow,Arial,sans-serif" font-size="15">Codes · Badges · Gap</text><path d="M20 105h220" stroke="#2d7136"/><path d="M20 118h55M86 118h68M166 118h74" stroke="#45bd55" stroke-width="5"/></g>
-  <g transform="translate(556)"><rect width="260" height="142" rx="12" fill="url(#amber)" stroke="#dca522" stroke-width="2"/><path d="M42 18c-16 0-28 12-28 27 0 22 28 47 28 47s28-25 28-47c0-15-12-27-28-27z" fill="#553b08" stroke="#f1bd38" stroke-width="2"/><circle cx="42" cy="44" r="10" fill="#ffd052"/><text x="82" y="42" fill="#f0bb34" font-family="Impact,Arial Black,sans-serif" font-size="29">MAP</text><text x="82" y="67" fill="#f3f6f8" font-family="Arial Narrow,Arial,sans-serif" font-size="15">Coverage · Places · Profiles</text><path d="M20 105h220" stroke="#81611e"/><path d="M20 118h45M78 118h88M178 118h62" stroke="#d7a726" stroke-width="5"/></g>
-  <g transform="translate(834)"><rect width="260" height="142" rx="12" fill="url(#red)" stroke="#dc3b40" stroke-width="2"/><text x="27" y="70" fill="#ef544f" font-family="Georgia,serif" font-size="67" font-weight="900">£</text><text x="82" y="42" fill="#ef514c" font-family="Impact,Arial Black,sans-serif" font-size="29">FINANCE</text><text x="82" y="67" fill="#f3f6f8" font-family="Arial Narrow,Arial,sans-serif" font-size="15">Income · Spend · Variance</text><path d="M20 105h220" stroke="#7f2428"/><path d="m22 120 32-14 28 8 34-29 35 18 31-25 55 12" fill="none" stroke="#e54242" stroke-width="4"/></g>
-</g>
-<g transform="translate(30 620)">
-  <path d="M0 0h1540l18 18v56l-18 18H0L-18 74V18z" fill="url(#steel)" stroke="#596872" stroke-width="2"/>
-  <circle cx="52" cy="46" r="27" fill="#1a1110" stroke="#b98d30" stroke-width="2"/>
-  <path d="m52 20 7 18 19 1-15 12 5 19-16-10-16 10 5-19-15-12 19-1z" fill="#d3a646"/>
-  <text x="760" y="53" text-anchor="middle" fill="#cfdae0" font-family="Arial Narrow,Arial,sans-serif" font-size="18" font-weight="900" letter-spacing="4">SEE THE MISSION  •  READ THE FLEET  •  COMMAND THE MAP  •  RECONCILE THE OPERATION</text>
-  <g transform="translate(1424 22)"><text x="0" y="12" fill="#8b969d" font-size="9">COMMS</text><circle cx="18" cy="35" r="6" fill="#e33131" filter="url(#glowR)"/><text x="54" y="12" fill="#8b969d" font-size="9">DATA</text><circle cx="68" cy="35" r="6" fill="#e2a72f"/><text x="104" y="12" fill="#8b969d" font-size="9">LINK</text><circle cx="116" cy="35" r="6" fill="#3fdb70"/></g>
-</g>
-<rect y="710" width="800" height="10" fill="#21b8ff"/><rect x="800" y="710" width="800" height="10" fill="#e32f38"/>
 </svg>

--- a/docs/media/readme-release-control.svg
+++ b/docs/media/readme-release-control.svg
@@ -1,110 +1,186 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" role="img" aria-labelledby="title desc">
-<title id="title">MissionChief Toolkit Release and Recovery Control</title>
-<desc id="desc">Verified delivery chain from canonical source through validation, distribution and private recovery.</desc>
-
+<title id="title">MissionChief Toolkit release and recovery operations centre</title>
+<desc id="desc">A realistic UK emergency operations control room showing the governed path from canonical source through validation, release channels, verification and recoverable backup.</desc>
 <defs>
-  <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-    <stop offset="0" stop-color="#02060a"/>
-    <stop offset=".42" stop-color="#07141e"/>
-    <stop offset="1" stop-color="#12080b"/>
-  </linearGradient>
-  <linearGradient id="steel" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#36434d"/>
-    <stop offset=".12" stop-color="#141c22"/>
-    <stop offset=".52" stop-color="#080d11"/>
-    <stop offset=".88" stop-color="#1b252c"/>
-    <stop offset="1" stop-color="#05080a"/>
-  </linearGradient>
-  <linearGradient id="blue" x1="0" y1="0" x2="1" y2="1">
-    <stop offset="0" stop-color="#0a537d"/>
-    <stop offset=".45" stop-color="#0b2b41"/>
-    <stop offset="1" stop-color="#07131c"/>
-  </linearGradient>
-  <linearGradient id="green" x1="0" y1="0" x2="1" y2="1">
-    <stop offset="0" stop-color="#225b2a"/>
-    <stop offset=".45" stop-color="#15351c"/>
-    <stop offset="1" stop-color="#08130b"/>
-  </linearGradient>
-  <linearGradient id="amber" x1="0" y1="0" x2="1" y2="1">
-    <stop offset="0" stop-color="#6c4d0b"/>
-    <stop offset=".45" stop-color="#3a2a0e"/>
-    <stop offset="1" stop-color="#151006"/>
-  </linearGradient>
-  <linearGradient id="red" x1="0" y1="0" x2="1" y2="1">
-    <stop offset="0" stop-color="#6d161e"/>
-    <stop offset=".45" stop-color="#391218"/>
-    <stop offset="1" stop-color="#16080b"/>
-  </linearGradient>
-  <linearGradient id="goldText" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#fff2a8"/>
-    <stop offset=".28" stop-color="#f6c84f"/>
-    <stop offset=".7" stop-color="#b87512"/>
-    <stop offset="1" stop-color="#f4bc2d"/>
-  </linearGradient>
-  <linearGradient id="whiteText" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#ffffff"/>
-    <stop offset=".55" stop-color="#e7e1d4"/>
-    <stop offset="1" stop-color="#a9a49a"/>
-  </linearGradient>
-  <pattern id="grid" width="42" height="42" patternUnits="userSpaceOnUse">
-    <path d="M42 0H0V42" fill="none" stroke="#66d1ff" stroke-opacity=".055"/>
-  </pattern>
-  <pattern id="scan" width="4" height="4" patternUnits="userSpaceOnUse">
-    <rect width="4" height="1.2" fill="#fff" opacity=".025"/>
-  </pattern>
-  <filter id="shadow" x="-30%" y="-30%" width="160%" height="160%">
-    <feDropShadow dx="0" dy="16" stdDeviation="16" flood-color="#000" flood-opacity=".7"/>
-  </filter>
-  <filter id="grit" x="-20%" y="-20%" width="140%" height="140%">
-    <feTurbulence type="fractalNoise" baseFrequency=".7" numOctaves="2" seed="9" result="noise"/>
-    <feColorMatrix in="noise" type="saturate" values="0" result="mono"/>
-    <feComponentTransfer in="mono" result="soft"><feFuncA type="table" tableValues="0 0 .08"/></feComponentTransfer>
-    <feBlend in="SourceGraphic" in2="soft" mode="screen"/>
-  </filter>
+  <linearGradient id="room" x1="0" y1="0" x2="0" y2="1"><stop stop-color="#07121c"/><stop offset=".55" stop-color="#02070b"/><stop offset="1" stop-color="#090307"/></linearGradient>
+  <linearGradient id="wall" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#1b2b34"/><stop offset=".38" stop-color="#0b141a"/><stop offset="1" stop-color="#030609"/></linearGradient>
+  <linearGradient id="desk" x1="0" y1="0" x2="0" y2="1"><stop stop-color="#43515a"/><stop offset=".12" stop-color="#11191e"/><stop offset=".65" stop-color="#05080a"/><stop offset="1" stop-color="#202d34"/></linearGradient>
+  <linearGradient id="screen" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#092233"/><stop offset=".55" stop-color="#03111b"/><stop offset="1" stop-color="#02070a"/></linearGradient>
+  <linearGradient id="steel" x1="0" y1="0" x2="0" y2="1"><stop stop-color="#71838c"/><stop offset=".12" stop-color="#1a252b"/><stop offset=".7" stop-color="#070a0c"/><stop offset="1" stop-color="#28343a"/></linearGradient>
+  <linearGradient id="bluePanel" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#0d5c86"/><stop offset=".5" stop-color="#07304a"/><stop offset="1" stop-color="#03101a"/></linearGradient>
+  <linearGradient id="greenPanel" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#185f32"/><stop offset=".5" stop-color="#0b321c"/><stop offset="1" stop-color="#031109"/></linearGradient>
+  <linearGradient id="amberPanel" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#75520d"/><stop offset=".5" stop-color="#3d2a08"/><stop offset="1" stop-color="#160e02"/></linearGradient>
+  <linearGradient id="redPanel" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#74212a"/><stop offset=".5" stop-color="#3b1017"/><stop offset="1" stop-color="#140408"/></linearGradient>
+  <pattern id="grid" width="34" height="34" patternUnits="userSpaceOnUse"><path d="M34 0H0V34" fill="none" stroke="#5ed2ff" stroke-opacity=".055"/></pattern>
+  <pattern id="scan" width="5" height="5" patternUnits="userSpaceOnUse"><rect width="5" height="1" fill="#fff" opacity=".018"/></pattern>
+  <filter id="shadow" x="-40%" y="-40%" width="180%" height="200%"><feDropShadow dx="0" dy="18" stdDeviation="15" flood-color="#000" flood-opacity=".88"/></filter>
+  <filter id="glow" x="-250%" y="-250%" width="600%" height="600%"><feGaussianBlur stdDeviation="9" result="g"/><feMerge><feMergeNode in="g"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+  <filter id="soft" x="-30%" y="-30%" width="160%" height="160%"><feGaussianBlur stdDeviation="5"/></filter>
+  <clipPath id="clip"><rect x="18" y="18" width="1564" height="864" rx="28"/></clipPath>
 </defs>
+<g clip-path="url(#clip)">
+  <rect width="1600" height="900" fill="url(#room)"/>
+  <rect width="1600" height="900" fill="url(#grid)"/>
+  <rect width="1600" height="900" fill="url(#scan)"/>
 
-<rect width="1600" height="900" rx="28" fill="url(#bg)"/><rect width="1600" height="900" rx="28" fill="url(#grid)"/><rect width="1600" height="900" rx="28" fill="url(#scan)"/>
-<path d="M20 10H1580l10 10v860l-10 10H20L10 880V20z" fill="none" stroke="url(#steel)" stroke-width="18"/>
-<rect x="24" y="24" width="1552" height="852" rx="18" fill="none" stroke="#62727c" stroke-opacity=".45" stroke-width="2"/>
-<g filter="url(#shadow)"><path d="M30 28h1540v62H30z" fill="url(#steel)" stroke="#50616b" stroke-width="2"/>
-<g transform="translate(42 38)"><rect width="64" height="42" rx="5" fill="#0a1116" stroke="#4f6470"/><path d="M0 0 64 42M64 0 0 42" stroke="#fff" stroke-width="11"/><path d="M0 0 64 42M64 0 0 42" stroke="#c92632" stroke-width="4"/><path d="M32 0v42M0 21h64" stroke="#fff" stroke-width="12"/><path d="M32 0v42M0 21h64" stroke="#c92632" stroke-width="6"/></g>
-<text x="120" y="64" fill="#5ed2ff" font-family="Courier New,monospace" font-size="12" font-weight="900" letter-spacing="1.7">UK EMERGENCY COMMAND NETWORK</text>
-<g transform="translate(390 38)"><rect width="190" height="42" rx="6" fill="#07131f" stroke="#168ddd"/><circle cx="23" cy="21" r="10" fill="#179ee8"/><text x="46" y="27" fill="#e9f8ff" font-size="15" font-weight="900" letter-spacing="2">VERIFIED v7.1.4</text></g>
-<g transform="translate(590 38)"><rect width="220" height="42" rx="6" fill="#270a0c" stroke="#d3342f"/><circle cx="23" cy="21" r="10" fill="#e9443b"/><text x="46" y="27" fill="#ffd9d2" font-size="12" font-weight="900" letter-spacing="1.25">GITHUB-AUTHORITATIVE</text></g>
-<g transform="translate(825 38)"><rect width="210" height="42" rx="6" fill="#0c280d" stroke="#4ac654"/><circle cx="23" cy="21" r="10" fill="#4fc857"/><text x="46" y="27" fill="#dcffdf" font-size="12" font-weight="900" letter-spacing="1.25">GREASY FORK VERIFIED</text></g>
-<g transform="translate(1045 38)"><rect width="220" height="42" rx="6" fill="#2b1d05" stroke="#d99a16"/><circle cx="23" cy="21" r="10" fill="#e0aa2e"/><text x="46" y="27" fill="#ffe6a5" font-size="12" font-weight="900" letter-spacing="1.25">PRIVATE BACKUP READY</text></g>
-<text x="1514" y="59" text-anchor="end" fill="#88949b" font-size="12" letter-spacing="2">CHANNEL STATUS</text><text x="1514" y="78" text-anchor="end" fill="#48dc71" font-size="14" font-weight="900" letter-spacing="2">STABLE</text><circle cx="1538" cy="70" r="6" fill="#49e080"/>
+  <!-- Control room walls -->
+  <path d="M0 0h1600v572H0z" fill="url(#wall)"/>
+  <path d="M0 572h1600v328H0z" fill="#030506"/>
+  <path d="M0 575h1600" stroke="#647680" stroke-opacity=".35" stroke-width="4"/>
+  <g opacity=".45">
+    <path d="M0 0 260 0 520 572H330z" fill="#163246"/>
+    <path d="M1600 0h-260l-260 572h190z" fill="#2a1118"/>
+  </g>
+
+  <!-- Header identity -->
+  <g transform="translate(38 30)" filter="url(#shadow)">
+    <path d="M0 0h1524l18 18v98l-18 18H0l-18-18V18z" fill="#050b10" fill-opacity=".94" stroke="#5e727c" stroke-width="2"/>
+    <g transform="translate(18 18)">
+      <rect width="82" height="50" rx="4" fill="#081017" stroke="#667882"/>
+      <path d="M0 0 82 50M82 0 0 50" stroke="#fff" stroke-width="13"/><path d="M0 0 82 50M82 0 0 50" stroke="#c71f31" stroke-width="5"/>
+      <path d="M41 0v50M0 25h82" stroke="#fff" stroke-width="15"/><path d="M41 0v50M0 25h82" stroke="#c71f31" stroke-width="7"/>
+    </g>
+    <text x="122" y="47" fill="#68d7ff" font-family="Arial,sans-serif" font-size="15" font-weight="900" letter-spacing="4">MISSIONCHIEF TOOLKIT // GOVERNED DELIVERY OPERATIONS</text>
+    <text x="122" y="94" fill="#fff" font-family="Arial Black,Arial,sans-serif" font-size="43" font-weight="900" letter-spacing="1">RELEASE &amp; RECOVERY CONTROL</text>
+    <g transform="translate(1190 22)" font-family="Arial,sans-serif">
+      <text x="0" y="15" fill="#7f919b" font-size="11" font-weight="800" letter-spacing="2">CHAIN HEALTH</text>
+      <circle cx="20" cy="54" r="8" fill="#34d878" filter="url(#glow)"/>
+      <text x="42" y="61" fill="#dffff0" font-size="19" font-weight="900" letter-spacing="2">VERIFIED</text>
+      <text x="0" y="96" fill="#8496a0" font-size="11" letter-spacing="1.4">SOURCE · RELEASE · RECOVERY</text>
+    </g>
+  </g>
+
+  <!-- Wall screens -->
+  <g transform="translate(62 188)" filter="url(#shadow)">
+    <!-- left screen -->
+    <g>
+      <rect width="430" height="250" rx="8" fill="#010407" stroke="#5f717a" stroke-width="5"/>
+      <rect x="12" y="12" width="406" height="226" rx="4" fill="url(#screen)" stroke="#14394d"/>
+      <text x="28" y="38" fill="#5bd3ff" font-family="Arial,sans-serif" font-size="12" font-weight="900" letter-spacing="2.4">CANONICAL SOURCE // MAIN</text>
+      <path d="M28 52h372" stroke="#1d749c"/>
+      <g font-family="Courier New,monospace" font-size="12">
+        <text x="28" y="82" fill="#58d5ff">src/</text>
+        <text x="68" y="82" fill="#e7f5fb">MissionChief_Map_Command_Toolkit.user.js</text>
+        <text x="28" y="112" fill="#8a9aa2">syntax</text><text x="130" y="112" fill="#49df78">PASS</text>
+        <text x="28" y="139" fill="#8a9aa2">metadata</text><text x="130" y="139" fill="#49df78">PASS</text>
+        <text x="28" y="166" fill="#8a9aa2">runtime contracts</text><text x="170" y="166" fill="#49df78">PASS</text>
+        <text x="28" y="193" fill="#8a9aa2">hosted media</text><text x="160" y="193" fill="#49df78">PASS</text>
+      </g>
+      <path d="M288 87h95M288 110h70M288 133h83M288 156h55M288 179h102" stroke="#24b9ee" stroke-width="4" stroke-linecap="round" opacity=".72"/>
+      <circle cx="388" cy="203" r="13" fill="#103c20" stroke="#43d56f"/><path d="m381 203 5 5 10-13" fill="none" stroke="#59e786" stroke-width="4"/>
+    </g>
+
+    <!-- centre screen -->
+    <g transform="translate(465)">
+      <rect width="560" height="250" rx="8" fill="#010407" stroke="#5f717a" stroke-width="5"/>
+      <rect x="12" y="12" width="536" height="226" rx="4" fill="url(#screen)" stroke="#14394d"/>
+      <text x="28" y="38" fill="#5bd3ff" font-family="Arial,sans-serif" font-size="12" font-weight="900" letter-spacing="2.4">UK RELEASE TOPOLOGY // VERIFIED DELIVERY CHAIN</text>
+      <path d="M28 52h504" stroke="#1d749c"/>
+      <!-- UK map -->
+      <g transform="translate(356 58) scale(.34)">
+        <path d="M196 0l-30 24-14 46-37 26-8 46-35 35 5 41-22 38 12 35-18 43 12 54 39 13 22 43 45-5 31 34 45-6 26-38 43-9 18-46 42-28-8-52 24-43-8-45-34-26-7-38-37-20 10-39-27-32-37 11-27-37z" fill="#0c2d3b" stroke="#51caff" stroke-width="7"/>
+        <g fill="#ff4652" filter="url(#glow)"><circle cx="165" cy="110" r="14"/><circle cx="196" cy="252" r="16"/><circle cx="224" cy="375" r="15"/></g>
+      </g>
+      <g font-family="Arial,sans-serif" font-weight="900">
+        <g transform="translate(28 78)"><rect width="112" height="58" rx="7" fill="url(#bluePanel)" stroke="#2ab9ff"/><text x="56" y="25" text-anchor="middle" fill="#fff" font-size="12">SOURCE</text><text x="56" y="43" text-anchor="middle" fill="#87e2ff" font-size="10">CANONICAL</text></g>
+        <path d="M146 107h34m-11-10 11 10-11 10" fill="none" stroke="#53cbff" stroke-width="4"/>
+        <g transform="translate(186 78)"><rect width="112" height="58" rx="7" fill="url(#greenPanel)" stroke="#45d169"/><text x="56" y="25" text-anchor="middle" fill="#fff" font-size="12">VALIDATE</text><text x="56" y="43" text-anchor="middle" fill="#8bf0a7" font-size="10">CONTRACTS</text></g>
+        <path d="M304 107h34m-11-10 11 10-11 10" fill="none" stroke="#53cbff" stroke-width="4"/>
+        <g transform="translate(28 155)"><rect width="112" height="58" rx="7" fill="url(#amberPanel)" stroke="#edb53e"/><text x="56" y="25" text-anchor="middle" fill="#fff" font-size="12">RELEASE</text><text x="56" y="43" text-anchor="middle" fill="#ffe09b" font-size="10">IMMUTABLE</text></g>
+        <path d="M146 184h34m-11-10 11 10-11 10" fill="none" stroke="#53cbff" stroke-width="4"/>
+        <g transform="translate(186 155)"><rect width="112" height="58" rx="7" fill="url(#redPanel)" stroke="#ef5962"/><text x="56" y="25" text-anchor="middle" fill="#fff" font-size="12">VERIFY</text><text x="56" y="43" text-anchor="middle" fill="#ffadb4" font-size="10">PARITY</text></g>
+      </g>
+    </g>
+
+    <!-- right screen -->
+    <g transform="translate(1060)">
+      <rect width="430" height="250" rx="8" fill="#010407" stroke="#5f717a" stroke-width="5"/>
+      <rect x="12" y="12" width="406" height="226" rx="4" fill="url(#screen)" stroke="#14394d"/>
+      <text x="28" y="38" fill="#5bd3ff" font-family="Arial,sans-serif" font-size="12" font-weight="900" letter-spacing="2.4">CHANNEL PARITY // PUBLIC DELIVERY</text>
+      <path d="M28 52h372" stroke="#1d749c"/>
+      <g font-family="Arial,sans-serif" font-size="14" font-weight="900">
+        <circle cx="44" cy="88" r="7" fill="#39d876"/><text x="64" y="94" fill="#e7fff0">GITHUB RELEASE</text><text x="367" y="94" text-anchor="end" fill="#6fe595">VERIFIED</text>
+        <circle cx="44" cy="126" r="7" fill="#39d876"/><text x="64" y="132" fill="#e7fff0">GREASY FORK</text><text x="367" y="132" text-anchor="end" fill="#6fe595">VERIFIED</text>
+        <circle cx="44" cy="164" r="7" fill="#39d876"/><text x="64" y="170" fill="#e7fff0">PRIVATE RECOVERY</text><text x="367" y="170" text-anchor="end" fill="#6fe595">READY</text>
+        <circle cx="44" cy="202" r="7" fill="#39d876"/><text x="64" y="208" fill="#e7fff0">DISCORD SIGNAL</text><text x="367" y="208" text-anchor="end" fill="#6fe595">POSTED</text>
+      </g>
+    </g>
+  </g>
+
+  <!-- Consoles -->
+  <g transform="translate(78 493)" filter="url(#shadow)">
+    <path d="M0 0h1444l28 25-64 309H64L-28 25z" fill="url(#desk)" stroke="#687b85" stroke-width="4"/>
+    <path d="M36 36h1372l-44 224H86z" fill="#030609" stroke="#25343b" stroke-width="3"/>
+    <path d="M86 260h1278l20 44H64z" fill="#10181d" stroke="#53656e"/>
+
+    <!-- pipeline modules -->
+    <g transform="translate(76 60)" font-family="Arial,sans-serif" filter="url(#shadow)">
+      <g>
+        <rect width="230" height="156" rx="10" fill="url(#bluePanel)" stroke="#2ab8ff" stroke-width="2"/>
+        <circle cx="40" cy="40" r="22" fill="#07273c" stroke="#4ecaff"/><path d="M40 19v42M19 40h42" stroke="#5cd4ff" stroke-width="4"/>
+        <text x="78" y="36" fill="#fff" font-size="19" font-weight="900">CANONICAL</text><text x="78" y="59" fill="#7bdcff" font-size="14" font-weight="900">SOURCE</text>
+        <text x="24" y="101" fill="#ccefff" font-size="12">Exact userscript on main</text><text x="24" y="126" fill="#ccefff" font-size="12">No external source authority</text>
+      </g>
+      <path d="M240 78h38m-12-12 12 12-12 12" fill="none" stroke="#53caff" stroke-width="5"/>
+      <g transform="translate(288)">
+        <rect width="230" height="156" rx="10" fill="url(#greenPanel)" stroke="#49d36e" stroke-width="2"/>
+        <path d="M40 17 62 25v19c0 18-10 29-22 38-12-9-22-20-22-38V25z" fill="#123d20" stroke="#65e087" stroke-width="3"/><path d="m31 44 7 7 14-18" fill="none" stroke="#7af19b" stroke-width="5"/>
+        <text x="78" y="36" fill="#fff" font-size="19" font-weight="900">VALIDATION</text><text x="78" y="59" fill="#8bf0a7" font-size="14" font-weight="900">EXACT HEAD</text>
+        <text x="24" y="101" fill="#d7ffe2" font-size="12">Syntax · metadata · runtime</text><text x="24" y="126" fill="#d7ffe2" font-size="12">Docs · assets · release rules</text>
+      </g>
+      <path d="M528 78h38m-12-12 12 12-12 12" fill="none" stroke="#53caff" stroke-width="5"/>
+      <g transform="translate(576)">
+        <rect width="230" height="156" rx="10" fill="url(#amberPanel)" stroke="#e8af37" stroke-width="2"/>
+        <circle cx="40" cy="40" r="22" fill="#4b3407" stroke="#f1bf4b"/><path d="M40 21v38M21 40h38" stroke="#ffd46a" stroke-width="4"/>
+        <text x="78" y="36" fill="#fff" font-size="19" font-weight="900">RELEASE</text><text x="78" y="59" fill="#ffe19d" font-size="14" font-weight="900">IMMUTABLE</text>
+        <text x="24" y="101" fill="#fff0c8" font-size="12">Tag · asset · SHA-256</text><text x="24" y="126" fill="#fff0c8" font-size="12">Stable distribution publication</text>
+      </g>
+      <path d="M816 78h38m-12-12 12 12-12 12" fill="none" stroke="#53caff" stroke-width="5"/>
+      <g transform="translate(864)">
+        <rect width="230" height="156" rx="10" fill="url(#redPanel)" stroke="#ef5962" stroke-width="2"/>
+        <circle cx="40" cy="40" r="22" fill="#4a1016" stroke="#ff6972"/><path d="M40 18a22 22 0 1 1-16 7M19 20h20v20" fill="none" stroke="#ff7b83" stroke-width="4"/>
+        <text x="78" y="36" fill="#fff" font-size="19" font-weight="900">RECOVERY</text><text x="78" y="59" fill="#ffadb4" font-size="14" font-weight="900">CHECKSUM-BACKED</text>
+        <text x="24" y="101" fill="#ffe2e4" font-size="12">Private migration backup</text><text x="24" y="126" fill="#ffe2e4" font-size="12">Deterministic rollback identity</text>
+      </g>
+      <path d="M1104 78h38m-12-12 12 12-12 12" fill="none" stroke="#53caff" stroke-width="5"/>
+      <g transform="translate(1152)">
+        <rect width="230" height="156" rx="10" fill="#122536" stroke="#6f8c9c" stroke-width="2"/>
+        <circle cx="40" cy="40" r="22" fill="#092032" stroke="#59cfff"/><circle cx="40" cy="40" r="8" fill="#3bdc7a" filter="url(#glow)"/>
+        <text x="78" y="36" fill="#fff" font-size="19" font-weight="900">CONFIRM</text><text x="78" y="59" fill="#8de4ff" font-size="14" font-weight="900">CHANNEL PARITY</text>
+        <text x="24" y="101" fill="#dff7ff" font-size="12">GitHub · Greasy Fork · Discord</text><text x="24" y="126" fill="#dff7ff" font-size="12">Release complete only at parity</text>
+      </g>
+    </g>
+
+    <!-- operator lights -->
+    <g transform="translate(92 278)">
+      <g fill="#31d776" filter="url(#glow)"><circle cx="0" cy="0" r="5"/><circle cx="30" cy="0" r="5"/><circle cx="60" cy="0" r="5"/><circle cx="90" cy="0" r="5"/></g>
+      <g fill="#27b7ff"><circle cx="120" cy="0" r="5"/><circle cx="150" cy="0" r="5"/></g>
+      <g fill="#ffbf3d"><circle cx="180" cy="0" r="5"/></g>
+    </g>
+    <text x="1360" y="286" text-anchor="end" fill="#8fa0a8" font-family="Courier New,monospace" font-size="12" letter-spacing="2">GITHUB AUTHORITATIVE</text>
+  </g>
+
+  <!-- floor reflections -->
+  <g opacity=".26" filter="url(#soft)">
+    <path d="M155 798h210l-70 102H92z" fill="#169bd4"/>
+    <path d="M560 798h210l35 102H516z" fill="#28a955"/>
+    <path d="M958 798h210l110 102H916z" fill="#d39422"/>
+    <path d="M1280 798h185l95 102h-331z" fill="#b32836"/>
+  </g>
+
+  <!-- footer rail -->
+  <g transform="translate(44 836)" filter="url(#shadow)">
+    <path d="M0 0h1512l16 16-16 40H0l-16-40z" fill="#04090d" stroke="#536771"/>
+    <g font-family="Arial,sans-serif" font-size="13" font-weight="900" letter-spacing="1.4">
+      <circle cx="28" cy="28" r="6" fill="#28d272"/><text x="44" y="33" fill="#fff">EXACT-HEAD VALIDATION</text>
+      <circle cx="342" cy="28" r="6" fill="#27b7ff"/><text x="358" y="33" fill="#fff">IMMUTABLE RELEASE ASSETS</text>
+      <circle cx="723" cy="28" r="6" fill="#ffbd3b"/><text x="739" y="33" fill="#fff">PUBLIC CHANNEL PARITY</text>
+      <circle cx="1059" cy="28" r="6" fill="#ff4d59"/><text x="1075" y="33" fill="#fff">PRIVATE RECOVERY IDENTITY</text>
+    </g>
+  </g>
+
+  <rect width="1600" height="900" fill="none" stroke="#748a95" stroke-width="3"/>
+  <rect x="12" y="12" width="1576" height="876" rx="30" fill="none" stroke="url(#steel)" stroke-width="20"/>
+  <rect x="24" y="24" width="1552" height="852" rx="22" fill="none" stroke="#6d818b" stroke-opacity=".55" stroke-width="2"/>
 </g>
-<g filter="url(#grit)"><text x="64" y="224" fill="url(#whiteText)" font-family="Impact,Arial Black,sans-serif" font-size="82" letter-spacing="1.2">RELEASE &amp; RECOVERY CONTROL</text></g>
-<text x="80" y="286" fill="url(#goldText)" font-family="Impact,Arial Black,sans-serif" font-size="43" letter-spacing="9">VERIFIED DELIVERY CHAIN</text>
-<path d="M70 306h990" stroke="#20b9ff" stroke-width="4"/>
-<g transform="translate(850 -58) scale(.5)" opacity=".58"><path d="M1098 136 l-29 13 -10 32 -27 12 -10 33 -34 13 -2 30 -23 24 7 29 -25 28 10 29 -18 24 4 36 24 9 12 33 31 -3 22 26 38 -4 19 -25 32 -5 14 -31 31 -18 -6 -36 20 -29 -4 -36 -26 -18 -4 -26 -27 -17 8 -25 -19 -26 -27 8 -18 -22 z" fill="#06121a" stroke="#27b7ff" stroke-width="5"/><g fill="#ff3e35"><circle cx="1046" cy="238" r="8"/><circle cx="1096" cy="350" r="9"/><circle cx="1134" cy="426" r="8"/></g><g fill="#ffba2e"><circle cx="1062" cy="315" r="8"/><circle cx="1122" cy="382" r="7"/></g><g fill="#29b7ff"><circle cx="1018" cy="270" r="7"/><circle cx="1148" cy="400" r="7"/></g></g>
-<g transform="translate(42 340)" filter="url(#shadow)" font-family="Arial Narrow,Arial,sans-serif">
-  <g><rect width="250" height="300" rx="12" fill="url(#blue)" stroke="#2db9ff" stroke-width="2"/><circle cx="42" cy="44" r="24" fill="#08233a" stroke="#32baff"/><circle cx="42" cy="44" r="10" fill="none" stroke="#45c5ff" stroke-width="3"/><path d="M42 17v15M42 56v15M15 44h15M54 44h15" stroke="#45c5ff" stroke-width="3"/><text x="82" y="43" fill="#4bc7ff" font-family="Impact,Arial Black,sans-serif" font-size="24">CANONICAL SOURCE</text><text x="22" y="92" fill="#fff" font-size="13">src/MissionChief_Map_</text><text x="22" y="115" fill="#fff" font-size="13">Command_Toolkit.user.js</text><rect x="22" y="146" width="206" height="112" rx="8" fill="#071018" stroke="#1d6f9c"/><path d="M37 169h115M37 188h142M37 207h89M37 226h126" stroke="#1fb4f0" stroke-width="5"/><text x="169" y="236" fill="#66d5ff" font-family="Impact,sans-serif" font-size="37">.JS</text></g>
-  <path d="M262 150h38m-12-14 14 14-14 14" fill="none" stroke="#20baff" stroke-width="6"/>
-  <g transform="translate(310)"><rect width="250" height="300" rx="12" fill="url(#green)" stroke="#50bc55" stroke-width="2"/><path d="M42 18 66 27v19c0 19-11 30-24 39-13-9-24-20-24-39V27z" fill="#173d1e" stroke="#5ed067" stroke-width="2"/><path d="m32 45 8 8 15-19" fill="none" stroke="#77e07f" stroke-width="5"/><text x="82" y="43" fill="#62d063" font-family="Impact,Arial Black,sans-serif" font-size="27">VALIDATION</text><g fill="#fff" font-size="16"><circle cx="30" cy="100" r="5" fill="#4bd05a"/><text x="48" y="106">syntax</text><circle cx="30" cy="135" r="5" fill="#4bd05a"/><text x="48" y="141">docs</text><circle cx="30" cy="170" r="5" fill="#4bd05a"/><text x="48" y="176">assets</text><circle cx="30" cy="205" r="5" fill="#4bd05a"/><text x="48" y="211">status</text></g><circle cx="182" cy="236" r="38" fill="#0b1f0e" stroke="#51d060" stroke-width="3"/><path d="m160 237 15 15 30-40" fill="none" stroke="#56d866" stroke-width="7"/></g>
-  <path d="M572 150h38m-12-14 14 14-14 14" fill="none" stroke="#20baff" stroke-width="6"/>
-  <g transform="translate(620)"><rect width="250" height="300" rx="12" fill="url(#amber)" stroke="#dca522" stroke-width="2"/><circle cx="42" cy="44" r="24" fill="#4b3506" stroke="#e4af2c"/><path d="M42 24v40M25 41h34" stroke="#ffd458" stroke-width="4"/><text x="82" y="34" fill="#f0bb34" font-family="Impact,Arial Black,sans-serif" font-size="22">RELEASE</text><text x="82" y="58" fill="#f0bb34" font-family="Impact,Arial Black,sans-serif" font-size="22">CHANNELS</text><g fill="#fff" font-size="15"><text x="28" y="112">● GitHub Release</text><text x="28" y="154">● Greasy Fork</text><text x="28" y="196">● Discord</text></g><path d="M35 245h180" stroke="#8c6818"/><path d="m44 264 22-15 22 8 22-20 22 12 22-9 22 17 22-13" fill="none" stroke="#dca522" stroke-width="3"/></g>
-  <path d="M882 150h38m-12-14 14 14-14 14" fill="none" stroke="#20baff" stroke-width="6"/>
-  <g transform="translate(930)"><rect width="250" height="300" rx="12" fill="url(#red)" stroke="#dc3b40" stroke-width="2"/><circle cx="42" cy="44" r="24" fill="#481112" stroke="#ef4a40"/><path d="M42 20a24 24 0 1 1-17 7M20 22h20v20" fill="none" stroke="#ff6255" stroke-width="4"/><text x="82" y="43" fill="#ef514c" font-family="Impact,Arial Black,sans-serif" font-size="27">RECOVERY</text><g fill="#fff" font-size="15"><text x="28" y="105">● SHA-256</text><text x="28" y="140">● backup commit</text><text x="28" y="175">● release-state</text><text x="28" y="210">● distribution</text></g><ellipse cx="182" cy="244" rx="40" ry="15" fill="#54151a" stroke="#e34747"/><path d="M142 244v30c0 8 80 8 80 0v-30M142 259c0 8 80 8 80 0" fill="none" stroke="#e34747" stroke-width="3"/></g>
-  <path d="M1192 150h38m-12-14 14 14-14 14" fill="none" stroke="#20baff" stroke-width="6"/>
-  <g transform="translate(1240)"><rect width="250" height="300" rx="12" fill="url(#blue)" stroke="#2db9ff" stroke-width="2"/><rect x="20" y="22" width="47" height="30" rx="3" fill="none" stroke="#3ec5ff" stroke-width="3"/><path d="M16 59h56" stroke="#3ec5ff" stroke-width="3"/><text x="82" y="34" fill="#4bc7ff" font-family="Impact,Arial Black,sans-serif" font-size="22">DEVICE</text><text x="82" y="58" fill="#4bc7ff" font-family="Impact,Arial Black,sans-serif" font-size="22">COVERAGE</text><g fill="#fff" font-size="16"><text x="30" y="112">● desktop</text><text x="30" y="150">● tablet</text><text x="30" y="188">● iOS</text></g><rect x="28" y="218" width="100" height="58" rx="5" fill="none" stroke="#38bdf5" stroke-width="3"/><rect x="146" y="230" width="42" height="46" rx="4" fill="none" stroke="#38bdf5" stroke-width="3"/><rect x="204" y="244" width="22" height="32" rx="4" fill="none" stroke="#38bdf5" stroke-width="3"/></g>
-</g>
-<g transform="translate(40 660)" filter="url(#shadow)" font-family="Arial Narrow,Arial,sans-serif">
-<rect width="1510" height="110" rx="12" fill="#071017" stroke="#384851" stroke-width="2"/>
-<text x="22" y="25" fill="#5ccfff" font-family="Courier New,monospace" font-size="11" font-weight="900" letter-spacing="2">DELIVERY PIPELINE</text>
-<g transform="translate(20 42)" font-size="20" font-weight="900">
-<rect width="185" height="50" rx="7" fill="#071c2d" stroke="#178dde"/><text x="92" y="33" text-anchor="middle" fill="#42bfff">main</text>
-<text x="210" y="34" fill="#24baff" font-size="34">→</text>
-<rect x="250" width="205" height="50" rx="7" fill="#102514" stroke="#4ac654"/><text x="352" y="33" text-anchor="middle" fill="#57d15f">validation</text>
-<text x="470" y="34" fill="#24baff" font-size="34">→</text>
-<rect x="510" width="220" height="50" rx="7" fill="#2a1e06" stroke="#d99a16"/><text x="620" y="33" text-anchor="middle" fill="#eab83c">release-state</text>
-<text x="745" y="34" fill="#24baff" font-size="34">→</text>
-<rect x="785" width="205" height="50" rx="7" fill="#071c2d" stroke="#178dde"/><text x="887" y="33" text-anchor="middle" fill="#42bfff">distribution</text>
-<text x="1005" y="34" fill="#24baff" font-size="34">→</text>
-<rect x="1045" width="175" height="50" rx="7" fill="#2c0d10" stroke="#d93a3f"/><text x="1132" y="33" text-anchor="middle" fill="#ed5555">backup</text>
-<text x="1235" y="34" fill="#24baff" font-size="34">→</text>
-<rect x="1275" width="195" height="50" rx="7" fill="#071c2d" stroke="#178dde"/><text x="1372" y="33" text-anchor="middle" fill="#42bfff">announce</text>
-</g></g>
-<g transform="translate(24 792)"><path d="M0 0h1552l14 14v72l-14 14H0L-14 86V14z" fill="url(#steel)" stroke="#586872" stroke-width="2"/><circle cx="54" cy="50" r="31" fill="#18110e" stroke="#c6a14d" stroke-width="2"/><path d="m54 19 8 22 23 1-18 15 6 23-19-12-19 12 6-23-18-15 23-1z" fill="#d1a841"/><text x="780" y="60" text-anchor="middle" fill="#d2dde2" font-family="Arial Narrow,Arial,sans-serif" font-size="19" font-weight="900" letter-spacing="5">GOVERNED SOURCE  •  VERIFIED RELEASE  •  RECOVERABLE DELIVERY</text></g>
 </svg>


### PR DESCRIPTION
## Objective

Replace the Toolkit repository’s stylised control-panel artwork with a more realistic, cinematic and distinctly UK multi-agency emergency-response visual system, while correcting the stale release identity exposed by the repository’s documentation-consistency gate.

## What changed

### Realistic UK response hero

- Rebuilt the repository hero as a rain-soaked night-time emergency scene.
- Features a UK fire appliance, ambulance, Battenburg police response vehicle and HM Coastguard helicopter.
- Retains the Toolkit’s command identity through a restrained incident-intelligence overlay rather than a wholly fictional console.
- Includes the United Kingdom identity, supported device coverage and the Toolkit’s retained operational domains.

### United Kingdom operational picture

- Replaced the previous systems board with a national multi-agency command view.
- Centres a live UK incident map surrounded by Fire & Rescue, Ambulance, Police and HM Coastguard response channels.
- Connects each emergency-service scene to the actual Toolkit capabilities it represents: mission intelligence, fleet identity, native transport, geographic control and financial reconciliation.

### Release and recovery operations centre

- Rebuilt the release-control artwork as a realistic emergency operations room.
- Visualises the governed path from canonical source through exact-head validation, immutable release, public-channel verification, private recovery and final parity confirmation.
- Keeps GitHub authority and recoverability visible without embedding a transient release number.

### README release reconciliation

- Updated the repository landing copy from the stale `v7.1.4` / `v7.1.5` presentation to the verified `v7.1.6` release state.
- Replaced the old release-focus section with the current Native Discharge patient confirmation behaviour.
- Synchronised the verified SHA-256, GitHub release, private recovery identity and hosted-media status with the machine-backed release ledger.
- Updated image descriptions and the product strapline to reflect the new realistic UK visual direction.

## Artwork contract

- All three artworks are original, self-contained SVGs.
- No external images, hotlinks, fonts or third-party media licences are required.
- No hard-coded Toolkit version appears in the artwork, preventing future release drift.
- Accessible SVG titles and descriptions are retained.

## Scope

Presentation and documentation only:

- `README.md`
- `docs/media/readme-hero.svg`
- `docs/media/readme-command-board.svg`
- `docs/media/readme-release-control.svg`

No userscript source, runtime behaviour, settings, observers, timers, distribution files, release ledger or deployment state changed.

## Validation

- Started from exact `main` head `0e528b30c3015e802f9411ac8c09bbcdf6f56c28`.
- XML parsing passed for all three SVGs.
- Each SVG rendered successfully through CairoSVG.
- Verified that the artwork is self-contained and contains no embedded release-version string.
- The first CI pass correctly detected the pre-existing README/release-ledger mismatch; this branch now reconciles that documentation against verified `v7.1.6` state.
- Exact diff remains limited to README presentation and its three hosted artwork surfaces.