### PR TITLE
Release Pipeline v5: Direct atomic validated-tree hotfix lane

### DIFF
--- a/.github/scripts/test_release_pipeline_v4.py
+++ b/.github/scripts/test_release_pipeline_v4.py
@@ -7,6 +7,9 @@ a=(r/".github/workflows/auto-release-after-validation.yml").read_text()
 p=(r/".github/workflows/release-toolkit.yml").read_text()
 assert "Prepare immutable release-ready bundle" in v and "release-bundle/" in v
 assert "release-readiness-check.yml" not in a and "validation_run_id:" in a and "validated_sha:" in a
+assert "Consume exact successful PR validation tree" in a
+assert "Upload promoted merged-main candidate" in a
+assert "Post-merge userscript validation used: no" in a
 for token in ("Resolve exact immutable release candidate","Verify Greasy Fork and back up concurrently","BACKUP_PID=$!","GF_PID=$!","sleep 2","sleep 5","sleep 15","Dispatch GitHub Pages asynchronously","status/release-speed-history.json","status/RELEASE_SPEED.md"):
     assert token in p, token
 assert "gh run watch" not in p
@@ -19,4 +22,4 @@ assert p.count("      - name: Record successful release, manifest, announcement 
 assert 'echo "- ✅ Greasy Fork verification and private backup ran concurrently"' in p
 assert 'GitHub Pages deployment dispatched asynchronously: ${PAGES_DISPATCHED}' in p
 
-print("Release Pipeline v4 contract passed.")
+print("Release Pipeline v4 publication contract passed with v5 validated-tree promotion.")

--- a/.github/scripts/test_validation_candidate_pipeline.py
+++ b/.github/scripts/test_validation_candidate_pipeline.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Static and executable contracts for artifact-only canonical validation."""
+"""Static and executable contracts for artifact-only validated-tree release authority."""
 from __future__ import annotations
 
 import json
@@ -44,6 +44,10 @@ def main() -> int:
         "permissions:\n  contents: read",
         "persist-credentials: false",
         "Write immutable validation candidate evidence",
+        'SOURCE_TREE="$(git rev-parse HEAD^{tree})"',
+        "sourceTree: $sourceTree",
+        "headCommit: $headCommit",
+        "pullRequest: $pullRequest",
         "missionchief-toolkit-validation-candidate-${{ github.sha }}",
         "publicMainChanged: false",
         "releaseDashboardChanged: false",
@@ -57,23 +61,30 @@ def main() -> int:
         "git push",
         "git pull --rebase",
         "github-actions[bot]",
+        "  push:\n",
     ], "Canonical validation workflow")
 
     require(automatic, [
-        "github.event.workflow_run.event == 'push'",
-        "github.event.workflow_run.head_sha",
-        "github.event.workflow_run.id",
-        "missionchief-toolkit-validation-candidate-${VALIDATED_SHA}",
-        "actions/runs/${VALIDATION_RUN_ID}/artifacts",
-        "verify_validation_candidate.py",
-        "CURRENT_MAIN=\"$(git rev-parse origin/main)\"",
-        "gh release view \"v${VERSION}\"",
-        "Dashboard candidate state used: no",
+        "types:\n      - closed",
+        "github.event.pull_request.merged == true",
+        "Consume exact successful PR validation tree",
+        "actions/workflows/validate-userscript.yml/runs",
+        "any(.pull_requests[]?; .number == $pr)",
+        'CURRENT_TREE="$(git rev-parse HEAD^{tree})"',
+        "Merged tree ${CURRENT_TREE} differs from validated PR tree ${CANDIDATE_TREE}",
+        "promoted_pull_request",
+        "Upload promoted merged-main candidate",
+        "validation_run_id: ${{ github.run_id }}",
+        "Post-merge userscript validation used: no",
+        "Post-merge release bundle rebuild used: no",
+        "gh workflow run validate-userscript.yml --ref main",
+        "github.event.workflow_run.event == 'workflow_dispatch'",
     ], "Automatic release workflow")
     forbid(automatic, [
         ".distributionCandidate",
         ".status.validation",
         "status/release-dashboard.json",
+        "github.event.workflow_run.event == 'push'",
     ], "Automatic release workflow")
 
     require(owner, [
@@ -107,7 +118,7 @@ def main() -> int:
         'sanitized.pop("releaseDryRun", None)',
         '"storage": "workflow-artifact"',
     ], "Dashboard stable-ledger sanitizer")
-    forbid(generator, ["data.get(\"distributionCandidate\"", "candidate.get("], "Dashboard generator")
+    forbid(generator, ['data.get("distributionCandidate"', "candidate.get("], "Dashboard generator")
     require(reconciler, [
         "Retired compatibility stub",
         "is retired; use the exact canonical-validation artifact instead",
@@ -124,7 +135,10 @@ def main() -> int:
     if result.returncode != 0:
         raise AssertionError("Validation candidate verifier self-tests failed")
 
-    print("Validation candidate pipeline passed: artifact authority, exact-run consumption and stable-only dist publication.")
+    print(
+        "Validation candidate pipeline passed: exact PR-tree promotion, no post-merge rebuild, "
+        "guarded current-main fallback and stable-only distribution publication."
+    )
     return 0
 
 

--- a/.github/workflows/auto-release-after-validation.yml
+++ b/.github/workflows/auto-release-after-validation.yml
@@ -1,8 +1,12 @@
 name: Automatic Toolkit Release
 
-run-name: Automatic release after validated main
+run-name: Automatic release from validated PR tree
 
 on:
+  pull_request:
+    branches: [main]
+    types:
+      - closed
   workflow_run:
     workflows:
       - Validate Canonical Userscript
@@ -12,17 +16,231 @@ on:
 permissions:
   actions: write
   contents: write
+  pull-requests: read
 
 concurrency:
   group: toolkit-automatic-release
   cancel-in-progress: false
 
 jobs:
-  prepare:
-    name: Resolve exact validated unreleased candidate
+  prepare_pr:
+    name: Promote exact merged PR candidate
     if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    outputs:
+      release_needed: ${{ steps.candidate.outputs.release_needed }}
+      version: ${{ steps.candidate.outputs.version }}
+      validated_sha: ${{ steps.candidate.outputs.validated_sha }}
+    steps:
+      - name: Check out exact merged main commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Consume exact successful PR validation tree
+        id: candidate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "release_needed=false" >> "$GITHUB_OUTPUT"
+          echo "version=" >> "$GITHUB_OUTPUT"
+          echo "validated_sha=$MERGE_SHA" >> "$GITHUB_OUTPUT"
+
+          for attempt in $(seq 1 15); do
+            git fetch origin main --prune
+            CURRENT_MAIN="$(git rev-parse origin/main)"
+            [[ "$CURRENT_MAIN" == "$MERGE_SHA" ]] && break
+            (( attempt == 15 )) && {
+              echo "::error::Merged commit ${MERGE_SHA} did not become current main."
+              exit 1
+            }
+            sleep 2
+          done
+          [[ "$(git rev-parse HEAD)" == "$MERGE_SHA" ]]
+
+          gh api --method GET \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/validate-userscript.yml/runs" \
+            -f event=pull_request \
+            -f status=completed \
+            -f branch="$PR_HEAD_REF" \
+            -f per_page=100 \
+            > /tmp/validation-runs.json
+
+          VALIDATION_RUN_ID="$(jq -r \
+            --arg head "$PR_HEAD_SHA" \
+            --argjson pr "$PR_NUMBER" \
+            '[.workflow_runs[]
+              | select(.conclusion == "success")
+              | select(.head_sha == $head)
+              | select(any(.pull_requests[]?; .number == $pr))]
+             | sort_by(.updated_at)
+             | last
+             | .id // empty' \
+            /tmp/validation-runs.json)"
+
+          if [[ -z "$VALIDATION_RUN_ID" ]]; then
+            echo "No successful exact-head PR validation was found; dispatching guarded main fallback."
+            gh workflow run validate-userscript.yml --ref main
+            exit 0
+          fi
+
+          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${VALIDATION_RUN_ID}/artifacts" > /tmp/validation-artifacts.json
+          ARTIFACT_ID="$(jq -r \
+            '[.artifacts[]
+              | select(.expired == false)
+              | select(.name | startswith("missionchief-toolkit-validation-candidate-"))]
+             | sort_by(.created_at)
+             | last
+             | .id // empty' \
+            /tmp/validation-artifacts.json)"
+
+          if [[ -z "$ARTIFACT_ID" ]]; then
+            echo "Exact PR validation artifact is unavailable; dispatching guarded main fallback."
+            gh workflow run validate-userscript.yml --ref main
+            exit 0
+          fi
+
+          rm -rf /tmp/validation-candidate
+          mkdir -p /tmp/validation-candidate
+          gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${ARTIFACT_ID}/zip" > /tmp/validation-candidate.zip
+          unzip -q /tmp/validation-candidate.zip -d /tmp/validation-candidate
+
+          ORIGINAL_EVIDENCE="/tmp/validation-candidate/validation-candidate/validation-candidate.json"
+          CANDIDATE_DIST="/tmp/validation-candidate/dist"
+          CANDIDATE_COMMIT="$(jq -r '.sourceCommit' "$ORIGINAL_EVIDENCE")"
+          CANDIDATE_REF="$(jq -r '.sourceRef' "$ORIGINAL_EVIDENCE")"
+          CANDIDATE_TREE="$(jq -r '.sourceTree' "$ORIGINAL_EVIDENCE")"
+          EVIDENCE_HEAD="$(jq -r '.headCommit' "$ORIGINAL_EVIDENCE")"
+          EVIDENCE_PR="$(jq -r '.pullRequest' "$ORIGINAL_EVIDENCE")"
+          CURRENT_TREE="$(git rev-parse HEAD^{tree})"
+
+          [[ "$EVIDENCE_HEAD" == "$PR_HEAD_SHA" ]]
+          [[ "$EVIDENCE_PR" == "$PR_NUMBER" ]]
+
+          if [[ "$CURRENT_TREE" != "$CANDIDATE_TREE" ]]; then
+            echo "Merged tree ${CURRENT_TREE} differs from validated PR tree ${CANDIDATE_TREE}; dispatching guarded main fallback."
+            gh workflow run validate-userscript.yml --ref main
+            exit 0
+          fi
+
+          python3 .github/scripts/verify_validation_candidate.py \
+            --evidence "$ORIGINAL_EVIDENCE" \
+            --source src/MissionChief_Map_Command_Toolkit.user.js \
+            --dist-dir "$CANDIDATE_DIST" \
+            --expected-commit "$CANDIDATE_COMMIT" \
+            --expected-ref "$CANDIDATE_REF" \
+            > /tmp/verified-pr-candidate.json
+
+          VERSION="$(jq -r '.version' /tmp/verified-pr-candidate.json)"
+          SOURCE_VERSION="$(sed -nE 's|^//[[:space:]]*@version[[:space:]]+(.+)$|\1|p' src/MissionChief_Map_Command_Toolkit.user.js | head -n 1 | xargs)"
+          [[ "$VERSION" == "$SOURCE_VERSION" ]]
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+          if gh release view "v${VERSION}" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Toolkit v${VERSION} is already published."
+            exit 0
+          fi
+
+          rm -rf validation-candidate dist release-bundle
+          cp -a /tmp/validation-candidate/validation-candidate validation-candidate
+          cp -a "$CANDIDATE_DIST" dist
+          cp -a /tmp/validation-candidate/release-bundle release-bundle
+
+          jq \
+            --arg commit "$MERGE_SHA" \
+            --arg ref "refs/heads/main" \
+            --arg tree "$CURRENT_TREE" \
+            --arg originalCommit "$CANDIDATE_COMMIT" \
+            --arg originalRef "$CANDIDATE_REF" \
+            '.sourceCommit=$commit
+             | .sourceRef=$ref
+             | .sourceTree=$tree
+             | .eventName="promoted_pull_request"
+             | .promotedFrom={sourceCommit:$originalCommit,sourceRef:$originalRef,sourceTree:$tree}' \
+            validation-candidate/validation-candidate.json \
+            > validation-candidate/validation-candidate.promoted.json
+          mv validation-candidate/validation-candidate.promoted.json \
+             validation-candidate/validation-candidate.json
+
+          python3 .github/scripts/verify_validation_candidate.py \
+            --evidence validation-candidate/validation-candidate.json \
+            --source src/MissionChief_Map_Command_Toolkit.user.js \
+            --dist-dir dist \
+            --expected-commit "$MERGE_SHA" \
+            --expected-ref refs/heads/main \
+            --expected-version "$VERSION"
+
+          echo "release_needed=true" >> "$GITHUB_OUTPUT"
+          echo "Toolkit v${VERSION} promoted from validated PR tree ${CANDIDATE_TREE} without rebuilding."
+
+      - name: Upload promoted merged-main candidate
+        if: steps.candidate.outputs.release_needed == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: missionchief-toolkit-validation-candidate-${{ steps.candidate.outputs.validated_sha }}
+          path: |
+            validation-candidate/validation-candidate.json
+            dist/MissionChief_Map_Command_Toolkit.user.js
+            dist/MissionChief_Map_Command_Toolkit.txt
+            dist/SHA256SUMS.txt
+            dist/release-manifest.json
+            release-bundle/
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Write direct-tree promotion summary
+        env:
+          RELEASE_NEEDED: ${{ steps.candidate.outputs.release_needed }}
+          VERSION: ${{ steps.candidate.outputs.version }}
+          VALIDATED_SHA: ${{ steps.candidate.outputs.validated_sha }}
+        shell: bash
+        run: |
+          {
+            echo "# Direct validated-tree release promotion"
+            echo
+            echo "- Pull request: \`#${{ github.event.pull_request.number }}\`"
+            echo "- Merged main commit: \`${VALIDATED_SHA}\`"
+            echo "- Version: \`${VERSION:-fallback}\`"
+            echo "- Release required: \`${RELEASE_NEEDED}\`"
+            echo "- Authority: exact validated PR repository tree"
+            echo "- Post-merge userscript validation used: no"
+            echo "- Post-merge release bundle rebuild used: no"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  production_pr:
+    name: Release promoted validated PR tree
+    needs: prepare_pr
+    if: needs.prepare_pr.outputs.release_needed == 'true'
+    permissions:
+      actions: write
+      contents: write
+    uses: ./.github/workflows/release-toolkit.yml
+    with:
+      version: ${{ needs.prepare_pr.outputs.version }}
+      confirmation: RELEASE
+      validation_run_id: ${{ github.run_id }}
+      validated_sha: ${{ needs.prepare_pr.outputs.validated_sha }}
+    secrets:
+      DISCORD_RELEASE_WEBHOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
+      MIGRATION_REPO_TOKEN: ${{ secrets.MIGRATION_REPO_TOKEN }}
+
+  prepare_fallback:
+    name: Resolve explicitly dispatched main fallback
+    if: >-
+      github.event_name == 'workflow_run' &&
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.event == 'workflow_dispatch' &&
       github.event.workflow_run.head_branch == 'main'
     runs-on: ubuntu-latest
     timeout-minutes: 8
@@ -30,14 +248,14 @@ jobs:
       release_needed: ${{ steps.candidate.outputs.release_needed }}
       version: ${{ steps.candidate.outputs.version }}
     steps:
-      - name: Check out exact validated commit
+      - name: Check out exact fallback validation commit
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Download and verify exact validation candidate
+      - name: Verify exact fallback candidate
         id: candidate
         env:
           GH_TOKEN: ${{ github.token }}
@@ -51,17 +269,21 @@ jobs:
           if [[ "$CURRENT_MAIN" != "$VALIDATED_SHA" ]]; then
             echo "release_needed=false" >> "$GITHUB_OUTPUT"
             echo "version=" >> "$GITHUB_OUTPUT"
-            echo "Validated commit ${VALIDATED_SHA} is stale; current main is ${CURRENT_MAIN}. Automatic release suppressed."
+            echo "Fallback validation ${VALIDATED_SHA} is stale; current main is ${CURRENT_MAIN}."
             exit 0
           fi
 
           ARTIFACT_NAME="missionchief-toolkit-validation-candidate-${VALIDATED_SHA}"
           gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${VALIDATION_RUN_ID}/artifacts" > /tmp/validation-artifacts.json
           ARTIFACT_ID="$(jq -r --arg name "$ARTIFACT_NAME" \
-            '.artifacts | map(select(.name == $name and .expired == false)) | sort_by(.created_at) | last | .id // empty' \
+            '.artifacts
+             | map(select(.name == $name and .expired == false))
+             | sort_by(.created_at)
+             | last
+             | .id // empty' \
             /tmp/validation-artifacts.json)"
           [[ -n "$ARTIFACT_ID" ]] || {
-            echo "::error::Exact validation candidate artifact was not found for run ${VALIDATION_RUN_ID}."
+            echo "::error::Exact fallback validation candidate artifact was not found."
             exit 1
           }
 
@@ -81,47 +303,25 @@ jobs:
             > /tmp/verified-validation-candidate.json
 
           VERSION="$(jq -r '.version' /tmp/verified-validation-candidate.json)"
-          SOURCE_VERSION="$(sed -nE 's|^//[[:space:]]*@version[[:space:]]+(.+)$|\1|p' src/MissionChief_Map_Command_Toolkit.user.js | head -n 1 | xargs)"
-          [[ "$VERSION" == "$SOURCE_VERSION" ]]
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
           if gh release view "v${VERSION}" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             echo "release_needed=false" >> "$GITHUB_OUTPUT"
             echo "Toolkit v${VERSION} is already published."
           else
             echo "release_needed=true" >> "$GITHUB_OUTPUT"
-            echo "Toolkit v${VERSION} is validated from exact commit ${VALIDATED_SHA} and will release automatically."
+            echo "Toolkit v${VERSION} will release from the explicit main fallback validation."
           fi
 
-      - name: Write candidate resolution summary
-        env:
-          RELEASE_NEEDED: ${{ steps.candidate.outputs.release_needed }}
-          VERSION: ${{ steps.candidate.outputs.version }}
-          VALIDATED_SHA: ${{ github.event.workflow_run.head_sha }}
-          VALIDATION_RUN_ID: ${{ github.event.workflow_run.id }}
-        shell: bash
-        run: |
-          {
-            echo "# Automatic release candidate resolution"
-            echo
-            echo "- Validation run: \`${VALIDATION_RUN_ID}\`"
-            echo "- Validated commit: \`${VALIDATED_SHA}\`"
-            echo "- Version: \`${VERSION:-stale}\`"
-            echo "- Release required: \`${RELEASE_NEEDED}\`"
-            echo "- Candidate authority: exact immutable validation artifact"
-            echo "- Dashboard candidate state used: no"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-  production:
-    name: Run maximum-speed verified production release
-    needs: prepare
-    if: needs.prepare.outputs.release_needed == 'true'
+  production_fallback:
+    name: Release explicitly validated main fallback
+    needs: prepare_fallback
+    if: needs.prepare_fallback.outputs.release_needed == 'true'
     permissions:
       actions: write
       contents: write
     uses: ./.github/workflows/release-toolkit.yml
     with:
-      version: ${{ needs.prepare.outputs.version }}
+      version: ${{ needs.prepare_fallback.outputs.version }}
       confirmation: RELEASE
       validation_run_id: ${{ github.event.workflow_run.id }}
       validated_sha: ${{ github.event.workflow_run.head_sha }}

--- a/.github/workflows/validate-userscript.yml
+++ b/.github/workflows/validate-userscript.yml
@@ -23,30 +23,6 @@ on:
       - ".github/workflows/validate-userscript.yml"
       - "status/source-baseline.json"
       - "status/update-manifest.json"
-  push:
-    branches:
-      - main
-    paths:
-      - "src/MissionChief_Map_Command_Toolkit.user.js"
-      - "CHANGELOG.md"
-      - "README.md"
-      - "docs/site-data.json"
-      - "docs/media/readme-hero.svg"
-      - "help/index.html"
-      - "documentation-drift-report.json"
-      - "documentation-drift-report.md"
-      - ".github/scripts/validate_userscript.py"
-      - ".github/scripts/verify_validation_candidate.py"
-      - ".github/scripts/test_documentation_consistency.py"
-      - ".github/scripts/test_validation_candidate_pipeline.py"
-      - ".github/scripts/test_version_status_contract.py"
-      - ".github/workflows/auto-release-after-validation.yml"
-      - ".github/workflows/owner-release-command.yml"
-      - ".github/workflows/publish-update-manifest.yml"
-      - ".github/workflows/release-toolkit.yml"
-      - ".github/workflows/validate-userscript.yml"
-      - "status/source-baseline.json"
-      - "status/update-manifest.json"
   workflow_dispatch:
 
 permissions:
@@ -123,6 +99,9 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Write immutable validation candidate evidence
+        env:
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number || '' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -132,13 +111,21 @@ jobs:
           SOURCE_HASH="$(sha256sum src/MissionChief_Map_Command_Toolkit.user.js | awk '{print $1}')"
           USER_HASH="$(sha256sum dist/MissionChief_Map_Command_Toolkit.user.js | awk '{print $1}')"
           TEXT_HASH="$(sha256sum dist/MissionChief_Map_Command_Toolkit.txt | awk '{print $1}')"
+          SOURCE_TREE="$(git rev-parse HEAD^{tree})"
+          CHECKOUT_COMMIT="$(git rev-parse HEAD)"
           [[ "$HASH" == "$SOURCE_HASH" && "$HASH" == "$USER_HASH" && "$HASH" == "$TEXT_HASH" ]]
+
+          PR_JSON=null
+          if [[ -n "$PR_NUMBER" ]]; then PR_JSON="$PR_NUMBER"; fi
 
           jq -n \
             --arg workflow "Validate Canonical Userscript" \
-            --arg commit "$GITHUB_SHA" \
+            --arg commit "$CHECKOUT_COMMIT" \
             --arg ref "$GITHUB_REF" \
+            --arg sourceTree "$SOURCE_TREE" \
             --arg event "$GITHUB_EVENT_NAME" \
+            --arg headCommit "$PR_HEAD_SHA" \
+            --argjson pullRequest "$PR_JSON" \
             --arg version "$VERSION" \
             --arg sha256 "$HASH" \
             --arg generatedAt "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
@@ -148,7 +135,10 @@ jobs:
               workflow: $workflow,
               sourceCommit: $commit,
               sourceRef: $ref,
+              sourceTree: $sourceTree,
               eventName: $event,
+              headCommit: $headCommit,
+              pullRequest: $pullRequest,
               version: $version,
               sha256: $sha256,
               generatedAt: $generatedAt,
@@ -169,7 +159,7 @@ jobs:
             --evidence validation-candidate/validation-candidate.json \
             --source src/MissionChief_Map_Command_Toolkit.user.js \
             --dist-dir dist \
-            --expected-commit "$GITHUB_SHA" \
+            --expected-commit "$CHECKOUT_COMMIT" \
             --expected-ref "$GITHUB_REF" \
             --expected-version "$VERSION"
 
@@ -192,6 +182,7 @@ jobs:
         run: |
           VERSION="$(jq -r '.version' validation-candidate/validation-candidate.json)"
           HASH="$(jq -r '.sha256' validation-candidate/validation-candidate.json)"
+          TREE="$(jq -r '.sourceTree' validation-candidate/validation-candidate.json)"
           {
             echo "# Toolkit v${VERSION} canonical validation"
             echo
@@ -200,7 +191,8 @@ jobs:
             echo "- ✅ Distribution files are byte-identical"
             echo "- ✅ Complete release bundle prepared once and retained with the candidate"
             echo "- ✅ Candidate SHA-256: \`${HASH}\`"
-            echo "- ✅ Exact source commit: \`${GITHUB_SHA}\`"
+            echo "- ✅ Validated repository tree: \`${TREE}\`"
+            echo "- ✅ Exact validation commit: \`${GITHUB_SHA}\`"
             echo "- 📦 Candidate retained as an immutable workflow artifact"
             echo "- ⛔ Public main changed: no"
             echo "- ⛔ Release dashboard changed: no"

--- a/docs/DEVELOPMENT_PACKAGE_WORKFLOW.md
+++ b/docs/DEVELOPMENT_PACKAGE_WORKFLOW.md
@@ -1,5 +1,7 @@
 # Reviewed development-package workflow
 
+> **Recovery-only transport.** Pipeline v5 uses direct atomic Git blobs, one tree, one commit and one branch-ref update for normal work. This workflow remains available only when a required file cannot be represented by the direct atomic lane.
+
 The reviewed development-package workflow operates only inside an **existing open pull request** owned by `Conroy1988`, hosted in this repository, and targeting `main`.
 
 The development branch and pull request must be created directly before either command is used. The workflow never creates an issue, branch, or pull request. This prevents diagnostic issue proliferation, duplicate pull requests, and GitHub Actions runs becoming stuck behind maintainer approval because they were created by `github-actions[bot]`.

--- a/docs/RELEASE_PIPELINE_V5.md
+++ b/docs/RELEASE_PIPELINE_V5.md
@@ -1,0 +1,42 @@
+# Release Pipeline v5 — Direct Atomic Hotfix Lane
+
+Pipeline v5 removes the remaining pre-merge construction bottleneck while preserving the verified Pipeline v4 publication path.
+
+## Normal hotfix operating sequence
+
+1. Start from the exact current `main` commit.
+2. Build the complete candidate outside GitHub: canonical source, both distribution mirrors, manifests, changelog, documentation and targeted regression contracts.
+3. Run JavaScript syntax, canonical validation, source/distribution parity and the complete retained preflight before the branch is changed.
+4. Upload every changed file as an immutable Git blob with `create_blob`.
+5. Create one repository tree with `create_tree`.
+6. Create one commit with `create_commit`.
+7. Advance the owner-created hotfix branch once with `update_ref`.
+8. Open the pull request only after the complete candidate has passed local validation.
+9. Enable auto-merge after the required CI gate is green.
+10. Release the exact validated pull-request tree after merge without rebuilding or repeating canonical validation.
+
+The normal lane must not create a temporary workflow, package fragment, permission override, diagnostic commit or self-cleaning writer.
+
+The development-package workflow is recovery-only. It remains available when a connector cannot represent a required file, but it is not the default development transport.
+
+## Validated-tree release authority
+
+Canonical validation records:
+
+- the checked-out validation commit;
+- the pull-request head commit;
+- the pull-request number;
+- the complete Git repository tree SHA;
+- the userscript SHA-256;
+- the release version;
+- the exact prepared release bundle.
+
+After squash merge, the automatic release compares the merged `main` tree SHA with the validated pull-request tree SHA. An exact match authorises immediate reuse of the immutable candidate. A mismatch never releases the stale candidate; it dispatches a guarded validation of current `main` and uses that result as the fallback.
+
+## Targets
+
+- Candidate construction: one branch commit.
+- PR opening to all release-critical checks: 90–150 seconds.
+- Merge to GitHub Release: 15–30 seconds.
+- Merge to fully verified release: 25–45 seconds.
+- Normal critical hotfix request to verified release: 3–5 minutes.


### PR DESCRIPTION
## Objective

Implements Phase 2 of #543: remove the remaining pre-merge construction and post-merge validation bottlenecks.

## Delivered architecture

- Normal changes are built and validated before the pull request is opened.
- Candidate files are uploaded as immutable Git blobs and committed through one tree and one branch-ref update.
- Canonical validation records the pull-request head, pull-request number and exact Git repository tree SHA alongside the existing source hash and release bundle.
- The automatic release starts from the merged pull request instead of waiting for a second validation of `main`.
- The merged `main` tree must exactly match the validated pull-request tree.
- The validated release bundle is promoted into the automatic-release run without rebuilding or rerunning userscript validation.
- A tree mismatch, missing artifact or missing exact-head validation automatically dispatches the guarded current-`main` fallback.
- The existing release workflow, Greasy Fork verification, private backup, Discord and rollback boundaries remain unchanged.
- The development-package workflow is explicitly retained as recovery-only transport.

## Atomic candidate evidence

- Base: `ddd07b8c1f0528027578473d9e797b074f865b0c`
- Head: `e195064bca944eefc450ea2bf41736720b8ac0d7`
- Commits: **1**
- Changed files: **6**
- Temporary workflows/packages/permissions: **0**

## Local validation completed before PR creation

- all modified workflow YAML parsed successfully;
- all modified Python contracts compiled;
- direct Git blob SHAs matched the locally calculated Git-object SHAs;
- branch is one commit ahead and zero behind;
- static validated-tree and promotion contracts were reconciled before upload.

## Target impact

- candidate construction commits: 12 on v8.0.4 → **1**;
- post-merge canonical rebuild/validation: **removed from the normal path**;
- merge → GitHub Release target: **15–30 seconds**;
- merge → fully verified target: **25–45 seconds**;
- normal critical hotfix request → verified release target: **3–5 minutes**.

This infrastructure change does not alter Toolkit runtime code or publish a new userscript version. Version 8.0.4 remains production.