### PR TITLE
Fix Pages monitor stale version false alarms

### DIFF
--- a/.github/pages-monitor-policy.json
+++ b/.github/pages-monitor-policy.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 2,
+  "schemaVersion": 3,
   "baseUrl": "https://conroy1988.github.io/missionchief-toolkit-assets/",
   "timeoutSeconds": 25,
   "routes": [
@@ -7,8 +7,8 @@
     {"path": "features/", "contentType": "text/html", "requiredText": ["Features", "Mission Age map timers", "Patient Transport Sweep", "Mission Value"]},
     {"path": "themes/", "contentType": "text/html", "requiredText": ["Themes", "Cyberpunk", "Factorio", "Hyrule Command"]},
     {"path": "docs/", "contentType": "text/html", "requiredText": ["Documentation", "The One We Knew Before", "Installation"]},
-    {"path": "changelog/", "contentType": "text/html", "requiredText": ["Changelog", "Version 7.0.0"]},
-    {"path": "status/", "contentType": "text/html", "requiredText": ["Status", "Current version 7.0.0"]},
+    {"path": "changelog/", "contentType": "text/html", "requiredText": ["Changelog", "Version {version}"]},
+    {"path": "status/", "contentType": "text/html", "requiredText": ["Status", "Current version {version}"]},
     {"path": "assets/site.css", "contentType": "text/css", "minimumBytes": 1000},
     {"path": "assets/site.js", "contentType": "javascript", "minimumBytes": 500}
   ]

--- a/.github/scripts/check_pages_live.py
+++ b/.github/scripts/check_pages_live.py
@@ -36,6 +36,11 @@ def fetch(url: str, timeout: int) -> tuple[int, str, bytes, str]:
         )
 
 
+def expand_required_text(value: Any, version: str) -> str:
+    """Resolve policy tokens against the verified release dashboard."""
+    return str(value).replace("{version}", version)
+
+
 def audit(root: Path) -> dict[str, Any]:
     policy = load_json(root / ".github/pages-monitor-policy.json")
     dashboard = load_json(root / "status/release-dashboard.json")
@@ -44,6 +49,9 @@ def audit(root: Path) -> dict[str, Any]:
     timeout = int(policy.get("timeoutSeconds", 25))
     failures: list[str] = []
     checks: list[dict[str, Any]] = []
+
+    if not version:
+        failures.append("Release dashboard does not expose a verified Toolkit version")
 
     for route in policy.get("routes", []):
         path = str(route.get("path", ""))
@@ -69,8 +77,9 @@ def audit(root: Path) -> dict[str, Any]:
             if len(body) < minimum:
                 failures.append(f"{path or '/'} returned only {len(body)} bytes; expected at least {minimum}")
             for required in route.get("requiredText", []):
-                if str(required) not in text:
-                    failures.append(f"{path or '/'} is missing required text: {required}")
+                required_text = expand_required_text(required, version)
+                if required_text not in text:
+                    failures.append(f"{path or '/'} is missing required text: {required_text}")
             if path == "" and version and version not in text:
                 failures.append(f"Home page does not expose current Toolkit version {version}")
             if not any(item.startswith(path or "/") for item in failures):

--- a/.github/scripts/test_pages_monitor_version_contract.py
+++ b/.github/scripts/test_pages_monitor_version_contract.py
@@ -12,6 +12,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 CHECKER_PATH = ROOT / ".github" / "scripts" / "check_pages_live.py"
 FIXTURE_PATH = ROOT / ".github" / "fixtures" / "pages-monitor-version-contract.json"
+POLICY_PATH = ROOT / ".github" / "pages-monitor-policy.json"
 WORKFLOW_PATH = ROOT / ".github" / "workflows" / "pages-production-monitor.yml"
 RELEASE_DASHBOARD_PATH = '      - "status/release-dashboard.json"'
 
@@ -53,20 +54,32 @@ def assert_workflow_trigger_contract() -> None:
     )
 
 
+def assert_dynamic_policy_contract(checker) -> None:
+    policy = json.loads(POLICY_PATH.read_text(encoding="utf-8"))
+    routes = {item["path"]: item for item in policy["routes"]}
+    assert "Version {version}" in routes["changelog/"]["requiredText"]
+    assert "Current version {version}" in routes["status/"]["requiredText"]
+    assert "7.0.0" not in json.dumps(policy)
+    assert checker.expand_required_text("Current version {version}", "8.0.4") == "Current version 8.0.4"
+
+
 def run_case(checker, item: dict) -> None:
     with tempfile.TemporaryDirectory(prefix="mcms-pages-monitor-") as temp:
         root = Path(temp)
         (root / ".github").mkdir(parents=True)
         (root / "status").mkdir(parents=True)
         policy = {
-            "schemaVersion": 1,
+            "schemaVersion": 3,
             "baseUrl": "https://example.invalid/toolkit/",
             "timeoutSeconds": 1,
             "routes": [
                 {
                     "path": "",
                     "contentType": "text/html",
-                    "requiredText": ["MissionChief Map Command Toolkit"],
+                    "requiredText": [
+                        "MissionChief Map Command Toolkit",
+                        "Version {version}",
+                    ],
                 }
             ],
         }
@@ -95,12 +108,13 @@ def run_case(checker, item: dict) -> None:
 def main() -> int:
     assert_workflow_trigger_contract()
     checker = load_checker()
+    assert_dynamic_policy_contract(checker)
     fixture = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
     for item in fixture["cases"]:
         run_case(checker, item)
     print(
         "Pages monitor version contract passed: "
-        f"dashboard push trigger plus {len(fixture['cases'])} published/candidate transition cases."
+        f"dynamic dashboard tokens plus {len(fixture['cases'])} published/candidate transition cases."
     )
     return 0
 


### PR DESCRIPTION
## Problem

The GitHub Pages production monitor still hard-coded `Version 7.0.0` and `Current version 7.0.0` in its route policy. Production is verified at Toolkit `8.0.4`, so healthy HTTP 200 responses were incorrectly treated as a production incident and issue #86 was reopened.

## Fix

- add `{version}` token expansion to `check_pages_live.py`;
- resolve that token from `status/release-dashboard.json` using the verified published release version;
- convert the changelog and status route checks to `Version {version}` and `Current version {version}`;
- fail closed when the release dashboard exposes no version;
- add fixture-backed regression coverage proving token expansion, candidate/public release handling, and permanent removal of the `7.0.0` assertion.

## Scope

Only the Pages production monitor, its policy and its test contract change. No userscript, distribution or live Toolkit runtime code changes.

## Expected recovery

After merge and Pages-monitor execution, the healthy `8.0.4` site should pass and automated incident #86 should close itself.

Fixes #86.