### PR TITLE
Diagnostic: prove Alliance Member Manager mount failure

### DIFF
--- a/.github/scripts/diagnose_issue553_full_mount.mjs
+++ b/.github/scripts/diagnose_issue553_full_mount.mjs
@@ -56,6 +56,28 @@ const html = `<!doctype html><html><head></head><body>
 </body></html>`;
 
 const { window } = parseHTML(html);
+
+// Linkedom intentionally implements a compact DOM. Add the browser table
+// collection properties used by the released installer so this diagnostic
+// exercises product logic rather than library omissions.
+for (const table of window.document.querySelectorAll("table")) {
+  Object.defineProperty(table, "tBodies", {
+    configurable: true,
+    value: Array.from(table.querySelectorAll("tbody")),
+  });
+  for (const body of table.tBodies) {
+    Object.defineProperty(body, "rows", {
+      configurable: true,
+      value: Array.from(body.querySelectorAll(":scope > tr")),
+    });
+    for (const row of body.rows) {
+      const cells = Array.from(row.querySelectorAll(":scope > th, :scope > td"));
+      cells.item = index => cells[index] || null;
+      Object.defineProperty(row, "cells", { configurable: true, value: cells });
+    }
+  }
+}
+
 const storage = new Map([["mcms_alliance_member_manager_enabled_v1", "true"]]);
 const localStorage = {
   getItem(key) { return storage.has(key) ? storage.get(key) : null; },
@@ -117,7 +139,7 @@ const bootstrap = `${extractFunction("decodedPathname")}\n${managerBlock}\nthis.
 try {
   vm.runInContext(bootstrap, sandbox, { filename: "alliance-member-manager-v8.1.4.js" });
   window.document.dispatchEvent(new window.Event("DOMContentLoaded"));
-  for (let i = 0; i < 20; i += 1) await Promise.resolve();
+  for (let i = 0; i < 40; i += 1) await Promise.resolve();
 
   const probe = sandbox.__managerProbe;
   const table = probe.table(window.document);

--- a/.github/scripts/diagnose_issue553_full_mount.mjs
+++ b/.github/scripts/diagnose_issue553_full_mount.mjs
@@ -37,7 +37,7 @@ assert.notEqual(start, -1, "manager block start missing");
 assert.notEqual(end, -1, "manager block end missing");
 const managerBlock = source.slice(start, end + "    // </mcms-alliance-member-manager>".length);
 
-const html = `<!doctype html><html><head></head><body>
+const memberComponent = `
   <main id="external-member-root">
     <h1>Members<br><small>Show 20 players of 1 (11,012,323,195) to 1 (1,267,484,428) of 568 pages</small></h1>
     <button>load previous page</button><button>load next page</button>
@@ -52,114 +52,141 @@ const html = `<!doctype html><html><head></head><body>
         </tbody>
       </table>
     </section>
-  </main>
-</body></html>`;
+  </main>`;
 
-const { window } = parseHTML(html);
-
-// Linkedom intentionally implements a compact DOM. Add the browser table
-// collection properties used by the released installer so this diagnostic
-// exercises product logic rather than library omissions.
-for (const table of window.document.querySelectorAll("table")) {
-  Object.defineProperty(table, "tBodies", {
-    configurable: true,
-    value: Array.from(table.querySelectorAll("tbody")),
-  });
-  for (const body of table.tBodies) {
-    Object.defineProperty(body, "rows", {
+function polyfillTables(document) {
+  for (const table of document.querySelectorAll("table")) {
+    if (!table.tBodies) Object.defineProperty(table, "tBodies", {
       configurable: true,
-      value: Array.from(body.querySelectorAll(":scope > tr")),
+      value: Array.from(table.querySelectorAll("tbody")),
     });
-    for (const row of body.rows) {
-      const cells = Array.from(row.querySelectorAll(":scope > th, :scope > td"));
-      cells.item = index => cells[index] || null;
-      Object.defineProperty(row, "cells", { configurable: true, value: cells });
+    for (const body of table.tBodies) {
+      if (!body.rows) Object.defineProperty(body, "rows", {
+        configurable: true,
+        value: Array.from(body.querySelectorAll(":scope > tr")),
+      });
+      for (const row of body.rows) {
+        if (row.cells) continue;
+        const cells = Array.from(row.querySelectorAll(":scope > th, :scope > td"));
+        cells.item = index => cells[index] || null;
+        Object.defineProperty(row, "cells", { configurable: true, value: cells });
+      }
     }
   }
 }
 
-const storage = new Map([["mcms_alliance_member_manager_enabled_v1", "true"]]);
-const localStorage = {
-  getItem(key) { return storage.has(key) ? storage.get(key) : null; },
-  setItem(key, value) { storage.set(key, String(value)); },
-  removeItem(key) { storage.delete(key); },
-};
+function createScenario({ pathname, initialMemberDom, gmEnabled, localEnabled }) {
+  const html = `<!doctype html><html><head></head><body>${initialMemberDom ? memberComponent : '<main id="map-root"></main>'}</body></html>`;
+  const { window } = parseHTML(html);
+  polyfillTables(window.document);
 
-const timers = new Map();
-let timerId = 0;
-function schedule(callback) {
-  const id = ++timerId;
-  timers.set(id, callback);
-  queueMicrotask(() => {
-    const pending = timers.get(id);
-    if (!pending) return;
-    timers.delete(id);
-    pending();
-  });
-  return id;
-}
-function clearScheduled(id) { timers.delete(id); }
-window.setTimeout = schedule;
-window.clearTimeout = clearScheduled;
+  const storage = new Map();
+  if (localEnabled !== null) storage.set("mcms_alliance_member_manager_enabled_v1", String(localEnabled));
+  const localStorage = {
+    getItem(key) { return storage.has(key) ? storage.get(key) : null; },
+    setItem(key, value) { storage.set(key, String(value)); },
+    removeItem(key) { storage.delete(key); },
+  };
 
-const sandbox = {
-  console,
-  window,
-  document: window.document,
-  Element: window.Element,
-  Event: window.Event,
-  DOMParser: window.DOMParser,
-  URL,
-  AbortController,
-  queueMicrotask,
-  pageWindow: window,
-  localStorage,
-  location: {
-    pathname: "/verband/mitglieder/123",
-    href: "https://www.missionchief.co.uk/verband/mitglieder/123",
-    origin: "https://www.missionchief.co.uk",
-  },
-  SCRIPT: { panelId: "mc-map-command-toolkit-panel", version: "8.1.4" },
-  GM_getValue: (_key, fallback) => fallback,
-  GM_setValue: () => undefined,
-  fetch: async () => { throw new Error("fetch must not run during initial mount"); },
-  showToast: () => undefined,
-};
-vm.createContext(sandbox);
+  const timers = new Map();
+  let timerId = 0;
+  function schedule(callback) {
+    const id = ++timerId;
+    timers.set(id, callback);
+    queueMicrotask(() => {
+      const pending = timers.get(id);
+      if (!pending) return;
+      timers.delete(id);
+      pending();
+    });
+    return id;
+  }
+  function clearScheduled(id) { timers.delete(id); }
+  window.setTimeout = schedule;
+  window.clearTimeout = clearScheduled;
 
-const bootstrap = `${extractFunction("decodedPathname")}\n${managerBlock}\nthis.__managerProbe = {
-  enabled: allianceMemberManagerEnabled,
-  route: isAllianceMemberManagerRoute,
-  table: allianceMemberManagerTable,
-  reconcile: reconcileAllianceMemberManager,
-  install: installAllianceMemberManager,
-  page: () => allianceMemberManagerPage,
-};`;
-
-try {
+  const sandbox = {
+    console,
+    window,
+    document: window.document,
+    Element: window.Element,
+    Event: window.Event,
+    MutationObserver: window.MutationObserver,
+    DOMParser: window.DOMParser,
+    URL,
+    AbortController,
+    queueMicrotask,
+    pageWindow: window,
+    localStorage,
+    location: {
+      pathname,
+      href: `https://www.missionchief.co.uk${pathname}`,
+      origin: "https://www.missionchief.co.uk",
+    },
+    SCRIPT: { panelId: "mc-map-command-toolkit-panel", version: "8.1.4" },
+    GM_getValue: (_key, fallback) => gmEnabled ?? fallback,
+    GM_setValue: () => undefined,
+    fetch: async () => { throw new Error("fetch must not run during initial mount"); },
+    showToast: () => undefined,
+  };
+  vm.createContext(sandbox);
+  const bootstrap = `${extractFunction("decodedPathname")}\n${managerBlock}\nthis.__managerProbe = {
+    enabled: allianceMemberManagerEnabled,
+    route: isAllianceMemberManagerRoute,
+    table: allianceMemberManagerTable,
+    reconcile: reconcileAllianceMemberManager,
+    page: () => allianceMemberManagerPage,
+  };`;
   vm.runInContext(bootstrap, sandbox, { filename: "alliance-member-manager-v8.1.4.js" });
   window.document.dispatchEvent(new window.Event("DOMContentLoaded"));
-  for (let i = 0; i < 40; i += 1) await Promise.resolve();
+  return { window, sandbox };
+}
 
-  const probe = sandbox.__managerProbe;
-  const table = probe.table(window.document);
-  const panel = window.document.querySelector("#mcms-alliance-member-manager");
+async function flush(rounds = 50) {
+  for (let index = 0; index < rounds; index += 1) await Promise.resolve();
+}
+
+function assertMounted(label, scenario) {
+  const panel = scenario.window.document.querySelector("#mcms-alliance-member-manager");
+  const table = scenario.sandbox.__managerProbe.table(scenario.window.document);
   const report = {
-    enabled: probe.enabled(),
-    route: probe.route(),
+    label,
+    enabled: scenario.sandbox.__managerProbe.enabled(),
+    route: scenario.sandbox.__managerProbe.route(),
     tableFound: Boolean(table),
     panelFound: Boolean(panel),
-    pageContext: Boolean(probe.page()),
-    bodyHtml: window.document.body.innerHTML.slice(0, 2000),
+    pageContext: Boolean(scenario.sandbox.__managerProbe.page()),
   };
-  console.log(JSON.stringify(report, null, 2));
-  assert.ok(table, "released installer did not discover the realistic member table");
-  assert.ok(panel, "released installer did not render the Alliance Member Manager panel");
-  assert.ok(panel.querySelector("select"), "manager panel rendered without filter controls");
-  assert.match(panel.textContent, /Load All Member Pages/u);
+  console.log(JSON.stringify(report));
+  assert.ok(table, `${label}: member table not discovered`);
+  assert.ok(panel, `${label}: manager panel not rendered`);
+  assert.ok(panel.querySelector("select"), `${label}: manager controls missing`);
+  assert.match(panel.textContent, /Load All Member Pages/u, `${label}: load-all control missing`);
+}
+
+try {
+  const direct = createScenario({
+    pathname: "/verband/mitglieder/123",
+    initialMemberDom: true,
+    gmEnabled: null,
+    localEnabled: true,
+  });
+  await flush();
+  assertMounted("direct-route-static-dom", direct);
+
+  const delayed = createScenario({
+    pathname: "/",
+    initialMemberDom: false,
+    gmEnabled: true,
+    localEnabled: null,
+  });
+  await flush();
+  delayed.window.document.body.insertAdjacentHTML("beforeend", memberComponent);
+  polyfillTables(delayed.window.document);
+  await flush(100);
+  assertMounted("neutral-route-delayed-dom", delayed);
 } catch (error) {
   console.error("FULL_MOUNT_DIAGNOSTIC_FAILURE");
   console.error(error?.stack || error);
-  console.error(window.document.body.innerHTML.slice(0, 4000));
   process.exitCode = 1;
 }

--- a/.github/scripts/diagnose_issue553_full_mount.mjs
+++ b/.github/scripts/diagnose_issue553_full_mount.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+"use strict";
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import vm from "node:vm";
+import { parseHTML } from "linkedom";
+
+const source = fs.readFileSync("src/MissionChief_Map_Command_Toolkit.user.js", "utf8");
+
+function extractFunction(name) {
+  const marker = `    function ${name}(`;
+  const start = source.indexOf(marker);
+  assert.notEqual(start, -1, `${name} is missing`);
+  const brace = source.indexOf("{", start);
+  let depth = 0;
+  let quote = "";
+  let escaped = false;
+  for (let index = brace; index < source.length; index += 1) {
+    const char = source[index];
+    if (quote) {
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === quote) quote = "";
+      continue;
+    }
+    if (char === "'" || char === '"' || char === "`") { quote = char; continue; }
+    if (char === "{") depth += 1;
+    if (char === "}" && --depth === 0) return source.slice(start, index + 1);
+  }
+  throw new Error(`Unable to extract ${name}`);
+}
+
+const start = source.indexOf("    // <mcms-alliance-member-manager>");
+const end = source.indexOf("    // </mcms-alliance-member-manager>", start);
+assert.notEqual(start, -1, "manager block start missing");
+assert.notEqual(end, -1, "manager block end missing");
+const managerBlock = source.slice(start, end + "    // </mcms-alliance-member-manager>".length);
+
+const html = `<!doctype html><html><head></head><body>
+  <main id="external-member-root">
+    <h1>Members<br><small>Show 20 players of 1 (11,012,323,195) to 1 (1,267,484,428) of 568 pages</small></h1>
+    <button>load previous page</button><button>load next page</button>
+    <a href="/verband/mitglieder/123?online=true">Show only online players</a>
+    <section id="external-member-component">
+      <div class="head"><span>20 filtered players</span><label><input class="search_input_field" placeholder="Search in loaded players"></label></div>
+      <table class="table table-striped">
+        <thead><tr><th>player</th><th>Role(s)</th><th>total credits earned</th></tr></thead>
+        <tbody>
+          <tr><td><img src="/images/user_green.png"><a href="/profile/10">Evilian</a></td><td><span class="badge">Senior Admin</span><br><small>Alliance Admin</small></td><td>11,012,323,195 Credits</td></tr>
+          <tr><td><img src="/images/user_gray.png"><a href="/profile/11">iCarnage</a></td><td></td><td>4,845,062,084 Credits</td></tr>
+        </tbody>
+      </table>
+    </section>
+  </main>
+</body></html>`;
+
+const { window } = parseHTML(html);
+const storage = new Map([["mcms_alliance_member_manager_enabled_v1", "true"]]);
+const localStorage = {
+  getItem(key) { return storage.has(key) ? storage.get(key) : null; },
+  setItem(key, value) { storage.set(key, String(value)); },
+  removeItem(key) { storage.delete(key); },
+};
+
+const timers = new Map();
+let timerId = 0;
+function schedule(callback) {
+  const id = ++timerId;
+  timers.set(id, callback);
+  queueMicrotask(() => {
+    const pending = timers.get(id);
+    if (!pending) return;
+    timers.delete(id);
+    pending();
+  });
+  return id;
+}
+function clearScheduled(id) { timers.delete(id); }
+window.setTimeout = schedule;
+window.clearTimeout = clearScheduled;
+
+const sandbox = {
+  console,
+  window,
+  document: window.document,
+  Element: window.Element,
+  Event: window.Event,
+  DOMParser: window.DOMParser,
+  URL,
+  AbortController,
+  queueMicrotask,
+  pageWindow: window,
+  localStorage,
+  location: {
+    pathname: "/verband/mitglieder/123",
+    href: "https://www.missionchief.co.uk/verband/mitglieder/123",
+    origin: "https://www.missionchief.co.uk",
+  },
+  SCRIPT: { panelId: "mc-map-command-toolkit-panel", version: "8.1.4" },
+  GM_getValue: (_key, fallback) => fallback,
+  GM_setValue: () => undefined,
+  fetch: async () => { throw new Error("fetch must not run during initial mount"); },
+  showToast: () => undefined,
+};
+vm.createContext(sandbox);
+
+const bootstrap = `${extractFunction("decodedPathname")}\n${managerBlock}\nthis.__managerProbe = {
+  enabled: allianceMemberManagerEnabled,
+  route: isAllianceMemberManagerRoute,
+  table: allianceMemberManagerTable,
+  reconcile: reconcileAllianceMemberManager,
+  install: installAllianceMemberManager,
+  page: () => allianceMemberManagerPage,
+};`;
+
+try {
+  vm.runInContext(bootstrap, sandbox, { filename: "alliance-member-manager-v8.1.4.js" });
+  window.document.dispatchEvent(new window.Event("DOMContentLoaded"));
+  for (let i = 0; i < 20; i += 1) await Promise.resolve();
+
+  const probe = sandbox.__managerProbe;
+  const table = probe.table(window.document);
+  const panel = window.document.querySelector("#mcms-alliance-member-manager");
+  const report = {
+    enabled: probe.enabled(),
+    route: probe.route(),
+    tableFound: Boolean(table),
+    panelFound: Boolean(panel),
+    pageContext: Boolean(probe.page()),
+    bodyHtml: window.document.body.innerHTML.slice(0, 2000),
+  };
+  console.log(JSON.stringify(report, null, 2));
+  assert.ok(table, "released installer did not discover the realistic member table");
+  assert.ok(panel, "released installer did not render the Alliance Member Manager panel");
+  assert.ok(panel.querySelector("select"), "manager panel rendered without filter controls");
+  assert.match(panel.textContent, /Load All Member Pages/u);
+} catch (error) {
+  console.error("FULL_MOUNT_DIAGNOSTIC_FAILURE");
+  console.error(error?.stack || error);
+  console.error(window.document.body.innerHTML.slice(0, 4000));
+  process.exitCode = 1;
+}

--- a/.github/workflows/diagnose-issue553-full-mount.yml
+++ b/.github/workflows/diagnose-issue553-full-mount.yml
@@ -1,0 +1,42 @@
+name: Diagnose Issue 553 Full Mount
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  diagnose:
+    if: github.event.pull_request.head.ref == 'diagnostic/alliance-member-ui-mount'
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - name: Check out exact diagnostic head
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          show-progress: false
+
+      - name: Install isolated DOM runtime
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install --no-save --package-lock=false --ignore-scripts linkedom@0.18.12
+
+      - name: Execute released installer against realistic member page
+        shell: bash
+        run: |
+          set -euo pipefail
+          node .github/scripts/diagnose_issue553_full_mount.mjs 2>&1 | tee issue553-full-mount.log
+
+      - name: Upload diagnostic
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: issue553-full-mount-${{ github.sha }}
+          path: issue553-full-mount.log
+          if-no-files-found: error
+          retention-days: 14


### PR DESCRIPTION
## Diagnostic completed — do not merge

The released v8.1.4 installer was executed directly against realistic rendered member-page fixtures.

### Proven results

- Direct route with an already-present table mounts successfully.
- Neutral top-level route before the redesigned member DOM appears fails immediately with:

```text
ReferenceError: teardownAllianceMemberManager is not defined
```

The production function is named `disposeAllianceMemberManager()`. The prior isolated runtime test supplied a fake `teardownAllianceMemberManager()` stub, concealing the missing production symbol. It also mocked `installAllianceMemberManager()` rather than executing the real installer.

This diagnostic PR is closed without merge. Its full-mount method is being promoted into the permanent blocking UI-integration gate in the v8.1.5 corrective PR.