### PR TITLE
Pipeline recovery: Fix changed-tree success exit status

### DIFF
--- a/.github/scripts/test_recover_development_package_workflow.py
+++ b/.github/scripts/test_recover_development_package_workflow.py
@@ -21,10 +21,13 @@ def main() -> int:
         "python3 .github/scripts/validate_userscript.py",
         "node --check src/MissionChief_Map_Command_Toolkit.user.js",
         "cmp --silent dist/MissionChief_Map_Command_Toolkit.user.js dist/MissionChief_Map_Command_Toolkit.txt",
+        "if git diff --cached --quiet; then",
+        "Package produced no repository changes.",
         "--force-with-lease=\"refs/heads/${BRANCH}:${EXPECTED_HEAD}\"",
         "HEAD:${BRANCH}",
     ]:
         assert marker in source, marker
+    assert "git diff --cached --quiet &&" not in source
     for forbidden in ["contents: write", "HEAD:main", "HEAD:refs/heads/main", "pull_request_target"]:
         assert forbidden not in source, forbidden
     inventory = json.loads(INVENTORY.read_text(encoding="utf-8"))

--- a/.github/workflows/recover-development-package.yml
+++ b/.github/workflows/recover-development-package.yml
@@ -111,7 +111,10 @@ jobs:
           node --check src/MissionChief_Map_Command_Toolkit.user.js
           cmp --silent dist/MissionChief_Map_Command_Toolkit.user.js dist/MissionChief_Map_Command_Toolkit.txt
           git add -A
-          git diff --cached --quiet && { echo "::error::Package produced no repository changes."; exit 1; }
+          if git diff --cached --quiet; then
+            echo "::error::Package produced no repository changes."
+            exit 1
+          fi
 
       - name: Commit and publish with exact lease
         id: publish


### PR DESCRIPTION
## Defect

The owner-dispatched recovery lane correctly applied and validated the v8.2.5 package, but the final changed-tree guard was the last command in its shell step:

```bash
git diff --cached --quiet && { echo "::error::Package produced no repository changes."; exit 1; }
```

When the package correctly produced changes, `git diff --quiet` returned `1`. Because that `&&` list ended the step, the shell reported the successful changed-tree path as a workflow failure.

## Correction

- use an explicit `if git diff --cached --quiet; then ... fi` guard;
- unchanged trees still fail closed;
- changed trees now continue to the exact leased commit/push step;
- add a regression that requires the explicit guard and forbids the defective `&&` form.

No product source, release state, permissions, branch target or publication authority changes.