### PR TITLE
Pipeline: Allow connector-triggered package recovery

### DIFF
--- a/.github/recovery-development-package-policy.json
+++ b/.github/recovery-development-package-policy.json
@@ -1,7 +1,19 @@
 {
   "schemaVersion": 1,
   "workflow": ".github/workflows/recover-development-package.yml",
-  "trigger": "manual owner workflow_dispatch",
+  "triggers": [
+    "manual owner workflow_dispatch",
+    "connector-authenticated push command"
+  ],
+  "commandTransport": {
+    "branch": "automation/development-packages",
+    "path": ".github/automation-commands/recover-development-package.json",
+    "actor": "Conroy1988",
+    "changedFiles": 1,
+    "exactMainHead": true,
+    "exactPullRequestHead": true,
+    "nonceRequired": true
+  },
   "acceptedPullRequest": {
     "state": "open",
     "base": "main",

--- a/.github/scripts/test_recover_development_package_workflow.py
+++ b/.github/scripts/test_recover_development_package_workflow.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Contract for the owner-dispatched reviewed-package recovery lane."""
+"""Contract for the owner-dispatched and connector-triggered reviewed-package recovery lane."""
 from pathlib import Path
 import json
 ROOT = Path(__file__).resolve().parents[2]
@@ -10,12 +10,22 @@ def main() -> int:
     source = WORKFLOW.read_text(encoding="utf-8")
     for marker in [
         "workflow_dispatch:",
+        "push:",
+        "automation/development-packages",
+        ".github/automation-commands/recover-development-package.json",
         "github.actor == 'Conroy1988'",
+        'COMMAND_EXPECTED_MAIN=""',
+        'COMMAND_EXPECTED_HEAD=""',
+        '.command == "recover-development-package"',
+        "Command main head is stale.",
+        "Command pull-request head is stale.",
+        'echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"',
         "Pull request must target main.",
         "Pull request must be owned by Conroy1988.",
         "Recovery accepts exactly one staged package file",
         ".github/development-packages/",
         "DEVELOPMENT_PR_TOKEN",
+        'PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}',
         "git rebase \"$MAIN_SHA\"",
         "python3 \"$PACKAGE_PATH\"",
         "python3 .github/scripts/validate_userscript.py",
@@ -28,7 +38,7 @@ def main() -> int:
     ]:
         assert marker in source, marker
     assert "git diff --cached --quiet &&" not in source
-    for forbidden in ["contents: write", "HEAD:main", "HEAD:refs/heads/main", "pull_request_target"]:
+    for forbidden in ["contents: write", "HEAD:main", "HEAD:refs/heads/main", "pull_request_target", "secrets: inherit"]:
         assert forbidden not in source, forbidden
     inventory = json.loads(INVENTORY.read_text(encoding="utf-8"))
     entries = {entry["workflow"]: entry for entry in inventory["reviewBranchWriters"]}

--- a/.github/workflows/recover-development-package.yml
+++ b/.github/workflows/recover-development-package.yml
@@ -1,6 +1,6 @@
 name: Recover Reviewed Development Package
 
-run-name: Recover development package for PR #${{ inputs.pr_number }}
+run-name: Recover reviewed development package
 
 on:
   workflow_dispatch:
@@ -9,12 +9,17 @@ on:
         description: "Existing owner-created package-only pull request number"
         required: true
         type: string
+  push:
+    branches:
+      - automation/development-packages
+    paths:
+      - .github/automation-commands/recover-development-package.json
 
 permissions:
   contents: read
 
 concurrency:
-  group: recover-development-package-pr-${{ inputs.pr_number }}
+  group: recover-development-package-${{ github.event_name }}-${{ github.sha }}
   cancel-in-progress: false
 
 jobs:
@@ -29,10 +34,43 @@ jobs:
         id: resolve
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ inputs.pr_number }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_REF: ${{ github.ref }}
+          EVENT_SHA: ${{ github.sha }}
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+          COMMAND_PATH: .github/automation-commands/recover-development-package.json
         shell: bash
         run: |
           set -euo pipefail
+          PR_NUMBER="$INPUT_PR_NUMBER"
+          COMMAND_EXPECTED_MAIN=""
+          COMMAND_EXPECTED_HEAD=""
+
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            [[ "$EVENT_REF" == "refs/heads/automation/development-packages" ]] || {
+              echo "::error::Connector recovery commands are accepted only from automation/development-packages."
+              exit 1
+            }
+            mapfile -t command_files < <(gh api "repos/${GITHUB_REPOSITORY}/commits/${EVENT_SHA}" --jq '.files[].filename')
+            [[ "${#command_files[@]}" -eq 1 && "${command_files[0]}" == "$COMMAND_PATH" ]] || {
+              echo "::error::A connector recovery command commit must change only ${COMMAND_PATH}."
+              exit 1
+            }
+            gh api "repos/${GITHUB_REPOSITORY}/contents/${COMMAND_PATH}?ref=${EVENT_SHA}" \
+              --jq '.content' | tr -d '\n' | base64 --decode > /tmp/recover-command.json
+            jq -e '
+              .schemaVersion == 1 and
+              .command == "recover-development-package" and
+              (.prNumber | type == "number" and . > 0 and floor == .) and
+              (.expectedMain | type == "string" and test("^[0-9a-f]{40}$")) and
+              (.expectedHead | type == "string" and test("^[0-9a-f]{40}$")) and
+              (.nonce | type == "string" and test("^[A-Za-z0-9._-]{8,80}$"))
+            ' /tmp/recover-command.json >/dev/null
+            PR_NUMBER="$(jq -r '.prNumber' /tmp/recover-command.json)"
+            COMMAND_EXPECTED_MAIN="$(jq -r '.expectedMain' /tmp/recover-command.json)"
+            COMMAND_EXPECTED_HEAD="$(jq -r '.expectedHead' /tmp/recover-command.json)"
+          fi
+
           [[ "$PR_NUMBER" =~ ^[0-9]+$ ]] || { echo "::error::Pull request number must be numeric."; exit 1; }
           data="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"
           state="$(jq -r '.state' <<< "$data")"
@@ -52,6 +90,13 @@ jobs:
           package="${files[0]}"
           [[ "$package" =~ ^\.github/development-packages/[A-Za-z0-9._/-]+\.py$ ]] || { echo "::error::The sole changed file is not a reviewed development package."; exit 1; }
           main_sha="$(gh api "repos/${GITHUB_REPOSITORY}/branches/main" --jq '.commit.sha')"
+
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            [[ "$main_sha" == "$COMMAND_EXPECTED_MAIN" ]] || { echo "::error::Command main head is stale."; exit 1; }
+            [[ "$head_sha" == "$COMMAND_EXPECTED_HEAD" ]] || { echo "::error::Command pull-request head is stale."; exit 1; }
+          fi
+
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
           echo "branch=$head_ref" >> "$GITHUB_OUTPUT"
           echo "expected_head=$head_sha" >> "$GITHUB_OUTPUT"
           echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
@@ -75,7 +120,7 @@ jobs:
       - name: Reconfirm immutable refs
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ inputs.pr_number }}
+          PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
           BRANCH: ${{ steps.resolve.outputs.branch }}
           EXPECTED_HEAD: ${{ steps.resolve.outputs.expected_head }}
           MAIN_SHA: ${{ steps.resolve.outputs.main_sha }}
@@ -84,7 +129,7 @@ jobs:
         run: |
           set -euo pipefail
           git fetch origin "refs/heads/main:refs/remotes/origin/main" "refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"
-          [[ "$(git rev-parse origin/main)" == "$MAIN_SHA" ]] || { echo "::error::Main moved; dispatch recovery again."; exit 1; }
+          [[ "$(git rev-parse origin/main)" == "$MAIN_SHA" ]] || { echo "::error::Main moved; submit a new recovery command."; exit 1; }
           [[ "$(git rev-parse origin/${BRANCH})" == "$EXPECTED_HEAD" ]] || { echo "::error::Package branch moved."; exit 1; }
           [[ "$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha')" == "$EXPECTED_HEAD" ]] || { echo "::error::Pull request head moved."; exit 1; }
           [[ -f "$PACKAGE_PATH" && ! -L "$PACKAGE_PATH" ]] || { echo "::error::Reviewed package is missing or symbolic."; exit 1; }
@@ -131,7 +176,7 @@ jobs:
       - name: Record recovery success
         env:
           GH_TOKEN: ${{ secrets.DEVELOPMENT_PR_TOKEN }}
-          PR_NUMBER: ${{ inputs.pr_number }}
+          PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
           RESULT_SHA: ${{ steps.publish.outputs.sha }}
         shell: bash
         run: |
@@ -142,8 +187,10 @@ jobs:
         if: failure()
         env:
           GH_TOKEN: ${{ secrets.DEVELOPMENT_PR_TOKEN }}
-          PR_NUMBER: ${{ inputs.pr_number }}
+          PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
         shell: bash
         run: |
           set -euo pipefail
-          gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body "Reviewed development-package recovery failed safely. No validation gate was bypassed. Diagnostics: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" || true
+          if [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body "Reviewed development-package recovery failed safely. No validation gate was bypassed. Diagnostics: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" || true
+          fi

--- a/docs/DEVELOPMENT_PACKAGE_RECOVERY.md
+++ b/docs/DEVELOPMENT_PACKAGE_RECOVERY.md
@@ -1,9 +1,16 @@
 # Reviewed development-package recovery
 
-The normal two-stage `issue_comment` development-package workflow remains the primary path.
+The normal two-stage `issue_comment` development-package workflow remains supported.
 
-When GitHub does not deliver its owner comment event, the owner may manually dispatch **Recover Reviewed Development Package** with the number of an existing pull request. The recovery lane is deliberately narrower than the normal path:
+When GitHub does not deliver its owner comment event, **Recover Reviewed Development Package** accepts either:
 
+- an owner `workflow_dispatch`; or
+- a connector-authenticated push that changes only `.github/automation-commands/recover-development-package.json` on `automation/development-packages`.
+
+The push command must identify the pull request, exact current `main` SHA, exact package pull-request head SHA and a unique nonce. The recovery lane remains deliberately narrow:
+
+- the command actor must be `Conroy1988`;
+- a push command commit may change only the exact command file;
 - the pull request must be open, owned by `Conroy1988`, hosted in this repository and target `main`;
 - the head branch must use the reviewed `feature/`, `fix/` or `chore/` namespaces;
 - the pull request must contain exactly one changed file under `.github/development-packages/`;
@@ -13,4 +20,4 @@ When GitHub does not deliver its owner comment event, the owner may manually dis
 - publication uses `DEVELOPMENT_PR_TOKEN` and an exact force-with-lease against the captured pull-request head;
 - the workflow cannot push to public `main` and cannot create a branch, issue or pull request.
 
-This is a manually owner-dispatched recovery transport, not an alternate validation standard. A resulting product candidate must still pass the normal pull-request Hotfix Gate before merge and the normal guarded release process before publication.
+This is a connector-triggerable recovery transport, not an alternate validation standard. A resulting product candidate must still pass the normal pull-request Hotfix Gate before merge. Release-candidate pull requests continue through the existing automatic post-merge guarded release pipeline.


### PR DESCRIPTION
## Objective

Remove routine owner interaction from reviewed development-package recovery.

## Change

- retain the existing owner `workflow_dispatch` path;
- add a push-command path on `automation/development-packages`;
- accept only a commit changing `.github/automation-commands/recover-development-package.json`;
- require actor `Conroy1988`, schema validation, nonce, exact current `main` SHA and exact package PR head SHA;
- retain open same-repository owner PR checks, package-only scope, reviewed branch namespaces, canonical validation and exact force-with-lease publication;
- retain the prohibition on public-main writes.

## Result

The assistant can trigger reviewed-package recovery through an authenticated connector write. Daniel no longer needs to open Actions or click **Run workflow** for routine recovery.

Implements the recovery portion of #578. No Toolkit product source or production release state changes.