### PR TITLE
Pipeline: Allow connector-triggered guarded releases

### DIFF
--- a/.github/connector-release-command-policy.json
+++ b/.github/connector-release-command-policy.json
@@ -1,0 +1,34 @@
+{
+  "schemaVersion": 1,
+  "workflow": ".github/workflows/owner-release-command.yml",
+  "supportedTransports": [
+    "owner issue comment",
+    "connector-authenticated push command"
+  ],
+  "commandTransport": {
+    "branch": "automation/releases",
+    "path": ".github/automation-commands/release-toolkit.json",
+    "actor": "Conroy1988",
+    "changedFiles": 1,
+    "directChildOfExpectedMain": true,
+    "exactCurrentMain": true,
+    "nonceRequired": true,
+    "confirmation": "RELEASE"
+  },
+  "requiredValidation": [
+    "exact authorized main checkout",
+    "fresh canonical userscript validation",
+    "JavaScript syntax",
+    "source and distribution parity",
+    "mandatory release readiness",
+    "guarded production release"
+  ],
+  "prohibited": [
+    "arbitrary command paths",
+    "arbitrary shell payloads",
+    "stale main heads",
+    "multi-file command commits",
+    "release bypass",
+    "replay after GitHub Release creation"
+  ]
+}

--- a/.github/scripts/test_connector_release_command.py
+++ b/.github/scripts/test_connector_release_command.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Security contract for connector-triggered guarded Toolkit releases."""
+from pathlib import Path
+import json
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github/workflows/owner-release-command.yml"
+POLICY = ROOT / ".github/connector-release-command-policy.json"
+
+
+def main() -> int:
+    source = WORKFLOW.read_text(encoding="utf-8")
+    for marker in [
+        "issue_comment:",
+        "push:",
+        "automation/releases",
+        ".github/automation-commands/release-toolkit.json",
+        "github.actor == 'Conroy1988'",
+        "A connector release command commit must change only",
+        '.command == "release-toolkit"',
+        '.confirmation == "RELEASE"',
+        "Release command must be a direct child of the expected main commit.",
+        "Release command main head is stale.",
+        "Main moved after release authorization.",
+        "GitHub Release v${VERSION} already exists.",
+        "python3 .github/scripts/validate_userscript.py",
+        'node --check "$SOURCE"',
+        "release-readiness-check.yml",
+        "release-toolkit.yml",
+        "confirmation: RELEASE",
+        "MIGRATION_REPO_TOKEN",
+        "DISCORD_RELEASE_WEBHOOK",
+    ]:
+        assert marker in source, marker
+
+    for forbidden in [
+        "pull_request_target",
+        "secrets: inherit",
+        "eval ",
+        "bash -c",
+        "HEAD:main",
+        "HEAD:refs/heads/main",
+    ]:
+        assert forbidden not in source, forbidden
+
+    policy = json.loads(POLICY.read_text(encoding="utf-8"))
+    command = policy["commandTransport"]
+    assert command["branch"] == "automation/releases"
+    assert command["changedFiles"] == 1
+    assert command["directChildOfExpectedMain"] is True
+    assert command["exactCurrentMain"] is True
+    assert command["nonceRequired"] is True
+    assert command["confirmation"] == "RELEASE"
+    assert "mandatory release readiness" in policy["requiredValidation"]
+    assert "guarded production release" in policy["requiredValidation"]
+    print("Connector-triggered guarded release contract passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/owner-release-command.yml
+++ b/.github/workflows/owner-release-command.yml
@@ -3,6 +3,11 @@ name: Owner Release Command
 on:
   issue_comment:
     types: [created]
+  push:
+    branches:
+      - automation/releases
+    paths:
+      - .github/automation-commands/release-toolkit.json
 
 permissions:
   actions: write
@@ -17,37 +22,93 @@ jobs:
   authorize:
     name: Authorize and freshly validate owner release command
     if: >-
-      github.event.issue.pull_request == null &&
-      startsWith(github.event.comment.body, '/release-toolkit ')
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request == null &&
+       startsWith(github.event.comment.body, '/release-toolkit ')) ||
+      (github.event_name == 'push' &&
+       github.actor == 'Conroy1988')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     outputs:
       version: ${{ steps.command.outputs.version }}
+      issue_number: ${{ steps.command.outputs.issue_number }}
+      expected_main: ${{ steps.command.outputs.expected_main }}
 
     steps:
-      - name: Authorize owner command
+      - name: Authorize exact owner command
         id: command
         env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_REF: ${{ github.ref }}
+          EVENT_SHA: ${{ github.sha }}
+          EVENT_ACTOR: ${{ github.actor }}
           COMMENT_BODY: ${{ github.event.comment.body }}
           COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
           AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association }}
+          COMMENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
+          COMMAND_PATH: .github/automation-commands/release-toolkit.json
         shell: bash
         run: |
           set -euo pipefail
-          [[ "$COMMENT_AUTHOR" == "Conroy1988" ]] || { echo "::error::Only Conroy1988 may dispatch a production release."; exit 1; }
-          [[ "$AUTHOR_ASSOCIATION" == "OWNER" ]] || { echo "::error::Release command author is not the repository owner."; exit 1; }
-          if [[ "$COMMENT_BODY" =~ ^/release-toolkit[[:space:]]+([0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?)[[:space:]]+RELEASE[[:space:]]*$ ]]; then
-            VERSION="${BASH_REMATCH[1]}"
+          VERSION=""
+          ISSUE_NUMBER=""
+          EXPECTED_MAIN=""
+
+          if [[ "$EVENT_NAME" == "issue_comment" ]]; then
+            [[ "$COMMENT_AUTHOR" == "Conroy1988" ]] || { echo "::error::Only Conroy1988 may dispatch a production release."; exit 1; }
+            [[ "$AUTHOR_ASSOCIATION" == "OWNER" ]] || { echo "::error::Release command author is not the repository owner."; exit 1; }
+            if [[ "$COMMENT_BODY" =~ ^/release-toolkit[[:space:]]+([0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?)[[:space:]]+RELEASE[[:space:]]*$ ]]; then
+              VERSION="${BASH_REMATCH[1]}"
+            else
+              echo "::error::Expected: /release-toolkit X.Y.Z RELEASE"
+              exit 1
+            fi
+            ISSUE_NUMBER="$COMMENT_ISSUE_NUMBER"
+            EXPECTED_MAIN="$(gh api "repos/${GITHUB_REPOSITORY}/branches/main" --jq '.commit.sha')"
+          elif [[ "$EVENT_NAME" == "push" ]]; then
+            [[ "$EVENT_ACTOR" == "Conroy1988" ]] || { echo "::error::Only Conroy1988 may submit a connector release command."; exit 1; }
+            [[ "$EVENT_REF" == "refs/heads/automation/releases" ]] || { echo "::error::Connector release commands are accepted only from automation/releases."; exit 1; }
+
+            mapfile -t command_files < <(gh api "repos/${GITHUB_REPOSITORY}/commits/${EVENT_SHA}" --jq '.files[].filename')
+            [[ "${#command_files[@]}" -eq 1 && "${command_files[0]}" == "$COMMAND_PATH" ]] || {
+              echo "::error::A connector release command commit must change only ${COMMAND_PATH}."
+              exit 1
+            }
+
+            gh api "repos/${GITHUB_REPOSITORY}/contents/${COMMAND_PATH}?ref=${EVENT_SHA}" \
+              --jq '.content' | tr -d '\n' | base64 --decode > /tmp/release-command.json
+            jq -e '
+              .schemaVersion == 1 and
+              .command == "release-toolkit" and
+              (.version | type == "string" and test("^[0-9]+\\.[0-9]+\\.[0-9]+([+-][0-9A-Za-z.-]+)?$")) and
+              .confirmation == "RELEASE" and
+              (.expectedMain | type == "string" and test("^[0-9a-f]{40}$")) and
+              (.issueNumber | type == "number" and . > 0 and floor == .) and
+              (.nonce | type == "string" and test("^[A-Za-z0-9._-]{8,80}$"))
+            ' /tmp/release-command.json >/dev/null
+
+            VERSION="$(jq -r '.version' /tmp/release-command.json)"
+            ISSUE_NUMBER="$(jq -r '.issueNumber' /tmp/release-command.json)"
+            EXPECTED_MAIN="$(jq -r '.expectedMain' /tmp/release-command.json)"
+            PARENT_SHA="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${EVENT_SHA}" --jq 'if (.parents | length) == 1 then .parents[0].sha else "" end')"
+            CURRENT_MAIN="$(gh api "repos/${GITHUB_REPOSITORY}/branches/main" --jq '.commit.sha')"
+            [[ "$PARENT_SHA" == "$EXPECTED_MAIN" ]] || { echo "::error::Release command must be a direct child of the expected main commit."; exit 1; }
+            [[ "$CURRENT_MAIN" == "$EXPECTED_MAIN" ]] || { echo "::error::Release command main head is stale."; exit 1; }
           else
-            echo "::error::Expected: /release-toolkit X.Y.Z RELEASE"
+            echo "::error::Unsupported release command event."
             exit 1
           fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Check out current main without write credentials
+          [[ "$ISSUE_NUMBER" =~ ^[0-9]+$ ]] || { echo "::error::Release issue number must be numeric."; exit 1; }
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "issue_number=$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "expected_main=$EXPECTED_MAIN" >> "$GITHUB_OUTPUT"
+
+      - name: Check out exact authorized main candidate
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
-          ref: main
+          ref: ${{ steps.command.outputs.expected_main }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -55,9 +116,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.command.outputs.version }}
+          EXPECTED_MAIN: ${{ steps.command.outputs.expected_main }}
         shell: bash
         run: |
           set -euo pipefail
+          git fetch origin main --prune
+          [[ "$(git rev-parse HEAD)" == "$EXPECTED_MAIN" ]] || { echo "::error::Checked-out candidate differs from the authorized main head."; exit 1; }
+          [[ "$(git rev-parse origin/main)" == "$EXPECTED_MAIN" ]] || { echo "::error::Main moved after release authorization."; exit 1; }
+
           SOURCE="src/MissionChief_Map_Command_Toolkit.user.js"
           grep -Eq "^//[[:space:]]*@version[[:space:]]+${VERSION//./\.}[[:space:]]*$" "$SOURCE"
           if gh release view "v${VERSION}" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
@@ -71,16 +137,17 @@ jobs:
           test "$(jq -r '.version' dist/release-manifest.json)" = "$VERSION"
           HASH="$(jq -r '.sha256' dist/release-manifest.json)"
           test "$(sha256sum "$SOURCE" | awk '{print $1}')" = "$HASH"
-          echo "Owner-authorized candidate v${VERSION} freshly validated from current main at $(git rev-parse HEAD)."
+          echo "Owner-authorized candidate v${VERSION} freshly validated from exact main ${EXPECTED_MAIN}."
 
       - name: Record guarded release start
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.command.outputs.version }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_NUMBER: ${{ steps.command.outputs.issue_number }}
+          EXPECTED_MAIN: ${{ steps.command.outputs.expected_main }}
         shell: bash
         run: |
-          gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body "Toolkit v${VERSION} passed owner authorization and a fresh canonical validation of current main. The native reusable release-readiness workflow is starting; production cannot begin unless it succeeds. Owner-command run: \`${GITHUB_RUN_ID}\`."
+          gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body "Toolkit v${VERSION} passed owner authorization and fresh canonical validation of exact main \`${EXPECTED_MAIN}\`. Mandatory release readiness is starting; production cannot begin unless it succeeds. Owner-command run: \`${GITHUB_RUN_ID}\`."
 
   readiness:
     name: Run mandatory release readiness
@@ -122,17 +189,17 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.authorize.outputs.version }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_NUMBER: ${{ needs.authorize.outputs.issue_number }}
         shell: bash
         run: |
-          gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body "Toolkit v${VERSION} completed mandatory readiness and the guarded production release as native reusable workflows in Actions run \`${GITHUB_RUN_ID}\`. GitHub Release, Greasy Fork verification, private backup, Discord publication, dashboard reconciliation, stable manifest publication and documentation deployment are owned by the completed production workflow."
+          gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body "Toolkit v${VERSION} completed mandatory readiness and the guarded production release in Actions run \`${GITHUB_RUN_ID}\`. GitHub Release, Greasy Fork verification, private backup, Discord publication, dashboard reconciliation, stable manifest publication and documentation deployment were completed by the production workflow."
 
       - name: Record guarded failure
         if: needs.readiness.result != 'success' || needs.production.result != 'success'
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.authorize.outputs.version }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_NUMBER: ${{ needs.authorize.outputs.issue_number }}
           READINESS_RESULT: ${{ needs.readiness.result }}
           PRODUCTION_RESULT: ${{ needs.production.result }}
         shell: bash

--- a/docs/CONNECTOR_RELEASE_COMMAND.md
+++ b/docs/CONNECTOR_RELEASE_COMMAND.md
@@ -1,0 +1,15 @@
+# Connector-triggered guarded Toolkit release
+
+The existing owner issue-comment command remains supported. Routine releases may also be started without owner interaction by pushing one exact command file to `automation/releases`.
+
+The command commit must:
+
+- be created by `Conroy1988`;
+- change only `.github/automation-commands/release-toolkit.json`;
+- be a direct child of the exact expected current `main` commit;
+- request an exact Toolkit version and existing tracking issue;
+- include `confirmation: RELEASE` and a unique nonce.
+
+The workflow then checks out the exact authorized `main` commit, reconfirms that `main` has not moved, rejects an existing release tag, performs fresh canonical validation, verifies JavaScript syntax and distribution parity, runs mandatory release readiness, and invokes the existing guarded production release workflow.
+
+The command contains data only. It cannot select a workflow, branch target, shell command, repository, release implementation or validation bypass. Replay is rejected after the GitHub Release exists.


### PR DESCRIPTION
## Objective

Complete #578 by removing the final routine owner interaction from guarded Toolkit releases.

## Transport

- retain the existing owner issue-comment command;
- add a connector-authenticated push command on `automation/releases`;
- accept only `.github/automation-commands/release-toolkit.json`;
- require a single-file command commit created by `Conroy1988`;
- require the command commit to be a direct child of the exact expected current `main` commit;
- require exact version, issue number, `RELEASE` confirmation and nonce.

## Preserved release authority

The command contains data only. It still performs fresh canonical validation and then invokes the existing mandatory release-readiness and guarded production-release workflows, including GitHub Release, Greasy Fork verification, private backup, Discord publication and reconciliation.

No Toolkit product source changes. This is the release half of #578.