### PR TITLE
Rebuild the Toolkit README as a UK emergency command network

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,185 +1,141 @@
 <div align="center">
 
-<img src="docs/media/readme-hero.svg" alt="MissionChief Map Command Toolkit realistic UK multi-agency emergency response scene" width="100%">
+<img src="docs/media/readme-hero.svg" alt="MissionChief Map Command Toolkit United Kingdom emergency command network" width="100%">
 
 # MissionChief Map Command Toolkit
 
-### **A realistic UK emergency-command network for the MissionChief map**
+### **The operational command layer for the MissionChief map**
 
-**Incident command · Mission intelligence · Fleet identity · Native transport · Geographic control · Financial reconciliation**
+**See the incident · Read the fleet · Control the map · Reconcile the operation**
 
-[![Install now](https://img.shields.io/badge/INSTALL_NOW-GREASY_FORK-8B0000?style=for-the-badge&logo=tampermonkey&logoColor=white)](https://update.greasyfork.org/scripts/586018/MissionChief%20Map%20Command%20Toolkit.user.js)
-[![Open documentation](https://img.shields.io/badge/OPEN-DOCUMENTATION-126782?style=for-the-badge&logo=readthedocs&logoColor=white)](https://conroy1988.github.io/missionchief-toolkit-assets/)
-[![Explore interfaces](https://img.shields.io/badge/EXPLORE-8_COMMAND_INTERFACES-D49B24?style=for-the-badge&logo=palette&logoColor=white)](https://conroy1988.github.io/missionchief-toolkit-assets/themes/)
-[![Release control](https://img.shields.io/badge/OPEN-RELEASE_CONTROL-22272E?style=for-the-badge&logo=githubactions&logoColor=white)](status/README.md)
+<table>
+<tr>
+<td width="25%" align="center"><a href="https://update.greasyfork.org/scripts/586018/MissionChief%20Map%20Command%20Toolkit.user.js"><strong>⬇ INSTALL / UPDATE</strong><br><sub>Greasy Fork stable channel</sub></a></td>
+<td width="25%" align="center"><a href="https://conroy1988.github.io/missionchief-toolkit-assets/"><strong>📘 OPEN THE GUIDE</strong><br><sub>Features, setup and operation</sub></a></td>
+<td width="25%" align="center"><a href="https://conroy1988.github.io/missionchief-toolkit-assets/themes/"><strong>🎛 EXPLORE INTERFACES</strong><br><sub>Eight complete command systems</sub></a></td>
+<td width="25%" align="center"><a href="status/README.md"><strong>✓ RELEASE CONTROL</strong><br><sub>Verified production state</sub></a></td>
+</tr>
+</table>
 
-## **Current verified release: `v8.0.3` · Development candidate: `v8.0.4`**
-### **Godfather duration and payout-position hotfix**
+## **Verified production release: `v8.2.7`**
+
+### **Patient Transport Sweep — native Cancel Transport control correction**
 
 [![GitHub release](https://img.shields.io/github/v/release/Conroy1988/missionchief-toolkit-assets?display_name=release&label=RELEASE&color=2563eb)](https://github.com/Conroy1988/missionchief-toolkit-assets/releases/latest)
 [![Greasy Fork](https://img.shields.io/greasyfork/v/586018?label=GREASY%20FORK&color=670000)](https://greasyfork.org/en/scripts/586018-missionchief-map-command-toolkit)
 [![Installs](https://img.shields.io/greasyfork/dt/586018?label=INSTALLS&color=0f766e)](https://greasyfork.org/en/scripts/586018-missionchief-map-command-toolkit)
-[![Stars](https://img.shields.io/github/stars/Conroy1988/missionchief-toolkit-assets?style=flat&color=ca8a04)](https://github.com/Conroy1988/missionchief-toolkit-assets/stargazers)
-[![Viewed](https://komarev.com/ghpvc/?username=Conroy1988-missionchief-toolkit-assets&label=VIEWED&color=7b6cf6&style=flat)](https://github.com/Conroy1988/missionchief-toolkit-assets)
 [![Canonical validation](https://github.com/Conroy1988/missionchief-toolkit-assets/actions/workflows/validate-userscript.yml/badge.svg)](https://github.com/Conroy1988/missionchief-toolkit-assets/actions/workflows/validate-userscript.yml)
 [![Licence](https://img.shields.io/badge/LICENCE-MIT-111827)](#licence-and-attribution)
 
-[**Command briefing**](#command-network-briefing) · [**Current release**](#current-release-signal--v803) · [**Incident Wire**](#incident-command-wire) · [**Systems**](#native-command-divisions) · [**Interfaces**](#eight-complete-interface-systems) · [**Devices**](#field-terminal-coverage) · [**Install**](#deployment-channel) · [**Release control**](#release--recovery-control)
+[**Command brief**](#command-brief) · [**Current release**](#current-release--v827) · [**Systems**](#operational-divisions) · [**Interfaces**](#eight-complete-interface-systems) · [**Devices**](#field-terminal-coverage) · [**Install**](#install-and-update) · [**Release control**](#release-and-recovery-control)
 
 </div>
 
 ---
 
-# v8.0.3 hotfix signal
+## Command brief
 
-> **CRITICAL GODFATHER DURATION AND PAYOUT-POSITION REPAIR // DEVELOPMENT BRANCH ONLY**
+MissionChief spreads operational information across the map, mission windows, vehicle tables, alliance pages, transport requests and finance views.
 
-The verified production release is **v8.0.2**. Candidate **v8.0.3** defaults the Godfather Offer flash to seven seconds when the normal four-second default is still active, preserves non-default user choices, and raises/compacts the payout on short-height layouts so the complete banner clears the command dock. Production remains on v8.0.2 until the guarded hotfix release completes.
-
----
-
-# Command network briefing
-
-> **UK EMERGENCY COMMAND NETWORK // SYSTEM STATUS: OPERATIONAL**
-
-MissionChief distributes operational information across the map, opened incidents, vehicle tables, transport requests, alliance pages, finance views and separate navigation surfaces.
-
-**MissionChief Map Command Toolkit converts those native signals into one configurable command network.** It helps the player see urgent work, read fleet capability, command geographic context, operate selected transport workflows and reconcile performance—without replacing MissionChief's own mission windows or dispatch controls.
+**MissionChief Map Command Toolkit converts those native signals into one configurable command layer.** It improves situational awareness, fleet readability, map context, selected transport workflows and financial reconciliation without replacing MissionChief’s own mission windows or dispatch controls.
 
 <table>
 <tr>
-<td width="25%" align="center"><strong>🚨 INCIDENT</strong><br><sub>Broadcast priority work through one bounded command wire.</sub></td>
-<td width="25%" align="center"><strong>🚒 FLEET</strong><br><sub>Read response codes, custom identity and nearby capability.</sub></td>
-<td width="25%" align="center"><strong>🗺️ MAP</strong><br><sub>Turn range, location and saved places into command context.</sub></td>
-<td width="25%" align="center"><strong>📟 CONTROL</strong><br><sub>Keep every feature bounded, restorable and device-aware.</sub></td>
+<td width="25%" align="center"><strong>🚨 INCIDENT</strong><br><sub>Priority awareness through one bounded Incident Command Wire.</sub></td>
+<td width="25%" align="center"><strong>🚒 FLEET</strong><br><sub>Response codes, custom identity and nearby resource context.</sub></td>
+<td width="25%" align="center"><strong>🗺 MAP</strong><br><sub>Coverage, saved places and mission geography made operational.</sub></td>
+<td width="25%" align="center"><strong>📊 CONTROL</strong><br><sub>Financial intelligence, recovery evidence and device-aware layouts.</sub></td>
 </tr>
 </table>
 
-> **CONTROL-ROOM DOCTRINE:** see the signal, understand the source, act through the correct native control, and leave the page recoverable.
+> **Command doctrine:** expose the signal, preserve the source, act through the correct native control, and leave the page recoverable.
 
 <div align="center">
 
-<img src="docs/media/readme-command-board.svg" alt="MissionChief Toolkit realistic United Kingdom multi-agency operational picture" width="100%">
+<img src="docs/media/readme-command-board.svg" alt="MissionChief Map Command Toolkit operational divisions surrounding the central product identity" width="100%">
 
 </div>
 
 ---
 
-# Live dispatch status
+## Current release — v8.2.7
 
-> **CHANNEL STATUS // VERIFIED PRODUCTION SIGNALS**
+### Patient Transport Sweep — click the real Cancel Transport control
 
-| Control channel | State | Evidence |
-|---|:---:|---|
-| **Canonical source** | 🟢 | Validated `src/MissionChief_Map_Command_Toolkit.user.js` |
-| **Production release** | 🟢 | GitHub Release `v8.0.3` published |
-| **Public distribution** | 🟢 | Greasy Fork version and metadata verified |
-| **Private recovery** | 🟢 | Versioned recovery commit retained |
-| **Discord release signal** | 🟢 | Verified release announcement posted |
-| **Hosted media** | 🟢 | Current release snapshot: 37 discovered · 33 referenced · 0 missing |
-| **Responsive command** | 🟢 | Desktop · Tablet/iPad · iPhone/iPad Safari |
+Version `8.2.7` corrects the native Patient Transport Sweep workflow when MissionChief opens the vehicle window but does not automatically activate the visible release control.
 
-The [Release Control Panel](status/README.md) is machine-backed from the current release ledger rather than manually asserted.
+- Discovers native release controls rendered as links, buttons or submit inputs.
+- Accepts both current MissionChief labels: **Cancel Transport** and **Discharge patient**.
+- Captures the original label before clicking so an unchanged label cannot be mistaken for completion.
+- Still requires **Patient isn’t transported**, control removal, control disablement or a genuine post-click transition before success is recorded.
+- Adds no request, observer, interval or Toolkit-managed timer.
+- Preserves own-vehicle exclusion, bounded waits, sequential processing, cancellation and duplicate protection.
 
----
-
-# Current release signal — v8.0.2
-
-> **CHANNEL UPDATE // GODFATHER LAYOUT AND PAYOUT AUDIO**
-
-Version 8.0.2 contained the decorative family seal, restored compact Tablet controls, raised the Offer payout and replaced its audio byte-for-byte with the verified stereo MP3.
-
-- The exact replacement audio remains protected by digest, byte-size, channel and bitrate contracts.
-- The v7 native MissionChief boundary and every retained operational system remain in force.
-- Candidate v8.0.3 adds the seven-second Godfather default and short-height dock-clearance repair.
+The verified release state, SHA-256 identity, public distribution and private recovery evidence are recorded in the [Release Control Panel](status/README.md).
 
 ---
 
-# Incident Command Wire
+## Operational divisions
 
-> **CHANNEL 01 // LIVE INCIDENT BROADCAST**
-
-The Incident Command Wire provides persistent situational awareness without becoming a second mission list.
-
-- priority incidents move continuously from right to left at a constant broadcast speed;
-- an accessibility-safe duplicate sequence removes empty gaps and visible loop jumps;
-- the fixed **Incident Command** identity remains separate from moving incident data;
-- one expanded queue control supports deliberate incident selection;
-- direct click-to-zoom navigation opens the relevant map position;
-- the complete incident row remains centred across all eight interfaces and supported layouts; and
-- reduced-motion, hidden-tab and Economy Mode conditions suppress non-essential movement.
-
-Permanent source and executable contracts protect loop ownership, dynamic speed, seeking and accessibility.
-
----
-
-# Native command divisions
-
-## 🔵 Channel 02 — Mission control
+### Mission command
 
 | Capability | Operational purpose |
 |---|---|
-| **Incident Command Wire** | Broadcasts the highest-priority incident sequence with an expanded queue and direct navigation |
+| **Incident Command Wire** | Broadcasts the priority incident sequence with an expanded queue and direct map navigation |
 | **Mission Age map timers** | Adds compact age badges above personal missions; shortcut `6` toggles the surface |
 | **Mission Value** | Shows verified mission value inside opened MissionChief windows |
 | **Unit Commitment** | Presents committed response context without replacing native dispatch controls |
 | **Transport Watcher** | Identifies patient and prisoner transport demand |
 
-## 🟢 Channel 03 — Fleet and transport control
+### Fleet and transport command
 
 | Capability | Operational purpose |
 |---|---|
 | **Vehicle Code Status** | Summarises the live fleet by response code, description and count |
 | **Custom Vehicle Badges** | Shows Own Vehicle Categories beside native vehicle types without replacing native identity |
-| **Auto-load all vehicles** | Uses MissionChief's native hidden-vehicle batch control |
-| **Patient Transport Sweep** | Processes eligible alliance ambulances through MissionChief's native vehicle window and discharge control |
+| **Auto-load all vehicles** | Uses MissionChief’s native hidden-vehicle batch control |
+| **Patient Transport Sweep** | Processes eligible alliance patient vehicles through MissionChief’s native vehicle and release controls |
 | **Resource Gap** | Compares active demand with nearby personal vehicle availability |
 
-Patient Transport Sweep remains deliberately bounded. It preserves ownership checks, confirmation evidence, idempotent counters and native discharge controls. It is not a generic click engine and does not create arbitrary vehicle actions.
+Patient Transport Sweep remains deliberately bounded. It uses MissionChief-owned windows and controls, verifies the native result, and stops safely when authoritative evidence does not change.
 
-## 🟡 Channel 04 — Map and place control
+### Map and place command
 
 | Capability | Operational purpose |
 |---|---|
-| **Coverage rings** | Adds readable range context around selected locations |
+| **Coverage rings** | Adds readable response-range context around selected locations |
 | **Smart Bookmark Labels** | Creates compact place labels, pins and touch previews |
-| **Profiles and layouts** | Preserves distinct command presentations without changing MissionChief's underlying data |
-| **Responsive modes** | Reflows the command surface for desktop, tablet/iPad and iOS Mobile Mode |
+| **Profiles and layouts** | Preserves distinct command presentations without changing MissionChief data |
+| **Responsive modes** | Reflows the command surface for Desktop, Tablet and iOS Mobile Mode |
 
-## 🔴 Channel 05 — Financial control
+### Finance and recovery command
 
 | Capability | Operational purpose |
 |---|---|
-| **Alliance Credits** | Adds mission value and eligibility-aware alliance filtering |
-| **Income and spending analysis** | Builds daily, weekly, monthly and custom-period performance context |
+| **Alliance Credits** | Adds mission-value and eligibility-aware alliance filtering |
+| **Financial intelligence** | Builds daily, weekly, monthly and custom-period performance context |
 | **Reconciliation checkpoints** | Anchors complete periods to MissionChief revenue, spending and sum evidence |
 | **Variance preservation** | Keeps unexplained differences visible instead of inventing classifications |
 | **Payout presentations** | Provides optional visual and audio payout feedback with reduced-motion controls |
-| **Discord reporting** | Sends the reconciled model through the saved Discord webhook configured by the user |
+| **Discord reporting** | Sends the reconciled model only through the saved Discord webhook configured by the user |
 
 ---
 
-# The One We Knew Before
+## The One We Knew Before
 
-> **PRODUCT BOUNDARY // MISSIONCHIEF REMAINS AUTHORITATIVE**
+Version 7 restored the Toolkit’s product boundary, and the v8 line continues it:
 
-Version 7 restored a clear product boundary. The Toolkit no longer owns a copied global mission-window stack. That retired code, its settings, stored state, observers, timers, listeners, schedulers, DOM transforms, compatibility hooks and teardown paths were removed rather than hidden.
-
-| v7 decision | Operational result |
+| Boundary | Operational result |
 |---|---|
-| **MissionChief remains authoritative** | Native mission windows, mission lists and dispatch controls stay in charge |
-| **Retired lifecycle ownership was deleted** | Less recurring work and a smaller failure surface |
-| **Independent Toolkit systems were protected** | Mission, fleet, transport, map, finance, interfaces and responsive modes remain independently useful |
-| **Retirement contracts were added** | Validation fails if the removed integration is accidentally reintroduced |
-| **The product identity was restored** | Toolkit remains a focused map-command and operational-intelligence layer |
-
-The v7.1 line advances that native boundary through Incident Command Wire and guarded transport progress rather than rebuilding a competing global interface.
+| **MissionChief remains authoritative** | Native mission windows, lists and dispatch controls stay in charge |
+| **Retired lifecycle ownership stays deleted** | Removed observers, timers, listeners, settings and DOM transforms do not return |
+| **Independent Toolkit systems remain protected** | Mission, fleet, transport, map, finance, interfaces and responsive modes remain independently useful |
+| **Retirement contracts remain executable** | Validation fails if removed integration code is accidentally reintroduced |
+| **The product identity stays focused** | The Toolkit remains a map-command and operational-intelligence layer |
 
 ---
 
-# Runtime command discipline
-
-> **PERFORMANCE CONTROL // FAST SIGNALS, BOUNDED OWNERSHIP, DETERMINISTIC TEARDOWN**
+## Runtime command discipline
 
 A command tool that slows the incident map is not a command tool.
 
@@ -189,23 +145,18 @@ A command tool that slows the incident map is not a command tool.
 - Map, command and responsive state use deterministic teardown and restoration.
 - **Economy Mode** suppresses non-essential work while retaining core information.
 - Reduced-motion preferences remove presentation overhead without hiding operational facts.
-- Incident Command motion has explicit ownership and pause conditions.
 - Source contracts protect observer, timer, listener, selector and retired-feature budgets.
-
-The target is not the largest possible feature list. It is the strongest useful command surface at a controlled runtime cost.
 
 ---
 
-# Eight complete interface systems
-
-> **INTERFACE NETWORK // SAME OPERATIONAL CONTRACT, EIGHT COMMAND LANGUAGES**
+## Eight complete interface systems
 
 Every interface presents the same retained capability and stored configuration. The visual language changes; the operational contract does not.
 
 | Interface | Command-room character |
 |---|---|
 | **Map Command** | Clean cyan telemetry and modern dispatch-console readability |
-| **Cyberpunk** | Neon incident signalling, angular telemetry and high-contrast warnings |
+| **Cyberpunk** | Neon incident signalling and angular high-contrast controls |
 | **Fallout 4** | Green phosphor terminals and industrial emergency-survival controls |
 | **Umbrella** | Clinical containment, black surfaces and red-alert discipline |
 | **Factorio** | Machinery panels, amber controls and production-line logic |
@@ -217,9 +168,7 @@ Inactive interfaces do not run theme-specific effects. [Explore all eight interf
 
 ---
 
-# Field terminal coverage
-
-> **FIELD TERMINALS // DESKTOP · TABLET · iOS**
+## Field terminal coverage
 
 | Mode | Designed behaviour |
 |---|---|
@@ -230,19 +179,17 @@ Inactive interfaces do not run theme-specific effects. [Explore all eight interf
 | **iPad Safari** | Split-view resilience, desktop-site awareness, visual-viewport fitting and orientation recovery |
 | **Economy / reduced motion** | Complete command information with non-essential movement removed |
 
-Responsive behaviour is part of the feature contract—not a cosmetic patch applied after desktop development.
+Responsive behaviour is part of the feature contract—not a cosmetic patch added after desktop development.
 
 ---
 
-# Deployment channel
+## Install and update
 
-> **GREASY FORK STABLE // INSTALL IN UNDER A MINUTE**
-
-1. Install **Tampermonkey** or a compatible userscript manager.
-2. Open the verified public installer: **[Install MissionChief Map Command Toolkit](https://update.greasyfork.org/scripts/586018/MissionChief%20Map%20Command%20Toolkit.user.js)**.
+1. Install **Tampermonkey** or another compatible userscript manager.
+2. Open the verified installer: **[Install MissionChief Map Command Toolkit](https://update.greasyfork.org/scripts/586018/MissionChief%20Map%20Command%20Toolkit.user.js)**.
 3. Confirm installation and reload MissionChief.
 4. Open the Toolkit command button on the map.
-5. Enable only the command systems useful to the current account, device and workflow.
+5. Enable only the systems useful to the current account, device and workflow.
 
 > [!IMPORTANT]
 > **Greasy Fork is the supported installation and automatic-update channel.** GitHub is the canonical source, validation authority, documentation host and immutable release archive.
@@ -259,105 +206,60 @@ Responsive behaviour is part of the feature contract—not a cosmetic patch appl
 
 ---
 
-# Release & recovery control
-
-> **RELEASE NETWORK // GOVERNED SOURCE · VERIFIED RELEASE · RECOVERABLE DELIVERY**
+## Release and recovery control
 
 <div align="center">
 
-<img src="docs/media/readme-release-control.svg" alt="MissionChief Toolkit realistic UK release and recovery operations centre" width="100%">
+<img src="docs/media/readme-release-control.svg" alt="MissionChief Map Command Toolkit verified release and recovery control room" width="100%">
 
 </div>
 
-## Current verified identity
+### Current verified identity
 
 | Field | Verified value |
 |---|---|
-| **Version** | `8.0.3` |
-| **Release focus** | Godfather seven-second duration and dock-clearance hotfix |
+| **Version** | `8.2.7` |
+| **Release focus** | Native Cancel Transport and Discharge patient control activation |
 | **Canonical source** | `src/MissionChief_Map_Command_Toolkit.user.js` |
-| **Validated SHA-256** | `773d6686fdcfe0af5901f54bdd58c58cf0ef8503bddaae354f32ed25879ac19b` |
-| **GitHub Release** | [`v8.0.3`](https://github.com/Conroy1988/missionchief-toolkit-assets/releases/tag/v8.0.3) |
+| **Validated SHA-256** | `f686888356d3a8498782a1e656c855db7ce445f38a11a4c68909b0163e5adc38` |
+| **GitHub Release** | [`v8.2.7`](https://github.com/Conroy1988/missionchief-toolkit-assets/releases/tag/v8.2.7) |
 | **Greasy Fork** | Verified against the stable release |
-| **Private backup** | `be6f8a187c4215053a5619acedce31b7f308577a` |
+| **Private backup** | `ee93565fb4ae0aef9c4a82308c392379ea1b598c` |
 | **Discord release delivery** | Posted |
-| **Hosted media audit** | Current release snapshot: 37 discovered · 33 referenced · 0 missing |
-
-## Governed release topology
+| **Hosted media audit** | 37 discovered · 33 referenced · 0 missing |
 
 ```text
-Issue-scoped development on main
-              ↓
-Pull request and executable contracts
-              ↓
-Exact-source validation artefact
-              ↓
-Governed release-state ledger
-              ↓
-Stable distribution publication
-              ↓
-GitHub Release + Greasy Fork verification
-              ↓
+Canonical source
+      ↓
+Exact-head validation
+      ↓
+Immutable GitHub Release
+      ↓
+Greasy Fork source verification
+      ↓
 Private recovery backup
-              ↓
+      ↓
 Discord release confirmation
 ```
 
-| Boundary | Responsibility |
-|---|---|
-| **`main`** | Canonical development source, documentation and reviewed product state |
-| **`release-state`** | Governed release ledger, recovery identity and operational records |
-| **`distribution`** | Stable public distribution source derived from verified release state |
-| **Actions artefacts** | Immutable validation candidates, audits, dry runs and diagnostics |
-| **Private recovery repository** | Versioned, checksum-backed disaster recovery |
-
 GitHub remains authoritative. Greasy Fork is verified as the public distribution channel rather than imported back into canonical source.
 
-Validation covers userscript syntax and metadata, source/distribution parity, retained feature ownership, v7 retirement boundaries, Incident Command Wire behaviour, Transport Sweep progress, runtime budgets, device modes, hosted media, documentation consistency, release channels, recovery evidence and sensitive-value guards.
-
 ---
 
-# Security channel
+## Security and engineering
 
-> **LOCAL CONFIGURATION // EXPLICIT REPORTING // NO REMOTE PLAYER DATABASE**
-
-The Toolkit runs in the browser against the signed-in MissionChief page. It does not operate a separate player-account service.
-
-- Most configuration remains local to the browser.
-- Hosted interface media loads only when required by the active interface.
-- Financial reporting can use only the saved Discord webhook configured by the user.
-- Settings exports can contain that webhook and must be treated as private operational material.
-- No exported settings file containing a live webhook should be published.
-- The Toolkit does not require a remote account, remote telemetry service or separate player database.
-
----
-
-# Engineering control
-
-> **ISSUE-SCOPED · VALIDATED · RECOVERABLE**
-
+- Configuration remains local to the browser unless the user explicitly uses a supported reporting feature.
+- Settings exports can contain the saved Discord webhook and must be treated as private operational material.
+- The Toolkit does not require a remote player account, remote telemetry service or separate player database.
 - `main` is canonical.
 - Confirmed work is tracked through GitHub Issues.
-- Scoped implementation uses owner-created branches and pull requests.
 - Production releases are derived from freshly validated canonical source.
-- Documentation, changelog, release notes, status records and distribution copy must describe the same live implementation.
+- Documentation, release notes, status records and distribution copy must describe the same implementation.
 - Desktop, Tablet/iPad and iOS Mobile/Safari remain mandatory release concerns.
-- Performance, teardown, disabled-module cost and recovery evidence are release requirements.
-
-| Resource | Purpose |
-|---|---|
-| [Documentation](https://conroy1988.github.io/missionchief-toolkit-assets/) | User guidance and system explanations |
-| [Interface gallery](https://conroy1988.github.io/missionchief-toolkit-assets/themes/) | Eight visual command systems |
-| [Release Control Panel](status/README.md) | Current verified release identity and channel health |
-| [Issues](https://github.com/Conroy1988/missionchief-toolkit-assets/issues) | Bugs, enhancements and roadmap work |
-| [Releases](https://github.com/Conroy1988/missionchief-toolkit-assets/releases) | Immutable release history and verified assets |
-| [Changelog](CHANGELOG.md) | Human-readable production history |
-| [Security](SECURITY.md) | Sensitive material and reporting policy |
-| [Contributing](CONTRIBUTING.md) | Contribution expectations |
 
 ---
 
-# Licence and attribution
+## Licence and attribution
 
 The Toolkit source is released under the [MIT Licence](LICENSE).
 
@@ -366,6 +268,8 @@ MissionChief Map Command Toolkit is an independent community userscript created 
 MissionChief, Leitstellenspiel, Cyberpunk 2077, Fallout, Resident Evil / Umbrella, Factorio, James Bond / 007, The Legend of Zelda and associated names or assets remain the property of their respective owners. Their mention does not imply sponsorship, affiliation or endorsement.
 
 <div align="center">
+
+---
 
 ## **SEE THE MISSION · READ THE FLEET · COMMAND THE MAP · RECONCILE THE OPERATION**
 

--- a/docs/media/readme-command-board.svg
+++ b/docs/media/readme-command-board.svg
@@ -1,191 +1,25 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" role="img" aria-labelledby="title desc">
-<title id="title">MissionChief Toolkit United Kingdom operational picture</title>
-<desc id="desc">A realistic multi-agency UK command board showing fire, ambulance, police and coastguard response around a live operational map with mission, fleet, transport, map and finance intelligence.</desc>
+<title id="title">MissionChief Map Command Toolkit operational picture</title>
+<desc id="desc">A balanced UK emergency command-board composition with four operational divisions arranged safely around the MissionChief Map Command Toolkit identity.</desc>
 <defs>
-  <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-    <stop offset="0" stop-color="#03070c"/><stop offset=".48" stop-color="#071724"/><stop offset="1" stop-color="#16070b"/>
-  </linearGradient>
-  <radialGradient id="mapGlow" cx=".5" cy=".45" r=".6">
-    <stop offset="0" stop-color="#1a789d" stop-opacity=".32"/><stop offset=".6" stop-color="#072336" stop-opacity=".1"/><stop offset="1" stop-color="#02070c" stop-opacity="0"/>
-  </radialGradient>
-  <linearGradient id="panel" x1="0" y1="0" x2="1" y2="1">
-    <stop offset="0" stop-color="#17242c" stop-opacity=".97"/><stop offset=".45" stop-color="#071018" stop-opacity=".96"/><stop offset="1" stop-color="#03070b" stop-opacity=".98"/>
-  </linearGradient>
-  <linearGradient id="redVehicle" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#f22a3a"/><stop offset=".45" stop-color="#8e0713"/><stop offset="1" stop-color="#2a0206"/></linearGradient>
-  <linearGradient id="whiteVehicle" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#ffffff"/><stop offset=".5" stop-color="#c6cfce"/><stop offset="1" stop-color="#59666a"/></linearGradient>
-  <linearGradient id="glass" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#8fdbff"/><stop offset=".35" stop-color="#22516a"/><stop offset="1" stop-color="#03090d"/></linearGradient>
-  <linearGradient id="yellow" x1="0" y1="0" x2="1" y2="0"><stop stop-color="#fbff4a"/><stop offset=".6" stop-color="#d4e600"/><stop offset="1" stop-color="#737e00"/></linearGradient>
-  <linearGradient id="green" x1="0" y1="0" x2="1" y2="0"><stop stop-color="#31da59"/><stop offset=".55" stop-color="#07852d"/><stop offset="1" stop-color="#013f12"/></linearGradient>
-  <linearGradient id="blue" x1="0" y1="0" x2="1" y2="0"><stop stop-color="#31afff"/><stop offset=".55" stop-color="#126ac8"/><stop offset="1" stop-color="#032e66"/></linearGradient>
-  <linearGradient id="steel" x1="0" y1="0" x2="0" y2="1"><stop stop-color="#657985"/><stop offset=".12" stop-color="#17232a"/><stop offset=".7" stop-color="#070b0e"/><stop offset="1" stop-color="#25333b"/></linearGradient>
-  <pattern id="grid" width="36" height="36" patternUnits="userSpaceOnUse"><path d="M36 0H0V36" fill="none" stroke="#62d1ff" stroke-opacity=".055"/></pattern>
-  <pattern id="scan" width="5" height="5" patternUnits="userSpaceOnUse"><rect width="5" height="1" fill="#fff" opacity=".02"/></pattern>
-  <filter id="shadow" x="-40%" y="-40%" width="180%" height="190%"><feDropShadow dx="0" dy="18" stdDeviation="15" flood-color="#000" flood-opacity=".82"/></filter>
-  <filter id="glow" x="-250%" y="-250%" width="600%" height="600%"><feGaussianBlur stdDeviation="9" result="g"/><feMerge><feMergeNode in="g"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-  <filter id="grain" x="-20%" y="-20%" width="140%" height="140%"><feTurbulence type="fractalNoise" baseFrequency=".8" numOctaves="2" seed="11"/><feColorMatrix type="saturate" values="0"/><feComponentTransfer><feFuncA type="table" tableValues="0 0 .05"/></feComponentTransfer><feBlend in="SourceGraphic" mode="screen"/></filter>
-  <clipPath id="clip"><rect x="18" y="18" width="1564" height="864" rx="28"/></clipPath>
+  <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#02060a"/><stop offset=".45" stop-color="#071723"/><stop offset="1" stop-color="#16070b"/></linearGradient>
+  <linearGradient id="panel" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#1a2932"/><stop offset=".45" stop-color="#071018"/><stop offset="1" stop-color="#030609"/></linearGradient>
+  <linearGradient id="glass" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#1c6c91" stop-opacity=".68"/><stop offset=".55" stop-color="#082334" stop-opacity=".88"/><stop offset="1" stop-color="#02090e"/></linearGradient>
+  <linearGradient id="titleFill" x1="0" y1="0" x2="0" y2="1"><stop stop-color="#fff"/><stop offset=".6" stop-color="#d8e6eb"/><stop offset="1" stop-color="#8ca0aa"/></linearGradient>
+  <linearGradient id="gold" x1="0" y1="0" x2="0" y2="1"><stop stop-color="#fff2a1"/><stop offset=".5" stop-color="#e7b43b"/><stop offset="1" stop-color="#8d5208"/></linearGradient>
+  <radialGradient id="glow"><stop stop-color="#60dfff" stop-opacity=".42"/><stop offset="1" stop-color="#0a80ba" stop-opacity="0"/></radialGradient>
+  <filter id="shadow" x="-30%" y="-30%" width="160%" height="180%"><feDropShadow dx="0" dy="16" stdDeviation="18" flood-color="#000" flood-opacity=".72"/></filter>
+  <filter id="smallGlow" x="-100%" y="-100%" width="300%" height="300%"><feGaussianBlur stdDeviation="5" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+  <pattern id="grid" width="48" height="48" patternUnits="userSpaceOnUse"><path d="M48 0H0V48" fill="none" stroke="#61d1ff" stroke-opacity=".045"/></pattern>
 </defs>
-<g clip-path="url(#clip)">
-  <rect width="1600" height="900" fill="url(#bg)"/>
-  <rect width="1600" height="900" fill="url(#grid)"/>
-  <rect width="1600" height="900" fill="url(#scan)"/>
-  <rect width="1600" height="900" fill="url(#mapGlow)"/>
-
-  <!-- Header -->
-  <g transform="translate(38 34)" filter="url(#shadow)">
-    <path d="M0 0h1524l18 18v94l-18 18H0l-18-18V18z" fill="url(#panel)" stroke="#657b86" stroke-width="2"/>
-    <g transform="translate(18 18)">
-      <rect width="78" height="48" rx="4" fill="#080e12" stroke="#697b84"/>
-      <path d="M0 0 78 48M78 0 0 48" stroke="#fff" stroke-width="12"/><path d="M0 0 78 48M78 0 0 48" stroke="#c71f31" stroke-width="5"/>
-      <path d="M39 0v48M0 24h78" stroke="#fff" stroke-width="14"/><path d="M39 0v48M0 24h78" stroke="#c71f31" stroke-width="7"/>
-    </g>
-    <text x="120" y="49" fill="#6cd8ff" font-family="Arial,sans-serif" font-size="15" font-weight="900" letter-spacing="4">MISSIONCHIEF TOOLKIT // UK MULTI-AGENCY COMMAND</text>
-    <text x="120" y="91" fill="#fff" font-family="Arial Black,Arial,sans-serif" font-size="40" font-weight="900" letter-spacing="1.5">UNITED KINGDOM OPERATIONAL PICTURE</text>
-    <g transform="translate(1172 22)" font-family="Arial,sans-serif">
-      <text x="0" y="15" fill="#81939d" font-size="11" font-weight="800" letter-spacing="2">COMMAND STATE</text>
-      <circle cx="21" cy="52" r="8" fill="#36dc7b" filter="url(#glow)"/>
-      <text x="43" y="59" fill="#dffff0" font-size="19" font-weight="900" letter-spacing="2">OPERATIONAL</text>
-      <text x="0" y="91" fill="#8fa0aa" font-size="11" letter-spacing="1.6">DESKTOP · TABLET · iOS</text>
-    </g>
-  </g>
-
-  <!-- Central UK map -->
-  <g transform="translate(535 178)" filter="url(#shadow)">
-    <path d="M0 0h530l18 18v590l-18 18H0l-18-18V18z" fill="#03090e" stroke="#4f6774" stroke-width="2"/>
-    <rect x="12" y="12" width="506" height="602" rx="10" fill="#06121b" stroke="#172d39"/>
-    <text x="28" y="44" fill="#6ed8ff" font-family="Arial,sans-serif" font-size="13" font-weight="900" letter-spacing="3">LIVE INCIDENT MAP // NATIVE MISSION CONTEXT</text>
-    <path d="M28 58h472" stroke="#1c94c7" stroke-opacity=".65"/>
-
-    <!-- stylised GB landmass -->
-    <g transform="translate(72 68)">
-      <path d="M196 0l-30 24-14 46-37 26-8 46-35 35 5 41-22 38 12 35-18 43 12 54 39 13 22 43 45-5 31 34 45-6 26-38 43-9 18-46 42-28-8-52 24-43-8-45-34-26-7-38-37-20 10-39-27-32-37 11-27-37z" fill="#0a2635" stroke="#50c9ff" stroke-width="4"/>
-      <path d="M76 176l60-68 64-32 57 31 48 67 29 93-26 91-64 67-78 8-63-44-31-104z" fill="none" stroke="#2ea7d8" stroke-opacity=".35" stroke-width="2"/>
-      <g fill="none" stroke="#2cc0ef" stroke-opacity=".24" stroke-width="2">
-        <path d="M103 150l178 247M127 99l212 212M63 257l282 36M108 375l212-196M150 70l82 359"/>
-      </g>
-      <g filter="url(#glow)">
-        <circle cx="165" cy="110" r="8" fill="#ff3f4a"/><circle cx="133" cy="196" r="7" fill="#ffbd34"/>
-        <circle cx="196" cy="252" r="9" fill="#26b9ff"/><circle cx="154" cy="327" r="7" fill="#ff3f4a"/>
-        <circle cx="224" cy="375" r="8" fill="#22d271"/><circle cx="272" cy="297" r="7" fill="#ffbd34"/>
-        <circle cx="301" cy="205" r="8" fill="#27baff"/>
-      </g>
-      <g fill="#dff7ff" font-family="Arial,sans-serif" font-size="11" font-weight="800">
-        <text x="178" y="101">EDINBURGH</text><text x="71" y="194">BELFAST</text><text x="210" y="246">MANCHESTER</text>
-        <text x="87" y="326">CARDIFF</text><text x="240" y="372">LONDON</text><text x="314" y="202">NORTH SEA</text>
-      </g>
-      <path d="M27 212l-17 24 6 35 23 8 15-22-5-33z" fill="#0a2635" stroke="#50c9ff" stroke-width="3"/>
-    </g>
-
-    <g transform="translate(28 526)" font-family="Arial,sans-serif">
-      <rect width="472" height="62" rx="8" fill="#07141c" stroke="#1c4b61"/>
-      <circle cx="22" cy="31" r="6" fill="#ff414b"/><text x="39" y="35" fill="#fff" font-size="12" font-weight="800">PRIORITY</text>
-      <circle cx="128" cy="31" r="6" fill="#ffbc36"/><text x="145" y="35" fill="#fff" font-size="12" font-weight="800">WATCH</text>
-      <circle cx="227" cy="31" r="6" fill="#25b9ff"/><text x="244" y="35" fill="#fff" font-size="12" font-weight="800">RESOURCE</text>
-      <circle cx="349" cy="31" r="6" fill="#29d273"/><text x="366" y="35" fill="#fff" font-size="12" font-weight="800">VERIFIED</text>
-    </g>
-  </g>
-
-  <!-- Fire panel -->
-  <g transform="translate(40 178)" filter="url(#shadow)">
-    <path d="M0 0h455l16 16v270l-16 16H0l-16-16V16z" fill="url(#panel)" stroke="#a72d36" stroke-width="2"/>
-    <text x="25" y="40" fill="#ff5963" font-family="Arial,sans-serif" font-size="13" font-weight="900" letter-spacing="3">FIRE &amp; RESCUE // RESPONSE CHANNEL</text>
-    <path d="M25 53h402" stroke="#9f2b34" stroke-opacity=".72"/>
-    <g transform="translate(30 74)">
-      <ellipse cx="196" cy="176" rx="190" ry="25" fill="#000" opacity=".64"/>
-      <path d="M12 70 58 24h239l62 44 53 28 31 65-25 22H24L0 154z" fill="url(#redVehicle)" stroke="#48050b" stroke-width="4"/>
-      <path d="M56 29h235l56 42H24z" fill="#7d0711"/>
-      <path d="M274 35h32l43 34h-70z" fill="url(#glass)" stroke="#283943" stroke-width="3"/>
-      <path d="M33 79h367v17H25z" fill="url(#yellow)"/><path d="M33 98h367v9H25z" fill="#173783"/>
-      <g fill="#9b0b17" stroke="#dc414b"><rect x="47" y="119" width="64" height="39"/><rect x="117" y="119" width="64" height="39"/><rect x="187" y="119" width="64" height="39"/></g>
-      <rect x="278" y="112" width="118" height="48" fill="#20282c" stroke="#a9222d"/>
-      <text x="337" y="141" text-anchor="middle" fill="#fff" font-family="Arial,sans-serif" font-size="14" font-weight="900">FIRE &amp; RESCUE</text>
-      <circle cx="89" cy="166" r="34" fill="#06090b" stroke="#303a3f" stroke-width="6"/><circle cx="89" cy="166" r="16" fill="#8c989e"/>
-      <circle cx="334" cy="166" r="34" fill="#06090b" stroke="#303a3f" stroke-width="6"/><circle cx="334" cy="166" r="16" fill="#8c989e"/>
-      <rect x="252" y="14" width="88" height="12" rx="5" fill="#168cff" stroke="#8bdeff"/><circle cx="274" cy="20" r="6" fill="#29b8ff" filter="url(#glow)"/>
-    </g>
-    <text x="28" y="284" fill="#cbd9df" font-family="Arial,sans-serif" font-size="12">Mission age · value · commitment · incident wire</text>
-  </g>
-
-  <!-- Ambulance panel -->
-  <g transform="translate(40 505)" filter="url(#shadow)">
-    <path d="M0 0h455l16 16v270l-16 16H0l-16-16V16z" fill="url(#panel)" stroke="#2b9e4c" stroke-width="2"/>
-    <text x="25" y="40" fill="#55db78" font-family="Arial,sans-serif" font-size="13" font-weight="900" letter-spacing="3">AMBULANCE // PATIENT TRANSPORT CHANNEL</text>
-    <path d="M25 53h402" stroke="#2b9e4c" stroke-opacity=".68"/>
-    <g transform="translate(28 73)">
-      <ellipse cx="200" cy="177" rx="191" ry="25" fill="#000" opacity=".64"/>
-      <path d="M13 70 61 24h248l73 43 45 65-14 50H24L0 156z" fill="url(#whiteVehicle)" stroke="#4b5659" stroke-width="4"/>
-      <path d="M61 29h240l64 40H27z" fill="#e9eee9"/>
-      <path d="M299 36h35l36 32h-69z" fill="url(#glass)" stroke="#394b52" stroke-width="3"/>
-      <path d="M34 78h373v20H25z" fill="url(#yellow)"/><path d="M34 99h373v21H25z" fill="url(#green)"/>
-      <text x="168" y="61" text-anchor="middle" fill="#0d6d32" font-family="Arial,sans-serif" font-size="17" font-weight="900" letter-spacing="2">AMBULANCE</text>
-      <path d="M41 123h50l-17 49H24zM93 123h50l-17 49H76zM145 123h50l-17 49H128zM197 123h50l-17 49H180z" fill="#e9f12c"/>
-      <path d="M67 123h50l-17 49H50zM119 123h50l-17 49H102zM171 123h50l-17 49H154zM223 123h50l-17 49H206z" fill="#087e30"/>
-      <path d="M313 107h86v56h-86z" fill="#d6dfda" stroke="#73807d"/><path d="M356 114v42M335 135h42" stroke="#0a8337" stroke-width="6"/>
-      <circle cx="91" cy="168" r="34" fill="#06090b" stroke="#303a3f" stroke-width="6"/><circle cx="91" cy="168" r="16" fill="#8c989e"/>
-      <circle cx="340" cy="168" r="34" fill="#06090b" stroke="#303a3f" stroke-width="6"/><circle cx="340" cy="168" r="16" fill="#8c989e"/>
-      <rect x="72" y="12" width="82" height="12" rx="5" fill="#168cff"/><rect x="286" y="12" width="82" height="12" rx="5" fill="#168cff"/>
-      <circle cx="95" cy="18" r="6" fill="#29b8ff" filter="url(#glow)"/><circle cx="342" cy="18" r="6" fill="#29b8ff" filter="url(#glow)"/>
-    </g>
-    <text x="28" y="284" fill="#cbd9df" font-family="Arial,sans-serif" font-size="12">Transport watcher · native discharge · progress integrity</text>
-  </g>
-
-  <!-- Police panel -->
-  <g transform="translate(1105 178)" filter="url(#shadow)">
-    <path d="M0 0h455l16 16v270l-16 16H0l-16-16V16z" fill="url(#panel)" stroke="#257fc5" stroke-width="2"/>
-    <text x="25" y="40" fill="#4cbaff" font-family="Arial,sans-serif" font-size="13" font-weight="900" letter-spacing="3">POLICE // INCIDENT CONTROL CHANNEL</text>
-    <path d="M25 53h402" stroke="#257fc5" stroke-opacity=".68"/>
-    <g transform="translate(26 82)">
-      <ellipse cx="199" cy="149" rx="190" ry="24" fill="#000" opacity=".64"/>
-      <path d="M13 83 71 39h176l86 38 58 43-14 41H28L0 139z" fill="url(#whiteVehicle)" stroke="#3e4d55" stroke-width="4"/>
-      <path d="M85 44h148l76 34H48z" fill="#dce6e9"/>
-      <path d="M91 49h65v31H63zM163 49h67l61 31H164z" fill="url(#glass)" stroke="#334851" stroke-width="3"/>
-      <path d="M35 89h326v20H27z" fill="url(#yellow)"/><path d="M35 110h326v20H27z" fill="url(#blue)"/>
-      <g fill="#eef32c"><path d="M55 88h43l-16 42H39z"/><path d="M141 88h43l-16 42H125z"/><path d="M227 88h43l-16 42H211z"/><path d="M313 88h43l-16 42H297z"/></g>
-      <g fill="#116cc8"><path d="M98 88h43l-16 42H82z"/><path d="M184 88h43l-16 42H168z"/><path d="M270 88h43l-16 42H254z"/></g>
-      <rect x="162" y="90" width="76" height="23" rx="4" fill="#f6f9fa"/><text x="200" y="107" text-anchor="middle" fill="#145694" font-family="Arial,sans-serif" font-size="14" font-weight="900">POLICE</text>
-      <circle cx="86" cy="146" r="31" fill="#06090b" stroke="#303a3f" stroke-width="6"/><circle cx="86" cy="146" r="14" fill="#8c989e"/>
-      <circle cx="306" cy="146" r="31" fill="#06090b" stroke="#303a3f" stroke-width="6"/><circle cx="306" cy="146" r="14" fill="#8c989e"/>
-      <rect x="139" y="29" width="103" height="12" rx="5" fill="#168cff"/><circle cx="164" cy="35" r="6" fill="#29b8ff" filter="url(#glow)"/><circle cx="218" cy="35" r="6" fill="#29b8ff" filter="url(#glow)"/>
-    </g>
-    <text x="28" y="284" fill="#cbd9df" font-family="Arial,sans-serif" font-size="12">Priority incidents · direct navigation · native dispatch context</text>
-  </g>
-
-  <!-- Coastguard panel -->
-  <g transform="translate(1105 505)" filter="url(#shadow)">
-    <path d="M0 0h455l16 16v270l-16 16H0l-16-16V16z" fill="url(#panel)" stroke="#d05533" stroke-width="2"/>
-    <text x="25" y="40" fill="#ff7b53" font-family="Arial,sans-serif" font-size="13" font-weight="900" letter-spacing="3">HM COASTGUARD // SEARCH &amp; RESCUE CHANNEL</text>
-    <path d="M25 53h402" stroke="#d05533" stroke-opacity=".68"/>
-    <g transform="translate(35 73) rotate(-2)">
-      <ellipse cx="191" cy="177" rx="165" ry="22" fill="#000" opacity=".55"/>
-      <path d="M30 91c22-38 70-57 127-48 55 8 92 35 111 68l-18 32-72 13-105-7-54-27z" fill="#f4f2e8" stroke="#7d8a90" stroke-width="4"/>
-      <path d="M67 82c24-25 57-32 89-27 31 4 58 20 76 44l-58 8-88-5z" fill="url(#glass)"/>
-      <path d="M20 120h224l-12 29H73z" fill="#d31f2a"/>
-      <path d="M221 100l112-24 8 10-95 38z" fill="#ecebe4" stroke="#78848a" stroke-width="3"/>
-      <path d="M325 76l45-33 9 7-30 39z" fill="#d31f2a"/>
-      <path d="M115 51l20-35 14 3-4 35z" fill="#b8c2c6"/>
-      <path d="M62 151h155" stroke="#222a2e" stroke-width="5"/>
-      <text x="133" y="137" text-anchor="middle" fill="#fff" font-family="Arial,sans-serif" font-size="15" font-weight="900" letter-spacing="1.5">HM COASTGUARD</text>
-      <path d="M136 18H14M132 14l-100-26M135 13l-92 30M141 16l90-35" stroke="#b4bdc1" stroke-width="5" stroke-linecap="round"/>
-      <circle cx="29" cy="119" r="6" fill="#29b8ff" filter="url(#glow)"/><circle cx="241" cy="133" r="6" fill="#29b8ff" filter="url(#glow)"/>
-    </g>
-    <text x="28" y="284" fill="#cbd9df" font-family="Arial,sans-serif" font-size="12">Coverage rings · location intelligence · responsive field control</text>
-  </g>
-
-  <!-- Command domains footer -->
-  <g transform="translate(40 830)" filter="url(#shadow)" font-family="Arial,sans-serif">
-    <path d="M0 0h1520l16 16-16 42H0l-16-42z" fill="#040a0e" stroke="#4d626d"/>
-    <g font-weight="900" font-size="13" letter-spacing="1.5">
-      <circle cx="28" cy="29" r="6" fill="#ff4854"/><text x="44" y="34" fill="#fff">MISSION INTELLIGENCE</text>
-      <circle cx="323" cy="29" r="6" fill="#26b9ff"/><text x="339" y="34" fill="#fff">FLEET IDENTITY</text>
-      <circle cx="556" cy="29" r="6" fill="#2ed274"/><text x="572" y="34" fill="#fff">NATIVE TRANSPORT</text>
-      <circle cx="844" cy="29" r="6" fill="#ffd145"/><text x="860" y="34" fill="#fff">GEOGRAPHIC CONTROL</text>
-      <circle cx="1162" cy="29" r="6" fill="#ba7cff"/><text x="1178" y="34" fill="#fff">FINANCIAL RECONCILIATION</text>
-    </g>
-  </g>
-
-  <rect width="1600" height="900" fill="none" stroke="#748a95" stroke-width="3"/>
-  <rect x="12" y="12" width="1576" height="876" rx="30" fill="none" stroke="url(#steel)" stroke-width="20"/>
-  <rect x="24" y="24" width="1552" height="852" rx="22" fill="none" stroke="#6f828b" stroke-opacity=".55" stroke-width="2"/>
-  <rect width="1600" height="900" fill="none" filter="url(#grain)"/>
-</g>
+<rect width="1600" height="900" rx="28" fill="url(#bg)"/><rect width="1600" height="900" rx="28" fill="url(#grid)"/><circle cx="800" cy="470" r="520" fill="url(#glow)"/>
+<g transform="translate(38 30)"><rect width="1524" height="70" rx="12" fill="#02070b" fill-opacity=".92" stroke="#63747d"/><text x="28" y="29" fill="#70d7ff" font-family="Arial,Helvetica,sans-serif" font-size="12" font-weight="900" letter-spacing="3">UNITED KINGDOM OPERATIONAL PICTURE</text><text x="28" y="53" fill="#f1f7f9" font-family="Arial,Helvetica,sans-serif" font-size="16" font-weight="900" letter-spacing="1.6">MISSIONCHIEF MAP COMMAND TOOLKIT</text><g transform="translate(1240 17)"><circle cx="15" cy="18" r="8" fill="#3de17a" filter="url(#smallGlow)"/><text x="35" y="23" fill="#e7f3f6" font-family="Arial,Helvetica,sans-serif" font-size="13" font-weight="900" letter-spacing="2">LIVE &amp; VERIFIED</text></g></g>
+<g filter="url(#shadow)"><rect x="452" y="278" width="696" height="344" rx="36" fill="#02070b" fill-opacity=".96" stroke="#64ceff" stroke-opacity=".6" stroke-width="3"/><rect x="470" y="296" width="660" height="308" rx="28" fill="url(#glass)" stroke="#89dcff" stroke-opacity=".28"/><path d="M500 330h205M895 330h205" stroke="#48c9ff" stroke-width="3"/><text x="800" y="395" text-anchor="middle" fill="url(#titleFill)" font-family="Arial Black,Arial,sans-serif" font-size="58" font-weight="900" letter-spacing="3">MISSIONCHIEF</text><text x="800" y="460" text-anchor="middle" fill="url(#gold)" font-family="Arial Black,Arial,sans-serif" font-size="40" font-weight="900" letter-spacing="2.5">MAP COMMAND TOOLKIT</text><text x="800" y="505" text-anchor="middle" fill="#9de6ff" font-family="Arial,Helvetica,sans-serif" font-size="15" font-weight="900" letter-spacing="3.4">ONE MAP · ONE COMMAND LAYER · NATIVE CONTROLS</text><g transform="translate(520 535)" font-family="Arial,Helvetica,sans-serif" font-size="12" font-weight="900"><g><rect width="130" height="38" rx="8" fill="#0b2b40" stroke="#28b9f0"/><text x="65" y="24" text-anchor="middle" fill="#e9f9ff">INCIDENTS</text></g><g transform="translate(145)"><rect width="130" height="38" rx="8" fill="#321014" stroke="#dd3942"/><text x="65" y="24" text-anchor="middle" fill="#fff0ef">FLEET</text></g><g transform="translate(290)"><rect width="130" height="38" rx="8" fill="#233008" stroke="#b4d143"/><text x="65" y="24" text-anchor="middle" fill="#f8ffe3">MAP</text></g><g transform="translate(435)"><rect width="130" height="38" rx="8" fill="#332309" stroke="#dfa936"/><text x="65" y="24" text-anchor="middle" fill="#fff5d7">FINANCE</text></g></g></g>
+<g fill="none" stroke-width="4"><path d="M452 355H394Q370 355 354 330L332 297" stroke="#2cbef5"/><path d="M1148 355h58q24 0 40-25l22-33" stroke="#ef4248"/><path d="M452 548h-58q-24 0-40 25l-22 33" stroke="#b5d248"/><path d="M1148 548h58q24 0 40 25l22 33" stroke="#e3af3c"/></g>
+<g transform="translate(40 132)" filter="url(#shadow)" font-family="Arial,Helvetica,sans-serif"><rect width="352" height="250" rx="22" fill="url(#panel)" stroke="#2ebef2" stroke-width="2"/><text x="24" y="34" fill="#63d7ff" font-size="13" font-weight="900" letter-spacing="2.4">CHANNEL 01</text><text x="24" y="68" fill="#fff" font-size="27" font-weight="900">MISSION CONTROL</text><rect x="22" y="88" width="308" height="100" rx="10" fill="#041019" stroke="#1f6e91"/><path d="M40 145c36-43 73 31 111-6s73 29 111-15 44 0 50-11" fill="none" stroke="#34c9ff" stroke-width="4"/><g fill="#ee3e45" filter="url(#smallGlow)"><circle cx="82" cy="128" r="6"/><circle cx="167" cy="142" r="6"/><circle cx="248" cy="123" r="6"/></g><text x="40" y="210" fill="#c7d8df" font-size="12" font-weight="800">Incident Command Wire · Mission Age</text><text x="40" y="231" fill="#8da2ac" font-size="11">Mission Value · Unit Commitment · Transport Watcher</text></g>
+<g transform="translate(1208 132)" filter="url(#shadow)" font-family="Arial,Helvetica,sans-serif"><rect width="352" height="250" rx="22" fill="url(#panel)" stroke="#ef4148" stroke-width="2"/><text x="24" y="34" fill="#ff6669" font-size="13" font-weight="900" letter-spacing="2.4">CHANNEL 02</text><text x="24" y="68" fill="#fff" font-size="27" font-weight="900">FLEET &amp; TRANSPORT</text><g transform="translate(24 90)"><path d="M5 38 35 12h80l23 29v54H4z" fill="#e5cd29" stroke="#1c2b31" stroke-width="2"/><path d="M8 55h127v25H8z" fill="#25733a"/><path d="M12 57 27 79l15-22 15 22 15-22 15 22 15-22 15 22 15-22v22H12z" fill="#e8dd3a"/><circle cx="31" cy="96" r="14" fill="#070a0c"/><circle cx="111" cy="96" r="14" fill="#070a0c"/><g transform="translate(92 2)"><path d="M4 38 38 5h106l26 34v56H2z" fill="#bd1822" stroke="#1c2b31" stroke-width="2"/><path d="M6 54h160v27H6z" fill="#ebd925"/><path d="M8 55 25 79l17-24 17 24 17-24 17 24 17-24 17 24 17-24 17 24v3H8z" fill="#c91e28"/><circle cx="38" cy="96" r="15" fill="#070a0c"/><circle cx="139" cy="96" r="15" fill="#070a0c"/></g><g transform="translate(206 29)"><path d="M4 29 30 6h75l35 28v43H2z" fill="#dfe5e8" stroke="#1c2b31" stroke-width="2"/><path d="M5 43h131v22H5z" fill="#146dcc"/><path d="M7 44 20 64l13-20 13 20 13-20 13 20 13-20 13 20 13-20 13 20v1H7z" fill="#d9ef35"/><circle cx="29" cy="78" r="13" fill="#070a0c"/><circle cx="112" cy="78" r="13" fill="#070a0c"/></g></g><text x="24" y="210" fill="#d7dfe2" font-size="12" font-weight="800">Vehicle Code Status · Custom Vehicle Badges</text><text x="24" y="231" fill="#9eaaaf" font-size="11">Patient Transport Sweep · Auto-load · Resource Gap</text></g>
+<g transform="translate(40 570)" filter="url(#shadow)" font-family="Arial,Helvetica,sans-serif"><rect width="352" height="250" rx="22" fill="url(#panel)" stroke="#b8d248" stroke-width="2"/><text x="24" y="34" fill="#d8ee6b" font-size="13" font-weight="900" letter-spacing="2.4">CHANNEL 03</text><text x="24" y="68" fill="#fff" font-size="27" font-weight="900">MAP &amp; PLACES</text><path d="M155 91l-27 12-9 30-24 13-8 33-22 17 7 25 23 6 12 20 31-2 18-21 22-4 11-27 24-16-5-31 15-23-13-25-24-6-11-19-20 6z" fill="#071a24" stroke="#44caff" stroke-width="3"/><g fill="#ff4b4f" filter="url(#smallGlow)"><circle cx="128" cy="133" r="5"/><circle cx="163" cy="167" r="6"/><circle cx="188" cy="206" r="5"/></g><g fill="#d8ed50"><circle cx="142" cy="188" r="5"/><circle cx="100" cy="214" r="5"/></g><path d="M128 133 163 167 142 188 188 206" fill="none" stroke="#5ad8ff" stroke-width="2" stroke-dasharray="5 5"/><text x="219" y="116" fill="#d7e3e7" font-size="12" font-weight="800">Coverage rings</text><text x="219" y="147" fill="#d7e3e7" font-size="12" font-weight="800">Smart Bookmark Labels</text><text x="219" y="178" fill="#d7e3e7" font-size="12" font-weight="800">Saved profiles</text><text x="219" y="209" fill="#d7e3e7" font-size="12" font-weight="800">Responsive layouts</text></g>
+<g transform="translate(1208 570)" filter="url(#shadow)" font-family="Arial,Helvetica,sans-serif"><rect width="352" height="250" rx="22" fill="url(#panel)" stroke="#e2ad3b" stroke-width="2"/><text x="24" y="34" fill="#f2c557" font-size="13" font-weight="900" letter-spacing="2.4">CHANNEL 04</text><text x="24" y="68" fill="#fff" font-size="27" font-weight="900">FINANCE &amp; RECOVERY</text><rect x="24" y="90" width="304" height="95" rx="10" fill="#090e12" stroke="#6f5722"/><path d="M43 161 82 145l39 7 39-35 39 16 39-25 70 34" fill="none" stroke="#f0bc42" stroke-width="4"/><path d="M43 169h265M43 142h265M43 115h265" stroke="#8e7432" stroke-opacity=".3"/><circle cx="160" cy="117" r="6" fill="#47dc77" filter="url(#smallGlow)"/><text x="40" y="210" fill="#d7dfe2" font-size="12" font-weight="800">Alliance Credits · Financial intelligence</text><text x="40" y="231" fill="#9eaaaf" font-size="11">Payout presentations · Discord · Verified recovery</text></g>
+<g transform="translate(426 664)" font-family="Arial,Helvetica,sans-serif"><rect width="748" height="156" rx="20" fill="#02070b" fill-opacity=".94" stroke="#5d6d75"/><text x="374" y="31" text-anchor="middle" fill="#8edfff" font-size="12" font-weight="900" letter-spacing="2.6">EIGHT COMPLETE INTERFACE SYSTEMS</text><g transform="translate(26 50)" font-size="11" font-weight="900"><g><rect width="160" height="36" rx="7" fill="#0c2738" stroke="#29bff5"/><text x="80" y="23" text-anchor="middle" fill="#e9f9ff">MAP COMMAND</text></g><g transform="translate(172)"><rect width="160" height="36" rx="7" fill="#270a2e" stroke="#e23dff"/><text x="80" y="23" text-anchor="middle" fill="#fff0ff">CYBERPUNK</text></g><g transform="translate(344)"><rect width="160" height="36" rx="7" fill="#12200d" stroke="#8cbf54"/><text x="80" y="23" text-anchor="middle" fill="#f3ffe9">FALLOUT 4</text></g><g transform="translate(516)"><rect width="160" height="36" rx="7" fill="#29090c" stroke="#d4313a"/><text x="80" y="23" text-anchor="middle" fill="#fff0ef">UMBRELLA</text></g><g transform="translate(0 48)"><rect width="160" height="36" rx="7" fill="#2a2208" stroke="#d7a828"/><text x="80" y="23" text-anchor="middle" fill="#fff5d0">FACTORIO</text></g><g transform="translate(172 48)"><rect width="160" height="36" rx="7" fill="#181410" stroke="#d4b46e"/><text x="80" y="23" text-anchor="middle" fill="#fff7e4">007 INTELLIGENCE</text></g><g transform="translate(344 48)"><rect width="160" height="36" rx="7" fill="#10231c" stroke="#55d5a4"/><text x="80" y="23" text-anchor="middle" fill="#ecfff8">HYRULE COMMAND</text></g><g transform="translate(516 48)"><rect width="160" height="36" rx="7" fill="#2c0a0b" stroke="#c39a4a"/><text x="80" y="23" text-anchor="middle" fill="#fff1d4">THE GODFATHER</text></g></g></g>
+<rect x="12" y="12" width="1576" height="876" rx="22" fill="none" stroke="#71838c" stroke-opacity=".55" stroke-width="2"/>
 </svg>

--- a/docs/media/readme-hero.svg
+++ b/docs/media/readme-hero.svg
@@ -1,313 +1,37 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1600" height="760" viewBox="0 0 1600 760" role="img" aria-labelledby="title desc">
-<title id="title">MissionChief Map Command Toolkit — UK emergency response command scene</title>
-<desc id="desc">A cinematic night-time United Kingdom emergency response scene with a fire appliance, ambulance, police car and coastguard helicopter linked by a digital incident command overlay.</desc>
+<title id="title">MissionChief Map Command Toolkit United Kingdom emergency command network</title>
+<desc id="desc">A realistic night-time UK multi-agency response scene built around the MissionChief Map Command Toolkit name, with ambulance, fire and rescue, police and coastguard assets.</desc>
 <defs>
-  <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#020713"/>
-    <stop offset=".55" stop-color="#07172a"/>
-    <stop offset="1" stop-color="#14222b"/>
-  </linearGradient>
-  <radialGradient id="horizon" cx=".56" cy=".52" r=".62">
-    <stop offset="0" stop-color="#29435a" stop-opacity=".75"/>
-    <stop offset=".5" stop-color="#0a1b2c" stop-opacity=".22"/>
-    <stop offset="1" stop-color="#020713" stop-opacity="0"/>
-  </radialGradient>
-  <linearGradient id="road" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#1e2930"/>
-    <stop offset=".45" stop-color="#0c1115"/>
-    <stop offset="1" stop-color="#020405"/>
-  </linearGradient>
-  <linearGradient id="wet" x1="0" y1="0" x2="1" y2="0">
-    <stop offset="0" stop-color="#071d2d"/>
-    <stop offset=".28" stop-color="#1b2631"/>
-    <stop offset=".5" stop-color="#101418"/>
-    <stop offset=".72" stop-color="#261412"/>
-    <stop offset="1" stop-color="#07131d"/>
-  </linearGradient>
-  <linearGradient id="fireBody" x1="0" y1="0" x2="1" y2=".7">
-    <stop offset="0" stop-color="#ff3949"/>
-    <stop offset=".25" stop-color="#b30e1e"/>
-    <stop offset=".62" stop-color="#64050e"/>
-    <stop offset="1" stop-color="#250207"/>
-  </linearGradient>
-  <linearGradient id="fireSide" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#b70d1d"/>
-    <stop offset=".6" stop-color="#6d0610"/>
-    <stop offset="1" stop-color="#2a0307"/>
-  </linearGradient>
-  <linearGradient id="ambulanceBody" x1="0" y1="0" x2="1" y2=".8">
-    <stop offset="0" stop-color="#fffef0"/>
-    <stop offset=".34" stop-color="#e6eadf"/>
-    <stop offset=".7" stop-color="#aeb7b0"/>
-    <stop offset="1" stop-color="#626b68"/>
-  </linearGradient>
-  <linearGradient id="policeBody" x1="0" y1="0" x2="1" y2="1">
-    <stop offset="0" stop-color="#ffffff"/>
-    <stop offset=".42" stop-color="#c8d2d8"/>
-    <stop offset=".72" stop-color="#768590"/>
-    <stop offset="1" stop-color="#2c3942"/>
-  </linearGradient>
-  <linearGradient id="glass" x1="0" y1="0" x2="1" y2="1">
-    <stop offset="0" stop-color="#8dd7ff" stop-opacity=".9"/>
-    <stop offset=".28" stop-color="#1d4a64" stop-opacity=".82"/>
-    <stop offset=".65" stop-color="#071822" stop-opacity=".96"/>
-    <stop offset="1" stop-color="#02070b"/>
-  </linearGradient>
-  <linearGradient id="chrome" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#f8fbff"/>
-    <stop offset=".22" stop-color="#778791"/>
-    <stop offset=".48" stop-color="#172128"/>
-    <stop offset=".73" stop-color="#a6b0b4"/>
-    <stop offset="1" stop-color="#222a2e"/>
-  </linearGradient>
-  <linearGradient id="blueLamp" x1="0" y1="0" x2="0" y2="1">
-    <stop offset="0" stop-color="#c9f4ff"/>
-    <stop offset=".28" stop-color="#2ac6ff"/>
-    <stop offset=".72" stop-color="#0069df"/>
-    <stop offset="1" stop-color="#022057"/>
-  </linearGradient>
-  <linearGradient id="yellow" x1="0" y1="0" x2="1" y2="0">
-    <stop offset="0" stop-color="#f9ff44"/>
-    <stop offset=".55" stop-color="#d8e800"/>
-    <stop offset="1" stop-color="#7e8c00"/>
-  </linearGradient>
-  <linearGradient id="greenBat" x1="0" y1="0" x2="1" y2="0">
-    <stop offset="0" stop-color="#1dcc49"/>
-    <stop offset=".55" stop-color="#078427"/>
-    <stop offset="1" stop-color="#024411"/>
-  </linearGradient>
-  <linearGradient id="blueBat" x1="0" y1="0" x2="1" y2="0">
-    <stop offset="0" stop-color="#2ea2ff"/>
-    <stop offset=".55" stop-color="#075ebd"/>
-    <stop offset="1" stop-color="#032f6d"/>
-  </linearGradient>
-  <linearGradient id="hud" x1="0" y1="0" x2="1" y2="1">
-    <stop offset="0" stop-color="#07111a" stop-opacity=".96"/>
-    <stop offset=".65" stop-color="#0a1720" stop-opacity=".84"/>
-    <stop offset="1" stop-color="#13070b" stop-opacity=".9"/>
-  </linearGradient>
-  <pattern id="rain" width="28" height="28" patternUnits="userSpaceOnUse" patternTransform="rotate(18)">
-    <path d="M2 0v15" stroke="#b9e9ff" stroke-opacity=".16" stroke-width="1.2"/>
-    <path d="M18 10v12" stroke="#b9e9ff" stroke-opacity=".08" stroke-width="1"/>
-  </pattern>
-  <pattern id="screenGrid" width="34" height="34" patternUnits="userSpaceOnUse">
-    <path d="M34 0H0V34" fill="none" stroke="#4dd0ff" stroke-opacity=".06"/>
-  </pattern>
-  <filter id="shadow" x="-40%" y="-40%" width="180%" height="180%">
-    <feDropShadow dx="0" dy="18" stdDeviation="16" flood-color="#000" flood-opacity=".88"/>
-  </filter>
-  <filter id="vehicleShadow" x="-50%" y="-50%" width="200%" height="220%">
-    <feDropShadow dx="0" dy="20" stdDeviation="12" flood-color="#000" flood-opacity=".85"/>
-  </filter>
-  <filter id="blueGlow" x="-250%" y="-250%" width="600%" height="600%">
-    <feGaussianBlur stdDeviation="11" result="g"/>
-    <feMerge><feMergeNode in="g"/><feMergeNode in="g"/><feMergeNode in="SourceGraphic"/></feMerge>
-  </filter>
-  <filter id="redGlow" x="-250%" y="-250%" width="600%" height="600%">
-    <feGaussianBlur stdDeviation="12" result="g"/>
-    <feMerge><feMergeNode in="g"/><feMergeNode in="SourceGraphic"/></feMerge>
-  </filter>
-  <filter id="soft" x="-30%" y="-30%" width="160%" height="160%">
-    <feGaussianBlur stdDeviation="3"/>
-  </filter>
-  <filter id="grain" x="-20%" y="-20%" width="140%" height="140%">
-    <feTurbulence type="fractalNoise" baseFrequency=".75" numOctaves="2" seed="17" result="n"/>
-    <feColorMatrix in="n" type="saturate" values="0"/>
-    <feComponentTransfer><feFuncA type="table" tableValues="0 0 .055"/></feComponentTransfer>
-    <feBlend in="SourceGraphic" mode="screen"/>
-  </filter>
-  <clipPath id="frameClip"><rect x="18" y="18" width="1564" height="724" rx="30"/></clipPath>
+  <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop stop-color="#02060b"/><stop offset=".58" stop-color="#0b1c2b"/><stop offset="1" stop-color="#18242b"/></linearGradient>
+  <linearGradient id="road" x1="0" y1="0" x2="0" y2="1"><stop stop-color="#202a2f"/><stop offset=".55" stop-color="#0d1216"/><stop offset="1" stop-color="#020405"/></linearGradient>
+  <linearGradient id="glass" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#80c9e8" stop-opacity=".58"/><stop offset=".45" stop-color="#193d51" stop-opacity=".8"/><stop offset="1" stop-color="#06131e" stop-opacity=".94"/></linearGradient>
+  <linearGradient id="metal" x1="0" y1="0" x2="0" y2="1"><stop stop-color="#53636d"/><stop offset=".15" stop-color="#151d22"/><stop offset=".7" stop-color="#06090b"/><stop offset="1" stop-color="#252f35"/></linearGradient>
+  <linearGradient id="redBody" x1="0" y1="0" x2="0" y2="1"><stop stop-color="#ef2f31"/><stop offset=".55" stop-color="#9b111b"/><stop offset="1" stop-color="#41070b"/></linearGradient>
+  <linearGradient id="yellowBody" x1="0" y1="0" x2="0" y2="1"><stop stop-color="#fff36a"/><stop offset=".58" stop-color="#e8ce24"/><stop offset="1" stop-color="#7c6500"/></linearGradient>
+  <linearGradient id="policeBody" x1="0" y1="0" x2="0" y2="1"><stop stop-color="#f4f7f8"/><stop offset=".6" stop-color="#bfcbd1"/><stop offset="1" stop-color="#59656b"/></linearGradient>
+  <linearGradient id="titleFill" x1="0" y1="0" x2="0" y2="1"><stop stop-color="#ffffff"/><stop offset=".55" stop-color="#dce8ee"/><stop offset="1" stop-color="#9fb1bb"/></linearGradient>
+  <linearGradient id="gold" x1="0" y1="0" x2="0" y2="1"><stop stop-color="#fff2a7"/><stop offset=".45" stop-color="#f0bd3f"/><stop offset="1" stop-color="#9d5b08"/></linearGradient>
+  <linearGradient id="edge" x1="0" y1="0" x2="1" y2="0"><stop stop-color="#1bbcff"/><stop offset=".48" stop-color="#7ae2ff"/><stop offset=".52" stop-color="#ff9a57"/><stop offset="1" stop-color="#e92531"/></linearGradient>
+  <radialGradient id="blueGlow"><stop stop-color="#77e5ff" stop-opacity=".95"/><stop offset=".25" stop-color="#1fa8ff" stop-opacity=".62"/><stop offset="1" stop-color="#0a6dff" stop-opacity="0"/></radialGradient>
+  <radialGradient id="redGlow"><stop stop-color="#ff8b71" stop-opacity=".9"/><stop offset=".25" stop-color="#ef3342" stop-opacity=".55"/><stop offset="1" stop-color="#d4081d" stop-opacity="0"/></radialGradient>
+  <filter id="shadow" x="-30%" y="-30%" width="160%" height="180%"><feDropShadow dx="0" dy="15" stdDeviation="16" flood-color="#000" flood-opacity=".72"/></filter>
+  <filter id="soft" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="12"/></filter>
+  <filter id="smallGlow" x="-100%" y="-100%" width="300%" height="300%"><feGaussianBlur stdDeviation="5" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+  <pattern id="rain" width="34" height="34" patternUnits="userSpaceOnUse" patternTransform="rotate(17)"><path d="M0 0v12" stroke="#d6f1ff" stroke-opacity=".08" stroke-width="1.2"/></pattern>
+  <clipPath id="roadClip"><path d="M0 470 L1600 430 L1600 760 L0 760 Z"/></clipPath>
 </defs>
-
-<g clip-path="url(#frameClip)">
-  <rect width="1600" height="760" fill="url(#sky)"/>
-  <rect width="1600" height="760" fill="url(#horizon)"/>
-
-  <g opacity=".55" filter="url(#soft)">
-    <path d="M-70 180C60 90 200 115 288 170c85-88 246-86 345 2 99-56 235-33 292 41 111-79 273-63 348 34 124-37 270 12 350 110v93H-70z" fill="#203443"/>
-    <path d="M-60 103c151-85 281-65 386 14 104-55 249-48 331 25 98-48 245-29 322 51 121-65 265-34 354 51 83-21 185 12 267 79V0H-60z" fill="#101c29"/>
-  </g>
-
-  <g opacity=".95">
-    <rect y="345" width="1600" height="110" fill="#050b10"/>
-    <g fill="#0a1117">
-      <path d="M0 345h115v-92h40v92h80v-138h42v138h74v-82h32v82h68v-125h49v125h75v-179h34v179h48v-91h34v91h76v-140h42v140h66v-103h34v103h87v-158h42v158h73v-118h34v118h58v-88h44v88h63v-165h31v165h72v-118h46v118h72v-72h41v72h116V455H0z"/>
-    </g>
-    <g fill="#101820">
-      <path d="M1060 346v-190h18v190zm-14-192h46l-8-22h-30z"/>
-      <circle cx="1069" cy="119" r="7" fill="#18232c"/>
-      <path d="M1210 346v-130h20v130zm-22-130h64l-10-18h-44z"/>
-      <path d="M1305 346v-94h26v94zm-11-94h48l-7-14h-34z"/>
-    </g>
-    <g fill="#e8c56a" opacity=".75">
-      <rect x="86" y="296" width="5" height="8"/><rect x="201" y="250" width="6" height="8"/>
-      <rect x="464" y="269" width="6" height="8"/><rect x="616" y="224" width="6" height="8"/>
-      <rect x="838" y="281" width="6" height="8"/><rect x="1098" y="260" width="6" height="8"/>
-      <rect x="1358" y="225" width="6" height="8"/><rect x="1490" y="292" width="6" height="8"/>
-    </g>
-  </g>
-
-  <path d="M0 430H1600v330H0z" fill="url(#road)"/>
-  <path d="M0 495c305-25 588-18 867 4 271 22 497 19 733-12v273H0z" fill="url(#wet)" opacity=".84"/>
-  <path d="M0 532c290-25 592-13 862 9 268 22 515 19 738-17" fill="none" stroke="#9db1ba" stroke-opacity=".25" stroke-width="3"/>
-  <path d="M0 668h1600" stroke="#d9e2e6" stroke-opacity=".18" stroke-width="3"/>
-  <g opacity=".44" filter="url(#soft)">
-    <path d="M130 563l145 0-63 197H83z" fill="#ff2038"/>
-    <path d="M526 560h178l69 200H461z" fill="#c8ff38"/>
-    <path d="M1030 574h210l157 186H946z" fill="#148cff"/>
-  </g>
-  <g stroke="#f5f2d6" stroke-width="9" stroke-linecap="round" opacity=".72">
-    <path d="M27 641h110"/><path d="M208 641h110"/><path d="M389 641h110"/>
-    <path d="M1281 641h105"/><path d="M1454 641h105"/>
-  </g>
-
-  <g transform="translate(1160 118) rotate(-4)" filter="url(#vehicleShadow)">
-    <ellipse cx="112" cy="151" rx="125" ry="22" fill="#000" opacity=".4"/>
-    <path d="M31 104c18-36 60-56 118-49 54 7 95 33 119 67l-15 30-62 14-116-3-58-24z" fill="#f4f3eb" stroke="#8c969c" stroke-width="3"/>
-    <path d="M64 95c23-25 54-34 90-29 34 4 57 19 77 44l-56 8-93-4z" fill="url(#glass)"/>
-    <path d="M20 134h222l-11 29H77z" fill="#d21c25"/>
-    <path d="M218 112l110-23 8 9-93 39z" fill="#e8e8e2" stroke="#78848b" stroke-width="3"/>
-    <path d="M318 88l44-34 10 6-31 41z" fill="#d11e28"/>
-    <path d="M328 91l62 22-3 9-69-15z" fill="#f3f1ea"/>
-    <path d="M106 63l22-37 15 2-4 38z" fill="#bfc7ca"/>
-    <path d="M54 163h154" stroke="#222c31" stroke-width="5"/>
-    <path d="M72 169h116" stroke="#11181c" stroke-width="7"/>
-    <circle cx="18" cy="127" r="5" fill="#258dff" filter="url(#blueGlow)"/>
-    <circle cx="237" cy="139" r="5" fill="#258dff" filter="url(#blueGlow)"/>
-    <text x="128" y="147" text-anchor="middle" fill="#fff" font-family="Arial,sans-serif" font-size="18" font-weight="900" letter-spacing="2">HM COASTGUARD</text>
-    <path d="M130 28H8M120 22l-96-26M124 20 37 48M130 23l88-35" stroke="#b8c1c5" stroke-width="5" stroke-linecap="round"/>
-  </g>
-
-  <g transform="translate(55 382)" filter="url(#vehicleShadow)">
-    <ellipse cx="303" cy="260" rx="300" ry="40" fill="#000" opacity=".75"/>
-    <path d="M28 97 84 28h287l70 63 105 26 38 115-44 30H37L0 230z" fill="url(#fireBody)" stroke="#340208" stroke-width="5"/>
-    <path d="M82 32h280l64 60H42z" fill="url(#fireSide)"/>
-    <path d="M325 42h66l45 53h-103z" fill="url(#glass)" stroke="#17242b" stroke-width="4"/>
-    <path d="M97 43h209v57H51z" fill="#211417" stroke="#5f1d24" stroke-width="4"/>
-    <path d="M50 105h485v21H41z" fill="url(#yellow)"/>
-    <path d="M49 130h486v13H43z" fill="#17367d"/>
-    <g fill="#8a0c18" stroke="#d72b36" stroke-width="2">
-      <rect x="65" y="153" width="74" height="62" rx="4"/>
-      <rect x="148" y="153" width="74" height="62" rx="4"/>
-      <rect x="231" y="153" width="74" height="62" rx="4"/>
-    </g>
-    <g stroke="#ed5a63" stroke-width="3" opacity=".65">
-      <path d="M73 163h58M73 174h58M73 185h58M73 196h58"/>
-      <path d="M156 163h58M156 174h58M156 185h58M156 196h58"/>
-      <path d="M239 163h58M239 174h58M239 185h58M239 196h58"/>
-    </g>
-    <path d="M326 116h206v114H306z" fill="#850913" stroke="#e2424c" stroke-width="3"/>
-    <path d="M331 124h186v22H325z" fill="#efe8d5"/>
-    <text x="423" y="141" text-anchor="middle" fill="#b20b18" font-family="Arial,sans-serif" font-size="15" font-weight="900" letter-spacing="2">FIRE &amp; RESCUE</text>
-    <path d="M345 154h161v52H332z" fill="#1b2125"/>
-    <g fill="#8e989e"><rect x="350" y="165" width="145" height="8"/><rect x="350" y="181" width="145" height="8"/></g>
-    <path d="M36 222h526l-24 32H44z" fill="#181d20"/>
-    <path d="M413 208h138l16 22-29 19H405z" fill="url(#chrome)"/>
-    <circle cx="113" cy="235" r="49" fill="#06090b" stroke="#273239" stroke-width="8"/>
-    <circle cx="113" cy="235" r="26" fill="url(#chrome)"/>
-    <circle cx="430" cy="235" r="49" fill="#06090b" stroke="#273239" stroke-width="8"/>
-    <circle cx="430" cy="235" r="26" fill="url(#chrome)"/>
-    <path d="M306 25h92l11 14H295z" fill="#222b30"/>
-    <rect x="309" y="14" width="97" height="16" rx="5" fill="url(#blueLamp)" stroke="#80dfff"/>
-    <rect x="18" y="192" width="20" height="20" rx="3" fill="#fff59b"/>
-    <rect x="534" y="192" width="24" height="20" rx="3" fill="#ffb7a3"/>
-    <circle cx="326" cy="22" r="8" fill="#24a9ff" filter="url(#blueGlow)"/>
-    <circle cx="388" cy="22" r="8" fill="#24a9ff" filter="url(#blueGlow)"/>
-  </g>
-
-  <g transform="translate(505 425)" filter="url(#vehicleShadow)">
-    <ellipse cx="300" cy="224" rx="285" ry="35" fill="#000" opacity=".72"/>
-    <path d="M30 74 78 25h327l94 53 60 83-25 55H39L0 180z" fill="url(#ambulanceBody)" stroke="#4d5757" stroke-width="5"/>
-    <path d="M80 28h319l84 49H43z" fill="#e8eee5"/>
-    <path d="M378 40h37l61 38h-88z" fill="url(#glass)" stroke="#43545b" stroke-width="4"/>
-    <path d="M290 38h77v48h-80z" fill="url(#glass)" stroke="#43545b" stroke-width="4"/>
-    <path d="M52 89h455v30H38z" fill="url(#yellow)"/>
-    <path d="M52 119h455v29H38z" fill="url(#greenBat)"/>
-    <g fill="url(#yellow)">
-      <path d="M67 152h52l-22 56H45z"/><path d="M121 152h52l-22 56H99z"/>
-      <path d="M175 152h52l-22 56H153z"/><path d="M229 152h52l-22 56H207z"/>
-    </g>
-    <g fill="url(#greenBat)">
-      <path d="M94 152h52l-22 56H72z"/><path d="M148 152h52l-22 56H126z"/>
-      <path d="M202 152h52l-22 56H180z"/><path d="M256 152h52l-22 56H234z"/>
-    </g>
-    <rect x="72" y="50" width="178" height="32" rx="4" fill="#f7faf4" stroke="#838d89"/>
-    <text x="161" y="73" text-anchor="middle" fill="#0c5a2d" font-family="Arial,sans-serif" font-size="21" font-weight="900" letter-spacing="2">AMBULANCE</text>
-    <path d="M322 108h154v82H310z" fill="#dae1dc" stroke="#7d8784" stroke-width="3"/>
-    <path d="M342 122h117v43" fill="none" stroke="#0e7c38" stroke-width="7"/>
-    <path d="M400 112v62M368 143h64" stroke="#0e7c38" stroke-width="7"/>
-    <path d="M32 188h510l-20 27H41z" fill="#313a3d"/>
-    <circle cx="111" cy="200" r="44" fill="#070a0c" stroke="#313d41" stroke-width="7"/>
-    <circle cx="111" cy="200" r="23" fill="url(#chrome)"/>
-    <circle cx="430" cy="200" r="44" fill="#070a0c" stroke="#313d41" stroke-width="7"/>
-    <circle cx="430" cy="200" r="23" fill="url(#chrome)"/>
-    <rect x="78" y="13" width="326" height="14" rx="6" fill="#27353a"/>
-    <rect x="96" y="6" width="82" height="16" rx="5" fill="url(#blueLamp)" stroke="#8fe4ff"/>
-    <rect x="320" y="6" width="82" height="16" rx="5" fill="url(#blueLamp)" stroke="#8fe4ff"/>
-    <circle cx="120" cy="14" r="8" fill="#28afff" filter="url(#blueGlow)"/>
-    <circle cx="375" cy="14" r="8" fill="#28afff" filter="url(#blueGlow)"/>
-  </g>
-
-  <g transform="translate(1030 482)" filter="url(#vehicleShadow)">
-    <ellipse cx="244" cy="165" rx="235" ry="29" fill="#000" opacity=".7"/>
-    <path d="M23 95 92 43h213l93 48 59 50-16 34H34L0 147z" fill="url(#policeBody)" stroke="#37464f" stroke-width="5"/>
-    <path d="M105 50h183l84 42H58z" fill="#dce6e9"/>
-    <path d="M112 56h76v38H79zM195 56h85l70 38H196z" fill="url(#glass)" stroke="#314851" stroke-width="3"/>
-    <path d="M44 101h362v25H31z" fill="url(#yellow)"/>
-    <path d="M44 126h362v25H31z" fill="url(#blueBat)"/>
-    <g fill="#f4f22e"><path d="M64 100h45l-18 50H46z"/><path d="M154 100h45l-18 50H136z"/><path d="M244 100h45l-18 50H226z"/><path d="M334 100h45l-18 50H316z"/></g>
-    <g fill="#126dd8"><path d="M109 100h45l-18 50H91z"/><path d="M199 100h45l-18 50H181z"/><path d="M289 100h45l-18 50H271z"/></g>
-    <rect x="197" y="103" width="88" height="27" rx="4" fill="#f5f8f9" stroke="#5f6c73"/>
-    <text x="241" y="123" text-anchor="middle" fill="#124d89" font-family="Arial,sans-serif" font-size="16" font-weight="900" letter-spacing="2">POLICE</text>
-    <path d="M31 151h407l-15 23H39z" fill="#1b2429"/>
-    <circle cx="101" cy="161" r="38" fill="#05080a" stroke="#2c373d" stroke-width="7"/>
-    <circle cx="101" cy="161" r="20" fill="url(#chrome)"/>
-    <circle cx="357" cy="161" r="38" fill="#05080a" stroke="#2c373d" stroke-width="7"/>
-    <circle cx="357" cy="161" r="20" fill="url(#chrome)"/>
-    <rect x="164" y="35" width="126" height="14" rx="5" fill="url(#blueLamp)" stroke="#8be2ff"/>
-    <circle cx="190" cy="42" r="7" fill="#29b7ff" filter="url(#blueGlow)"/>
-    <circle cx="264" cy="42" r="7" fill="#29b7ff" filter="url(#blueGlow)"/>
-    <path d="M407 102h35l14 18-38 7z" fill="#f8fbff"/>
-  </g>
-
-  <g opacity=".55" filter="url(#soft)">
-    <path d="M92 405l215 0 85 355H0z" fill="#ff1631" opacity=".14"/>
-    <path d="M602 431h267l104 329H488z" fill="#16a7ff" opacity=".16"/>
-    <path d="M1110 480h272l218 280H965z" fill="#087aff" opacity=".15"/>
-  </g>
-  <rect width="1600" height="760" fill="url(#rain)"/>
-
-  <g transform="translate(46 38)" filter="url(#shadow)">
-    <path d="M0 0h1005l26 26v270l-26 26H0l-26-26V26z" fill="url(#hud)" stroke="#5c7683" stroke-width="2"/>
-    <path d="M0 0h1005l26 26H-26l26-26z" fill="#102331"/>
-    <path d="M-11 17h730" stroke="#36c8ff" stroke-width="3"/>
-    <g transform="translate(16 24)">
-      <rect width="104" height="56" rx="5" fill="#081119" stroke="#5c6d77"/>
-      <path d="M0 0 104 56M104 0 0 56" stroke="#fff" stroke-width="15" opacity=".93"/>
-      <path d="M0 0 104 56M104 0 0 56" stroke="#c51f31" stroke-width="6"/>
-      <path d="M52 0v56M0 28h104" stroke="#fff" stroke-width="17"/>
-      <path d="M52 0v56M0 28h104" stroke="#c51f31" stroke-width="8"/>
-    </g>
-    <text x="142" y="50" fill="#6fd7ff" font-family="Arial,sans-serif" font-size="14" font-weight="800" letter-spacing="4">UNITED KINGDOM OPERATIONAL COMMAND</text>
-    <text x="18" y="147" fill="#ffffff" font-family="Arial Black,Arial,sans-serif" font-size="71" font-weight="900" letter-spacing="1">MISSIONCHIEF</text>
-    <text x="18" y="215" fill="#ffd24e" font-family="Arial Black,Arial,sans-serif" font-size="47" font-weight="900" letter-spacing="3">MAP COMMAND TOOLKIT</text>
-    <path d="M19 235h930" stroke="#25baff" stroke-width="4"/>
-    <text x="20" y="273" fill="#d7e7ed" font-family="Arial,sans-serif" font-size="19" font-weight="700" letter-spacing="2">INCIDENT INTELLIGENCE · FLEET CONTROL · TRANSPORT · MAP · FINANCE</text>
-  </g>
-
-  <g transform="translate(48 684)" filter="url(#shadow)">
-    <path d="M0 0h1504l16 16-16 40H0l-16-40z" fill="#050b10" fill-opacity=".94" stroke="#425864"/>
-    <g font-family="Arial,sans-serif" font-weight="900" font-size="14" letter-spacing="1.5">
-      <circle cx="28" cy="28" r="7" fill="#2fd274"/><text x="47" y="33" fill="#dfffea">NATIVE MISSIONCHIEF CONTROL</text>
-      <circle cx="355" cy="28" r="7" fill="#22b8ff"/><text x="374" y="33" fill="#e1f7ff">DESKTOP · TABLET · iOS</text>
-      <circle cx="681" cy="28" r="7" fill="#ffd348"/><text x="700" y="33" fill="#fff3bd">SEVEN COMPLETE INTERFACES</text>
-      <circle cx="1066" cy="28" r="7" fill="#ff4a55"/><text x="1085" y="33" fill="#ffe4e6">BOUNDED · RECOVERABLE · FAIL-SAFE</text>
-    </g>
-  </g>
-
-  <rect width="1600" height="760" fill="url(#screenGrid)" opacity=".24"/>
-  <rect width="1600" height="760" fill="none" stroke="#70838d" stroke-width="3"/>
-  <rect x="12" y="12" width="1576" height="736" rx="30" fill="none" stroke="#17242b" stroke-width="20"/>
-  <rect x="22" y="22" width="1556" height="716" rx="24" fill="none" stroke="#5b707b" stroke-opacity=".58" stroke-width="2"/>
-</g>
+<rect width="1600" height="760" rx="28" fill="url(#sky)"/>
+<rect width="1600" height="760" rx="28" fill="url(#rain)"/>
+<g opacity=".72"><path d="M0 430V310h90v120M110 430V250h105v180M235 430V325h72v105M330 430V215h130v215M480 430V290h92v140M595 430V245h120v185M742 430V320h78v110M845 430V235h105v195M980 430V300h88v130M1095 430V220h120v210M1240 430V280h92v150M1355 430V205h120v225M1495 430V310h105" fill="#071018"/><g fill="#f4d57b" opacity=".34"><rect x="38" y="340" width="10" height="22"/><rect x="64" y="338" width="10" height="22"/><rect x="145" y="285" width="12" height="28"/><rect x="180" y="285" width="12" height="28"/><rect x="368" y="260" width="12" height="28"/><rect x="410" y="260" width="12" height="28"/><rect x="625" y="280" width="12" height="28"/><rect x="672" y="280" width="12" height="28"/><rect x="875" y="270" width="12" height="28"/><rect x="920" y="270" width="12" height="28"/><rect x="1125" y="255" width="12" height="28"/><rect x="1170" y="255" width="12" height="28"/><rect x="1390" y="245" width="12" height="28"/><rect x="1435" y="245" width="12" height="28"/></g></g>
+<path d="M0 470 L1600 430 L1600 760 L0 760 Z" fill="url(#road)"/>
+<g clip-path="url(#roadClip)" opacity=".5" filter="url(#soft)"><path d="M245 480 L320 760" stroke="#1aaeff" stroke-width="44"/><path d="M530 455 L620 760" stroke="#eb2332" stroke-width="54"/><path d="M780 450 L830 760" stroke="#1baeff" stroke-width="36"/><path d="M1080 450 L1010 760" stroke="#f1c833" stroke-width="40"/><path d="M1320 440 L1210 760" stroke="#1baeff" stroke-width="34"/></g>
+<path d="M140 620h1320" stroke="#e7eef1" stroke-opacity=".11" stroke-width="2"/><path d="M720 470 670 760M910 465 960 760" stroke="#e4e7e8" stroke-opacity=".25" stroke-width="8" stroke-dasharray="34 28"/>
+<g transform="translate(48 34)"><rect width="1504" height="54" rx="10" fill="#03070b" fill-opacity=".88" stroke="#5a6972" stroke-opacity=".65"/><g transform="translate(14 9)"><rect width="58" height="36" rx="3" fill="#183c78"/><path d="M0 0 58 36M58 0 0 36" stroke="#fff" stroke-width="8"/><path d="M0 0 58 36M58 0 0 36" stroke="#c8102e" stroke-width="3"/><path d="M29 0v36M0 18h58" stroke="#fff" stroke-width="11"/><path d="M29 0v36M0 18h58" stroke="#c8102e" stroke-width="6"/></g><text x="92" y="34" fill="#80ddff" font-family="Arial,Helvetica,sans-serif" font-size="15" font-weight="800" letter-spacing="2.8">UNITED KINGDOM EMERGENCY COMMAND NETWORK</text><g transform="translate(1128 11)"><circle cx="15" cy="15" r="8" fill="#42e27b" filter="url(#smallGlow)"/><text x="35" y="21" fill="#e9f4f7" font-family="Arial,Helvetica,sans-serif" font-size="14" font-weight="800" letter-spacing="2">SYSTEM OPERATIONAL</text></g></g>
+<g filter="url(#shadow)"><rect x="140" y="112" width="1040" height="260" rx="24" fill="#02070b" fill-opacity=".72" stroke="#6fcfff" stroke-opacity=".28"/><path d="M172 132h405M742 132h406" stroke="url(#edge)" stroke-width="3"/><text x="660" y="206" text-anchor="middle" fill="url(#titleFill)" font-family="Arial Black,Arial,Helvetica,sans-serif" font-size="88" font-weight="900" letter-spacing="5">MISSIONCHIEF</text><text x="660" y="286" text-anchor="middle" fill="url(#gold)" font-family="Arial Black,Arial,Helvetica,sans-serif" font-size="56" font-weight="900" letter-spacing="4">MAP COMMAND TOOLKIT</text><text x="660" y="330" text-anchor="middle" fill="#8bdfff" font-family="Arial,Helvetica,sans-serif" font-size="17" font-weight="800" letter-spacing="4.2">INCIDENTS · FLEET · TRANSPORT · MAP · FINANCE</text></g>
+<g transform="translate(1220 108)" filter="url(#shadow)"><path d="M44 68c42-33 113-36 175-6l66 31-32 28-71-10c-39 29-98 28-132 5l-36-6 10-26z" fill="#e9edf0" stroke="#303a40" stroke-width="3"/><path d="M108 61h79l35 24-119 6z" fill="#d32a32"/><path d="M217 86 316 40l8 9-83 63z" fill="#d8dde0" stroke="#303a40" stroke-width="3"/><path d="M315 45h94" stroke="#cfd8dc" stroke-width="8"/><path d="M360 18v54M335 45h50" stroke="#dce5e8" stroke-width="5"/><path d="M85 101h105" stroke="#d52c35" stroke-width="11"/><path d="M129 46v-27M52 22h151" stroke="#ccd5d8" stroke-width="5"/><ellipse cx="127" cy="18" rx="104" ry="4" fill="#9fb0b8"/><circle cx="82" cy="117" r="10" fill="#0d1519"/><circle cx="214" cy="113" r="10" fill="#0d1519"/><text x="147" y="103" text-anchor="middle" fill="#1d2a30" font-family="Arial,Helvetica,sans-serif" font-size="14" font-weight="900">HM COASTGUARD</text><circle cx="61" cy="79" r="29" fill="url(#blueGlow)"/><circle cx="63" cy="78" r="6" fill="#b9f2ff"/></g>
+<g transform="translate(72 445)" filter="url(#shadow)"><path d="M20 54 65 13h228l50 53v108H18z" fill="url(#yellowBody)" stroke="#27343a" stroke-width="4"/><path d="M66 18h128v71H32z" fill="url(#glass)" stroke="#1b2d36" stroke-width="3"/><path d="M205 18h81l45 50h-126z" fill="url(#glass)" stroke="#1b2d36" stroke-width="3"/><path d="M24 97h314v54H24z" fill="#2e7a36"/><path d="M24 97 65 151l42-54 42 54 42-54 42 54 42-54 42 54 21-28v28H24z" fill="#e8d72f"/><rect x="88" y="109" width="158" height="27" rx="5" fill="#f4efb7" fill-opacity=".9"/><text x="167" y="129" text-anchor="middle" fill="#1c6e35" font-family="Arial Black,Arial,sans-serif" font-size="20" letter-spacing="2">AMBULANCE</text><rect x="84" y="4" width="130" height="12" rx="5" fill="#0b2639"/><g fill="#5ddcff" filter="url(#smallGlow)"><rect x="92" y="6" width="28" height="7" rx="3"/><rect x="178" y="6" width="28" height="7" rx="3"/></g><rect x="41" y="151" width="276" height="24" fill="#151d21"/><circle cx="83" cy="176" r="31" fill="#090c0e" stroke="#45545b" stroke-width="7"/><circle cx="83" cy="176" r="12" fill="#87959c"/><circle cx="281" cy="176" r="31" fill="#090c0e" stroke="#45545b" stroke-width="7"/><circle cx="281" cy="176" r="12" fill="#87959c"/><circle cx="34" cy="137" r="31" fill="url(#blueGlow)"/><circle cx="33" cy="137" r="6" fill="#d8f9ff"/><text x="178" y="218" text-anchor="middle" fill="#e4eff2" font-family="Arial,Helvetica,sans-serif" font-size="14" font-weight="900" letter-spacing="3">AMBULANCE RESPONSE</text></g>
+<g transform="translate(424 406)" filter="url(#shadow)"><path d="M18 51 94 10h324l56 57v137H15z" fill="url(#redBody)" stroke="#2b3439" stroke-width="4"/><path d="M94 16h116v75H48z" fill="url(#glass)" stroke="#1a2b34" stroke-width="3"/><path d="M219 16h178l54 53H219z" fill="url(#glass)" stroke="#1a2b34" stroke-width="3"/><rect x="33" y="104" width="420" height="56" rx="4" fill="#e8d821"/><path d="M34 105 76 159l42-54 42 54 42-54 42 54 42-54 42 54 42-54 42 54 41-54v54H34z" fill="#d82a2d"/><rect x="110" y="112" width="253" height="36" rx="6" fill="#3e0b0e" fill-opacity=".9"/><text x="237" y="138" text-anchor="middle" fill="#fff7cf" font-family="Arial Black,Arial,sans-serif" font-size="25" letter-spacing="2">FIRE &amp; RESCUE</text><path d="M77 3h300" stroke="#cad6da" stroke-width="7"/><path d="M110 -7h240" stroke="#8d9ca3" stroke-width="5"/><rect x="115" y="-1" width="86" height="13" rx="5" fill="#0b2639"/><rect x="290" y="-1" width="86" height="13" rx="5" fill="#0b2639"/><g fill="#63ddff" filter="url(#smallGlow)"><rect x="124" y="2" width="28" height="7" rx="3"/><rect x="338" y="2" width="28" height="7" rx="3"/></g><rect x="38" y="160" width="414" height="43" fill="#161d21"/><circle cx="100" cy="202" r="39" fill="#090c0e" stroke="#4e5d64" stroke-width="8"/><circle cx="100" cy="202" r="15" fill="#89979d"/><circle cx="376" cy="202" r="39" fill="#090c0e" stroke="#4e5d64" stroke-width="8"/><circle cx="376" cy="202" r="15" fill="#89979d"/><circle cx="32" cy="147" r="36" fill="url(#redGlow)"/><circle cx="31" cy="147" r="7" fill="#ffb6a9"/><text x="244" y="253" text-anchor="middle" fill="#e4eff2" font-family="Arial,Helvetica,sans-serif" font-size="14" font-weight="900" letter-spacing="3">FIRE &amp; RESCUE COMMAND</text></g>
+<g transform="translate(958 480)" filter="url(#shadow)"><path d="M24 80 78 31h211l73 60v78H12z" fill="url(#policeBody)" stroke="#26343b" stroke-width="4"/><path d="M95 34h88v56H53z" fill="url(#glass)" stroke="#1a2b34" stroke-width="3"/><path d="M193 34h78l64 56H193z" fill="url(#glass)" stroke="#1a2b34" stroke-width="3"/><path d="M19 100h333v46H19z" fill="#166dcc"/><path d="M19 101 55 145l36-44 36 44 36-44 36 44 36-44 36 44 36-44 29 35v9H19z" fill="#d9ee31"/><rect x="119" y="107" width="142" height="28" rx="5" fill="#eef5f8" fill-opacity=".94"/><text x="190" y="128" text-anchor="middle" fill="#1763aa" font-family="Arial Black,Arial,sans-serif" font-size="20" letter-spacing="2">POLICE</text><rect x="139" y="23" width="88" height="10" rx="5" fill="#0c2738"/><g fill="#62dfff" filter="url(#smallGlow)"><rect x="145" y="25" width="25" height="6" rx="3"/><rect x="196" y="25" width="25" height="6" rx="3"/></g><rect x="24" y="145" width="326" height="25" fill="#151d21"/><circle cx="78" cy="170" r="31" fill="#090c0e" stroke="#4b5960" stroke-width="7"/><circle cx="78" cy="170" r="12" fill="#87959c"/><circle cx="297" cy="170" r="31" fill="#090c0e" stroke="#4b5960" stroke-width="7"/><circle cx="297" cy="170" r="12" fill="#87959c"/><circle cx="342" cy="127" r="30" fill="url(#blueGlow)"/><circle cx="343" cy="127" r="6" fill="#dcfaff"/><text x="187" y="211" text-anchor="middle" fill="#e4eff2" font-family="Arial,Helvetica,sans-serif" font-size="14" font-weight="900" letter-spacing="3">POLICE RESPONSE</text></g>
+<g transform="translate(1324 402)" font-family="Arial,Helvetica,sans-serif"><rect width="228" height="270" rx="18" fill="#02070b" fill-opacity=".9" stroke="#60727b"/><text x="22" y="34" fill="#81dcff" font-size="12" font-weight="900" letter-spacing="2.4">COMMAND CHANNELS</text><g transform="translate(20 55)"><rect width="188" height="36" rx="7" fill="#0c2737" stroke="#1baee8"/><circle cx="20" cy="18" r="6" fill="#2cc9ff"/><text x="38" y="23" fill="#f0fbff" font-size="12" font-weight="800">INCIDENT COMMAND</text><g transform="translate(0 47)"><rect width="188" height="36" rx="7" fill="#2b0b0e" stroke="#dc3039"/><circle cx="20" cy="18" r="6" fill="#f3474e"/><text x="38" y="23" fill="#fff5f4" font-size="12" font-weight="800">FLEET &amp; TRANSPORT</text></g><g transform="translate(0 94)"><rect width="188" height="36" rx="7" fill="#172507" stroke="#a8c930"/><circle cx="20" cy="18" r="6" fill="#cbe64e"/><text x="38" y="23" fill="#f8ffe1" font-size="12" font-weight="800">MAP &amp; PLACES</text></g><g transform="translate(0 141)"><rect width="188" height="36" rx="7" fill="#281b06" stroke="#d9a72f"/><circle cx="20" cy="18" r="6" fill="#f2c34d"/><text x="38" y="23" fill="#fff4d1" font-size="12" font-weight="800">FINANCE &amp; RECOVERY</text></g></g><text x="114" y="254" text-anchor="middle" fill="#7f939d" font-size="10" font-weight="800" letter-spacing="1.5">DESKTOP · TABLET · iOS</text></g>
+<rect x="12" y="12" width="1576" height="736" rx="22" fill="none" stroke="#71838c" stroke-opacity=".55" stroke-width="2"/>
 </svg>

--- a/docs/media/readme-release-control.svg
+++ b/docs/media/readme-release-control.svg
@@ -1,186 +1,20 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" role="img" aria-labelledby="title desc">
-<title id="title">MissionChief Toolkit release and recovery operations centre</title>
-<desc id="desc">A realistic UK emergency operations control room showing the governed path from canonical source through validation, release channels, verification and recoverable backup.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="820" viewBox="0 0 1600 820" role="img" aria-labelledby="title desc">
+<title id="title">MissionChief Map Command Toolkit release and recovery control room</title>
+<desc id="desc">A realistic UK emergency operations control room visualising the governed release path for MissionChief Map Command Toolkit without overlapping text or temporary release numbers.</desc>
 <defs>
-  <linearGradient id="room" x1="0" y1="0" x2="0" y2="1"><stop stop-color="#07121c"/><stop offset=".55" stop-color="#02070b"/><stop offset="1" stop-color="#090307"/></linearGradient>
-  <linearGradient id="wall" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#1b2b34"/><stop offset=".38" stop-color="#0b141a"/><stop offset="1" stop-color="#030609"/></linearGradient>
-  <linearGradient id="desk" x1="0" y1="0" x2="0" y2="1"><stop stop-color="#43515a"/><stop offset=".12" stop-color="#11191e"/><stop offset=".65" stop-color="#05080a"/><stop offset="1" stop-color="#202d34"/></linearGradient>
-  <linearGradient id="screen" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#092233"/><stop offset=".55" stop-color="#03111b"/><stop offset="1" stop-color="#02070a"/></linearGradient>
-  <linearGradient id="steel" x1="0" y1="0" x2="0" y2="1"><stop stop-color="#71838c"/><stop offset=".12" stop-color="#1a252b"/><stop offset=".7" stop-color="#070a0c"/><stop offset="1" stop-color="#28343a"/></linearGradient>
-  <linearGradient id="bluePanel" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#0d5c86"/><stop offset=".5" stop-color="#07304a"/><stop offset="1" stop-color="#03101a"/></linearGradient>
-  <linearGradient id="greenPanel" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#185f32"/><stop offset=".5" stop-color="#0b321c"/><stop offset="1" stop-color="#031109"/></linearGradient>
-  <linearGradient id="amberPanel" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#75520d"/><stop offset=".5" stop-color="#3d2a08"/><stop offset="1" stop-color="#160e02"/></linearGradient>
-  <linearGradient id="redPanel" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#74212a"/><stop offset=".5" stop-color="#3b1017"/><stop offset="1" stop-color="#140408"/></linearGradient>
-  <pattern id="grid" width="34" height="34" patternUnits="userSpaceOnUse"><path d="M34 0H0V34" fill="none" stroke="#5ed2ff" stroke-opacity=".055"/></pattern>
-  <pattern id="scan" width="5" height="5" patternUnits="userSpaceOnUse"><rect width="5" height="1" fill="#fff" opacity=".018"/></pattern>
-  <filter id="shadow" x="-40%" y="-40%" width="180%" height="200%"><feDropShadow dx="0" dy="18" stdDeviation="15" flood-color="#000" flood-opacity=".88"/></filter>
-  <filter id="glow" x="-250%" y="-250%" width="600%" height="600%"><feGaussianBlur stdDeviation="9" result="g"/><feMerge><feMergeNode in="g"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-  <filter id="soft" x="-30%" y="-30%" width="160%" height="160%"><feGaussianBlur stdDeviation="5"/></filter>
-  <clipPath id="clip"><rect x="18" y="18" width="1564" height="864" rx="28"/></clipPath>
+  <linearGradient id="room" x1="0" y1="0" x2="0" y2="1"><stop stop-color="#07131d"/><stop offset=".55" stop-color="#02070b"/><stop offset="1" stop-color="#090307"/></linearGradient>
+  <linearGradient id="desk" x1="0" y1="0" x2="0" y2="1"><stop stop-color="#56656d"/><stop offset=".12" stop-color="#172127"/><stop offset=".7" stop-color="#05080a"/><stop offset="1" stop-color="#27343b"/></linearGradient>
+  <linearGradient id="screen" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#0b3146"/><stop offset=".55" stop-color="#03111a"/><stop offset="1" stop-color="#020608"/></linearGradient>
+  <linearGradient id="titleFill" x1="0" y1="0" x2="0" y2="1"><stop stop-color="#fff"/><stop offset=".55" stop-color="#dbe8ed"/><stop offset="1" stop-color="#91a4ad"/></linearGradient>
+  <linearGradient id="gold" x1="0" y1="0" x2="0" y2="1"><stop stop-color="#fff0a0"/><stop offset=".5" stop-color="#e2af38"/><stop offset="1" stop-color="#875007"/></linearGradient>
+  <filter id="shadow" x="-30%" y="-30%" width="160%" height="180%"><feDropShadow dx="0" dy="16" stdDeviation="18" flood-color="#000" flood-opacity=".72"/></filter>
+  <filter id="glow" x="-100%" y="-100%" width="300%" height="300%"><feGaussianBlur stdDeviation="5" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+  <pattern id="grid" width="36" height="36" patternUnits="userSpaceOnUse"><path d="M36 0H0V36" fill="none" stroke="#63d1ff" stroke-opacity=".05"/></pattern>
 </defs>
-<g clip-path="url(#clip)">
-  <rect width="1600" height="900" fill="url(#room)"/>
-  <rect width="1600" height="900" fill="url(#grid)"/>
-  <rect width="1600" height="900" fill="url(#scan)"/>
-
-  <!-- Control room walls -->
-  <path d="M0 0h1600v572H0z" fill="url(#wall)"/>
-  <path d="M0 572h1600v328H0z" fill="#030506"/>
-  <path d="M0 575h1600" stroke="#647680" stroke-opacity=".35" stroke-width="4"/>
-  <g opacity=".45">
-    <path d="M0 0 260 0 520 572H330z" fill="#163246"/>
-    <path d="M1600 0h-260l-260 572h190z" fill="#2a1118"/>
-  </g>
-
-  <!-- Header identity -->
-  <g transform="translate(38 30)" filter="url(#shadow)">
-    <path d="M0 0h1524l18 18v98l-18 18H0l-18-18V18z" fill="#050b10" fill-opacity=".94" stroke="#5e727c" stroke-width="2"/>
-    <g transform="translate(18 18)">
-      <rect width="82" height="50" rx="4" fill="#081017" stroke="#667882"/>
-      <path d="M0 0 82 50M82 0 0 50" stroke="#fff" stroke-width="13"/><path d="M0 0 82 50M82 0 0 50" stroke="#c71f31" stroke-width="5"/>
-      <path d="M41 0v50M0 25h82" stroke="#fff" stroke-width="15"/><path d="M41 0v50M0 25h82" stroke="#c71f31" stroke-width="7"/>
-    </g>
-    <text x="122" y="47" fill="#68d7ff" font-family="Arial,sans-serif" font-size="15" font-weight="900" letter-spacing="4">MISSIONCHIEF TOOLKIT // GOVERNED DELIVERY OPERATIONS</text>
-    <text x="122" y="94" fill="#fff" font-family="Arial Black,Arial,sans-serif" font-size="43" font-weight="900" letter-spacing="1">RELEASE &amp; RECOVERY CONTROL</text>
-    <g transform="translate(1190 22)" font-family="Arial,sans-serif">
-      <text x="0" y="15" fill="#7f919b" font-size="11" font-weight="800" letter-spacing="2">CHAIN HEALTH</text>
-      <circle cx="20" cy="54" r="8" fill="#34d878" filter="url(#glow)"/>
-      <text x="42" y="61" fill="#dffff0" font-size="19" font-weight="900" letter-spacing="2">VERIFIED</text>
-      <text x="0" y="96" fill="#8496a0" font-size="11" letter-spacing="1.4">SOURCE · RELEASE · RECOVERY</text>
-    </g>
-  </g>
-
-  <!-- Wall screens -->
-  <g transform="translate(62 188)" filter="url(#shadow)">
-    <!-- left screen -->
-    <g>
-      <rect width="430" height="250" rx="8" fill="#010407" stroke="#5f717a" stroke-width="5"/>
-      <rect x="12" y="12" width="406" height="226" rx="4" fill="url(#screen)" stroke="#14394d"/>
-      <text x="28" y="38" fill="#5bd3ff" font-family="Arial,sans-serif" font-size="12" font-weight="900" letter-spacing="2.4">CANONICAL SOURCE // MAIN</text>
-      <path d="M28 52h372" stroke="#1d749c"/>
-      <g font-family="Courier New,monospace" font-size="12">
-        <text x="28" y="82" fill="#58d5ff">src/</text>
-        <text x="68" y="82" fill="#e7f5fb">MissionChief_Map_Command_Toolkit.user.js</text>
-        <text x="28" y="112" fill="#8a9aa2">syntax</text><text x="130" y="112" fill="#49df78">PASS</text>
-        <text x="28" y="139" fill="#8a9aa2">metadata</text><text x="130" y="139" fill="#49df78">PASS</text>
-        <text x="28" y="166" fill="#8a9aa2">runtime contracts</text><text x="170" y="166" fill="#49df78">PASS</text>
-        <text x="28" y="193" fill="#8a9aa2">hosted media</text><text x="160" y="193" fill="#49df78">PASS</text>
-      </g>
-      <path d="M288 87h95M288 110h70M288 133h83M288 156h55M288 179h102" stroke="#24b9ee" stroke-width="4" stroke-linecap="round" opacity=".72"/>
-      <circle cx="388" cy="203" r="13" fill="#103c20" stroke="#43d56f"/><path d="m381 203 5 5 10-13" fill="none" stroke="#59e786" stroke-width="4"/>
-    </g>
-
-    <!-- centre screen -->
-    <g transform="translate(465)">
-      <rect width="560" height="250" rx="8" fill="#010407" stroke="#5f717a" stroke-width="5"/>
-      <rect x="12" y="12" width="536" height="226" rx="4" fill="url(#screen)" stroke="#14394d"/>
-      <text x="28" y="38" fill="#5bd3ff" font-family="Arial,sans-serif" font-size="12" font-weight="900" letter-spacing="2.4">UK RELEASE TOPOLOGY // VERIFIED DELIVERY CHAIN</text>
-      <path d="M28 52h504" stroke="#1d749c"/>
-      <!-- UK map -->
-      <g transform="translate(356 58) scale(.34)">
-        <path d="M196 0l-30 24-14 46-37 26-8 46-35 35 5 41-22 38 12 35-18 43 12 54 39 13 22 43 45-5 31 34 45-6 26-38 43-9 18-46 42-28-8-52 24-43-8-45-34-26-7-38-37-20 10-39-27-32-37 11-27-37z" fill="#0c2d3b" stroke="#51caff" stroke-width="7"/>
-        <g fill="#ff4652" filter="url(#glow)"><circle cx="165" cy="110" r="14"/><circle cx="196" cy="252" r="16"/><circle cx="224" cy="375" r="15"/></g>
-      </g>
-      <g font-family="Arial,sans-serif" font-weight="900">
-        <g transform="translate(28 78)"><rect width="112" height="58" rx="7" fill="url(#bluePanel)" stroke="#2ab9ff"/><text x="56" y="25" text-anchor="middle" fill="#fff" font-size="12">SOURCE</text><text x="56" y="43" text-anchor="middle" fill="#87e2ff" font-size="10">CANONICAL</text></g>
-        <path d="M146 107h34m-11-10 11 10-11 10" fill="none" stroke="#53cbff" stroke-width="4"/>
-        <g transform="translate(186 78)"><rect width="112" height="58" rx="7" fill="url(#greenPanel)" stroke="#45d169"/><text x="56" y="25" text-anchor="middle" fill="#fff" font-size="12">VALIDATE</text><text x="56" y="43" text-anchor="middle" fill="#8bf0a7" font-size="10">CONTRACTS</text></g>
-        <path d="M304 107h34m-11-10 11 10-11 10" fill="none" stroke="#53cbff" stroke-width="4"/>
-        <g transform="translate(28 155)"><rect width="112" height="58" rx="7" fill="url(#amberPanel)" stroke="#edb53e"/><text x="56" y="25" text-anchor="middle" fill="#fff" font-size="12">RELEASE</text><text x="56" y="43" text-anchor="middle" fill="#ffe09b" font-size="10">IMMUTABLE</text></g>
-        <path d="M146 184h34m-11-10 11 10-11 10" fill="none" stroke="#53cbff" stroke-width="4"/>
-        <g transform="translate(186 155)"><rect width="112" height="58" rx="7" fill="url(#redPanel)" stroke="#ef5962"/><text x="56" y="25" text-anchor="middle" fill="#fff" font-size="12">VERIFY</text><text x="56" y="43" text-anchor="middle" fill="#ffadb4" font-size="10">PARITY</text></g>
-      </g>
-    </g>
-
-    <!-- right screen -->
-    <g transform="translate(1060)">
-      <rect width="430" height="250" rx="8" fill="#010407" stroke="#5f717a" stroke-width="5"/>
-      <rect x="12" y="12" width="406" height="226" rx="4" fill="url(#screen)" stroke="#14394d"/>
-      <text x="28" y="38" fill="#5bd3ff" font-family="Arial,sans-serif" font-size="12" font-weight="900" letter-spacing="2.4">CHANNEL PARITY // PUBLIC DELIVERY</text>
-      <path d="M28 52h372" stroke="#1d749c"/>
-      <g font-family="Arial,sans-serif" font-size="14" font-weight="900">
-        <circle cx="44" cy="88" r="7" fill="#39d876"/><text x="64" y="94" fill="#e7fff0">GITHUB RELEASE</text><text x="367" y="94" text-anchor="end" fill="#6fe595">VERIFIED</text>
-        <circle cx="44" cy="126" r="7" fill="#39d876"/><text x="64" y="132" fill="#e7fff0">GREASY FORK</text><text x="367" y="132" text-anchor="end" fill="#6fe595">VERIFIED</text>
-        <circle cx="44" cy="164" r="7" fill="#39d876"/><text x="64" y="170" fill="#e7fff0">PRIVATE RECOVERY</text><text x="367" y="170" text-anchor="end" fill="#6fe595">READY</text>
-        <circle cx="44" cy="202" r="7" fill="#39d876"/><text x="64" y="208" fill="#e7fff0">DISCORD SIGNAL</text><text x="367" y="208" text-anchor="end" fill="#6fe595">POSTED</text>
-      </g>
-    </g>
-  </g>
-
-  <!-- Consoles -->
-  <g transform="translate(78 493)" filter="url(#shadow)">
-    <path d="M0 0h1444l28 25-64 309H64L-28 25z" fill="url(#desk)" stroke="#687b85" stroke-width="4"/>
-    <path d="M36 36h1372l-44 224H86z" fill="#030609" stroke="#25343b" stroke-width="3"/>
-    <path d="M86 260h1278l20 44H64z" fill="#10181d" stroke="#53656e"/>
-
-    <!-- pipeline modules -->
-    <g transform="translate(76 60)" font-family="Arial,sans-serif" filter="url(#shadow)">
-      <g>
-        <rect width="230" height="156" rx="10" fill="url(#bluePanel)" stroke="#2ab8ff" stroke-width="2"/>
-        <circle cx="40" cy="40" r="22" fill="#07273c" stroke="#4ecaff"/><path d="M40 19v42M19 40h42" stroke="#5cd4ff" stroke-width="4"/>
-        <text x="78" y="36" fill="#fff" font-size="19" font-weight="900">CANONICAL</text><text x="78" y="59" fill="#7bdcff" font-size="14" font-weight="900">SOURCE</text>
-        <text x="24" y="101" fill="#ccefff" font-size="12">Exact userscript on main</text><text x="24" y="126" fill="#ccefff" font-size="12">No external source authority</text>
-      </g>
-      <path d="M240 78h38m-12-12 12 12-12 12" fill="none" stroke="#53caff" stroke-width="5"/>
-      <g transform="translate(288)">
-        <rect width="230" height="156" rx="10" fill="url(#greenPanel)" stroke="#49d36e" stroke-width="2"/>
-        <path d="M40 17 62 25v19c0 18-10 29-22 38-12-9-22-20-22-38V25z" fill="#123d20" stroke="#65e087" stroke-width="3"/><path d="m31 44 7 7 14-18" fill="none" stroke="#7af19b" stroke-width="5"/>
-        <text x="78" y="36" fill="#fff" font-size="19" font-weight="900">VALIDATION</text><text x="78" y="59" fill="#8bf0a7" font-size="14" font-weight="900">EXACT HEAD</text>
-        <text x="24" y="101" fill="#d7ffe2" font-size="12">Syntax · metadata · runtime</text><text x="24" y="126" fill="#d7ffe2" font-size="12">Docs · assets · release rules</text>
-      </g>
-      <path d="M528 78h38m-12-12 12 12-12 12" fill="none" stroke="#53caff" stroke-width="5"/>
-      <g transform="translate(576)">
-        <rect width="230" height="156" rx="10" fill="url(#amberPanel)" stroke="#e8af37" stroke-width="2"/>
-        <circle cx="40" cy="40" r="22" fill="#4b3407" stroke="#f1bf4b"/><path d="M40 21v38M21 40h38" stroke="#ffd46a" stroke-width="4"/>
-        <text x="78" y="36" fill="#fff" font-size="19" font-weight="900">RELEASE</text><text x="78" y="59" fill="#ffe19d" font-size="14" font-weight="900">IMMUTABLE</text>
-        <text x="24" y="101" fill="#fff0c8" font-size="12">Tag · asset · SHA-256</text><text x="24" y="126" fill="#fff0c8" font-size="12">Stable distribution publication</text>
-      </g>
-      <path d="M816 78h38m-12-12 12 12-12 12" fill="none" stroke="#53caff" stroke-width="5"/>
-      <g transform="translate(864)">
-        <rect width="230" height="156" rx="10" fill="url(#redPanel)" stroke="#ef5962" stroke-width="2"/>
-        <circle cx="40" cy="40" r="22" fill="#4a1016" stroke="#ff6972"/><path d="M40 18a22 22 0 1 1-16 7M19 20h20v20" fill="none" stroke="#ff7b83" stroke-width="4"/>
-        <text x="78" y="36" fill="#fff" font-size="19" font-weight="900">RECOVERY</text><text x="78" y="59" fill="#ffadb4" font-size="14" font-weight="900">CHECKSUM-BACKED</text>
-        <text x="24" y="101" fill="#ffe2e4" font-size="12">Private migration backup</text><text x="24" y="126" fill="#ffe2e4" font-size="12">Deterministic rollback identity</text>
-      </g>
-      <path d="M1104 78h38m-12-12 12 12-12 12" fill="none" stroke="#53caff" stroke-width="5"/>
-      <g transform="translate(1152)">
-        <rect width="230" height="156" rx="10" fill="#122536" stroke="#6f8c9c" stroke-width="2"/>
-        <circle cx="40" cy="40" r="22" fill="#092032" stroke="#59cfff"/><circle cx="40" cy="40" r="8" fill="#3bdc7a" filter="url(#glow)"/>
-        <text x="78" y="36" fill="#fff" font-size="19" font-weight="900">CONFIRM</text><text x="78" y="59" fill="#8de4ff" font-size="14" font-weight="900">CHANNEL PARITY</text>
-        <text x="24" y="101" fill="#dff7ff" font-size="12">GitHub · Greasy Fork · Discord</text><text x="24" y="126" fill="#dff7ff" font-size="12">Release complete only at parity</text>
-      </g>
-    </g>
-
-    <!-- operator lights -->
-    <g transform="translate(92 278)">
-      <g fill="#31d776" filter="url(#glow)"><circle cx="0" cy="0" r="5"/><circle cx="30" cy="0" r="5"/><circle cx="60" cy="0" r="5"/><circle cx="90" cy="0" r="5"/></g>
-      <g fill="#27b7ff"><circle cx="120" cy="0" r="5"/><circle cx="150" cy="0" r="5"/></g>
-      <g fill="#ffbf3d"><circle cx="180" cy="0" r="5"/></g>
-    </g>
-    <text x="1360" y="286" text-anchor="end" fill="#8fa0a8" font-family="Courier New,monospace" font-size="12" letter-spacing="2">GITHUB AUTHORITATIVE</text>
-  </g>
-
-  <!-- floor reflections -->
-  <g opacity=".26" filter="url(#soft)">
-    <path d="M155 798h210l-70 102H92z" fill="#169bd4"/>
-    <path d="M560 798h210l35 102H516z" fill="#28a955"/>
-    <path d="M958 798h210l110 102H916z" fill="#d39422"/>
-    <path d="M1280 798h185l95 102h-331z" fill="#b32836"/>
-  </g>
-
-  <!-- footer rail -->
-  <g transform="translate(44 836)" filter="url(#shadow)">
-    <path d="M0 0h1512l16 16-16 40H0l-16-40z" fill="#04090d" stroke="#536771"/>
-    <g font-family="Arial,sans-serif" font-size="13" font-weight="900" letter-spacing="1.4">
-      <circle cx="28" cy="28" r="6" fill="#28d272"/><text x="44" y="33" fill="#fff">EXACT-HEAD VALIDATION</text>
-      <circle cx="342" cy="28" r="6" fill="#27b7ff"/><text x="358" y="33" fill="#fff">IMMUTABLE RELEASE ASSETS</text>
-      <circle cx="723" cy="28" r="6" fill="#ffbd3b"/><text x="739" y="33" fill="#fff">PUBLIC CHANNEL PARITY</text>
-      <circle cx="1059" cy="28" r="6" fill="#ff4d59"/><text x="1075" y="33" fill="#fff">PRIVATE RECOVERY IDENTITY</text>
-    </g>
-  </g>
-
-  <rect width="1600" height="900" fill="none" stroke="#748a95" stroke-width="3"/>
-  <rect x="12" y="12" width="1576" height="876" rx="30" fill="none" stroke="url(#steel)" stroke-width="20"/>
-  <rect x="24" y="24" width="1552" height="852" rx="22" fill="none" stroke="#6d818b" stroke-opacity=".55" stroke-width="2"/>
-</g>
+<rect width="1600" height="820" rx="28" fill="url(#room)"/><rect width="1600" height="820" rx="28" fill="url(#grid)"/>
+<g transform="translate(44 38)" filter="url(#shadow)"><rect width="1512" height="92" rx="14" fill="#02070b" fill-opacity=".94" stroke="#60717a"/><text x="30" y="34" fill="#79d9ff" font-family="Arial,Helvetica,sans-serif" font-size="13" font-weight="900" letter-spacing="2.8">MISSIONCHIEF MAP COMMAND TOOLKIT</text><text x="30" y="68" fill="url(#titleFill)" font-family="Arial Black,Arial,sans-serif" font-size="31" font-weight="900" letter-spacing="2">RELEASE &amp; RECOVERY CONTROL</text><g transform="translate(1230 23)"><circle cx="16" cy="21" r="9" fill="#43df78" filter="url(#glow)"/><text x="40" y="27" fill="#eaf6f8" font-family="Arial,Helvetica,sans-serif" font-size="14" font-weight="900" letter-spacing="2">VERIFIED</text></g></g>
+<g transform="translate(64 160)" filter="url(#shadow)"><rect width="1472" height="350" rx="20" fill="#060c10" stroke="#5e7078" stroke-width="3"/><g transform="translate(18 18)"><rect width="460" height="314" rx="12" fill="url(#screen)" stroke="#237fac"/><text x="24" y="34" fill="#6ed9ff" font-family="Arial,Helvetica,sans-serif" font-size="12" font-weight="900" letter-spacing="2.4">SOURCE AUTHORITY</text><text x="24" y="72" fill="#fff" font-family="Arial Black,Arial,sans-serif" font-size="26">CANONICAL MAIN</text><g transform="translate(25 100)" fill="none" stroke="#34bff2" stroke-width="5"><path d="M0 0h260M0 31h330M0 62h210M0 93h290M0 124h245"/></g><rect x="310" y="194" width="110" height="74" rx="10" fill="#061018" stroke="#3cc5f7"/><text x="365" y="239" text-anchor="middle" fill="#7edfff" font-family="Arial Black,Arial,sans-serif" font-size="28">.JS</text></g><g transform="translate(496 18)"><rect width="460" height="314" rx="12" fill="url(#screen)" stroke="#4aab59"/><text x="24" y="34" fill="#76e783" font-family="Arial,Helvetica,sans-serif" font-size="12" font-weight="900" letter-spacing="2.4">EXACT-HEAD VALIDATION</text><text x="24" y="72" fill="#fff" font-family="Arial Black,Arial,sans-serif" font-size="26">ALL GATES PASSED</text><g transform="translate(28 105)" font-family="Arial,Helvetica,sans-serif" font-size="14" font-weight="800" fill="#eefaf0"><circle cx="10" cy="4" r="7" fill="#4bdd63"/><text x="30" y="10">Source and metadata</text><circle cx="10" cy="47" r="7" fill="#4bdd63"/><text x="30" y="53">Runtime contracts</text><circle cx="10" cy="90" r="7" fill="#4bdd63"/><text x="30" y="96">Documentation and assets</text><circle cx="10" cy="133" r="7" fill="#4bdd63"/><text x="30" y="139">Distribution parity</text></g><path d="m337 221 32 32 63-86" fill="none" stroke="#57dc68" stroke-width="12" stroke-linecap="round" stroke-linejoin="round"/></g><g transform="translate(974 18)"><rect width="460" height="314" rx="12" fill="url(#screen)" stroke="#d4a43b"/><text x="24" y="34" fill="#f3c757" font-family="Arial,Helvetica,sans-serif" font-size="12" font-weight="900" letter-spacing="2.4">DELIVERY &amp; RECOVERY</text><text x="24" y="72" fill="#fff" font-family="Arial Black,Arial,sans-serif" font-size="26">CHANNEL PARITY</text><g transform="translate(26 104)" font-family="Arial,Helvetica,sans-serif" font-size="13" font-weight="900"><g><rect width="184" height="46" rx="8" fill="#251904" stroke="#d5a73f"/><text x="92" y="29" text-anchor="middle" fill="#fff1c5">GITHUB RELEASE</text></g><g transform="translate(220)"><rect width="184" height="46" rx="8" fill="#11210f" stroke="#50b95a"/><text x="92" y="29" text-anchor="middle" fill="#effff0">GREASY FORK</text></g><g transform="translate(0 65)"><rect width="184" height="46" rx="8" fill="#1c1227" stroke="#8c64c4"/><text x="92" y="29" text-anchor="middle" fill="#f7efff">PRIVATE RECOVERY</text></g><g transform="translate(220 65)"><rect width="184" height="46" rx="8" fill="#101b2b" stroke="#4d83d1"/><text x="92" y="29" text-anchor="middle" fill="#eff5ff">DISCORD SIGNAL</text></g></g><path d="M118 235h227" stroke="#e5b54b" stroke-width="5"/><path d="m331 220 18 15-18 15" fill="none" stroke="#e5b54b" stroke-width="5"/><text x="232" y="279" text-anchor="middle" fill="#d9c89f" font-family="Arial,Helvetica,sans-serif" font-size="12" font-weight="900" letter-spacing="2">IMMUTABLE · VERIFIED · RECOVERABLE</text></g></g>
+<g transform="translate(85 548)" font-family="Arial,Helvetica,sans-serif" filter="url(#shadow)"><rect width="1430" height="120" rx="18" fill="#03080c" fill-opacity=".95" stroke="#5b6b73"/><g transform="translate(22 25)" font-size="11" font-weight="900"><g><rect width="185" height="68" rx="10" fill="#0b2a3e" stroke="#27b9ef"/><text x="92" y="28" text-anchor="middle" fill="#e8f9ff">CANONICAL</text><text x="92" y="48" text-anchor="middle" fill="#8edfff">SOURCE</text></g><path d="M191 34h35m-12-11 12 11-12 11" fill="none" stroke="#5dcfff" stroke-width="4"/><g transform="translate(234)"><rect width="185" height="68" rx="10" fill="#102310" stroke="#4fc35f"/><text x="92" y="28" text-anchor="middle" fill="#edffef">EXACT-HEAD</text><text x="92" y="48" text-anchor="middle" fill="#83e88e">VALIDATION</text></g><path d="M425 34h35m-12-11 12 11-12 11" fill="none" stroke="#5dcfff" stroke-width="4"/><g transform="translate(468)"><rect width="185" height="68" rx="10" fill="#281d08" stroke="#d5a63d"/><text x="92" y="28" text-anchor="middle" fill="#fff5d6">IMMUTABLE</text><text x="92" y="48" text-anchor="middle" fill="#edc664">RELEASE</text></g><path d="M659 34h35m-12-11 12 11-12 11" fill="none" stroke="#5dcfff" stroke-width="4"/><g transform="translate(702)"><rect width="185" height="68" rx="10" fill="#0f2211" stroke="#51bd5a"/><text x="92" y="28" text-anchor="middle" fill="#effff0">PUBLIC</text><text x="92" y="48" text-anchor="middle" fill="#80df89">PARITY</text></g><path d="M893 34h35m-12-11 12 11-12 11" fill="none" stroke="#5dcfff" stroke-width="4"/><g transform="translate(936)"><rect width="185" height="68" rx="10" fill="#21132b" stroke="#8e65c4"/><text x="92" y="28" text-anchor="middle" fill="#faf1ff">PRIVATE</text><text x="92" y="48" text-anchor="middle" fill="#c6a2ed">RECOVERY</text></g><path d="M1127 34h35m-12-11 12 11-12 11" fill="none" stroke="#5dcfff" stroke-width="4"/><g transform="translate(1170)"><rect width="185" height="68" rx="10" fill="#101d2e" stroke="#4d83d1"/><text x="92" y="28" text-anchor="middle" fill="#eff5ff">DISCORD</text><text x="92" y="48" text-anchor="middle" fill="#94b8ed">CONFIRMATION</text></g></g></g>
+<g transform="translate(130 696)" opacity=".96"><path d="M0 36h1340l80 84H-80z" fill="url(#desk)" stroke="#56666e" stroke-width="3"/><g fill="#0b1115" stroke="#34444c" stroke-width="2"><rect x="80" y="-12" width="260" height="78" rx="7"/><rect x="540" y="-12" width="260" height="78" rx="7"/><rect x="1000" y="-12" width="260" height="78" rx="7"/></g><g fill="#2cc8ff" opacity=".55"><rect x="105" y="6" width="210" height="6"/><rect x="565" y="6" width="210" height="6"/><rect x="1025" y="6" width="210" height="6"/></g></g>
+<rect x="12" y="12" width="1576" height="796" rx="22" fill="none" stroke="#71838c" stroke-opacity=".55" stroke-width="2"/>
 </svg>


### PR DESCRIPTION
## Objective

Rebuild the MissionChief Map Command Toolkit repository landing page around a coherent, realistic UK emergency-services identity while correcting all stale release presentation and protecting text from clipping, overlap and uncontrolled scaling.

## Visual redesign

### UK emergency command hero

- Replaces the previous hero with a rain-soaked United Kingdom emergency-command scene centred on the full **MissionChief Map Command Toolkit** name.
- Uses a protected title safe zone, fixed fleet geometry and separate ambulance, fire and rescue, police and HM Coastguard compositions.
- Keeps all labels within explicit bounds and uses GitHub-safe SVG text and shapes only.

### Operational picture

- Rebuilds the command board around one central Toolkit identity.
- Places Mission Control, Fleet & Transport, Map & Places and Finance & Recovery in four fixed quadrants.
- Adds an isolated eight-interface rail so theme labels cannot collide with operational panels.

### Release and recovery control

- Rebuilds the release graphic as a structured UK emergency operations room.
- Uses three fixed wall screens plus a six-stage release pipeline.
- Removes temporary release numbers from artwork so future releases cannot leave the graphics stale.

## README overhaul

- Rewrites the page around the current verified `v8.2.7` production state.
- Removes obsolete v8.0.2–v8.0.4 candidate and hotfix copy.
- Documents the current Patient Transport Sweep native **Cancel Transport** / **Discharge patient** correction.
- Synchronises the SHA-256, GitHub Release, private recovery commit and hosted-media audit with the machine-backed release ledger.
- Tightens hierarchy, tables, navigation and installation guidance.
- Preserves all required product-boundary, security, interface, device and saved Discord webhook statements.

## Scope

Presentation and documentation only:

- `README.md`
- `docs/media/readme-hero.svg`
- `docs/media/readme-command-board.svg`
- `docs/media/readme-release-control.svg`

No userscript source, distribution file, runtime behaviour, settings, observers, timers, release ledger or deployment state changed.

## Validation completed before publication

- Started from exact `main` head `32234e8a2a40f1743837132a76f5ed334d41dc46`.
- XML parsing passed for all three SVGs.
- All three SVGs rendered successfully at 1600px width.
- Manual rendered inspection confirmed no clipped text, overlapping labels or elements outside the viewBox.
- Artwork contains no embedded semantic release number.
- README required-token and forbidden-token checks passed locally.
- Exact branch diff contains only the four intended presentation files.