### PR TITLE
Audit: Refresh v8.3.2 controlled Chrome CSS baseline

### DIFF
--- a/.github/scripts/collect_controlled_browser_evidence.py
+++ b/.github/scripts/collect_controlled_browser_evidence.py
@@ -4,45 +4,88 @@
 This is deliberately not a substitute for authenticated MissionChief live scenarios.
 """
 from __future__ import annotations
-import argparse, hashlib, html, json, re, shutil, statistics, subprocess, tempfile
+
+import argparse
+import hashlib
+import html
+import json
+import re
+import shutil
+import statistics
+import subprocess
+import tempfile
 from pathlib import Path
 
-VIEWPORTS=[('desktop',1440,900),('tablet',1024,768),('ios',390,844)]
+VIEWPORTS = [('desktop', 1440, 900), ('tablet', 1024, 768), ('ios', 390, 844)]
+DEFAULT_SAMPLES = 11
+
+
+def toolkit_version(source: str) -> str:
+    match = re.search(r'(?m)^//\s*@version\s+([^\s]+)\s*$', source)
+    if not match:
+        raise ValueError('Toolkit metadata version not found')
+    return match.group(1)
+
 
 def extract_main_css(source: str) -> str:
-    start=source.index('function installMainStyles()')
-    marker=source.index('addStyle(`',start)+len('addStyle(`')
-    i=marker; escaped=False
-    while i < len(source):
-        ch=source[i]
-        if escaped: escaped=False
-        elif ch=='\\': escaped=True
-        elif ch=='`': return source[marker:i]
-        i+=1
+    start = source.index('function installMainStyles()')
+    marker = source.index('addStyle(`', start) + len('addStyle(`')
+    index = marker
+    escaped = False
+    while index < len(source):
+        char = source[index]
+        if escaped:
+            escaped = False
+        elif char == '\\':
+            escaped = True
+        elif char == '`':
+            return source[marker:index]
+        index += 1
     raise ValueError('installMainStyles template terminator not found')
 
+
 def extract_root_attributes(source: str) -> list[str]:
-    start=source.index('function applyRootAttributes()')
-    end=source.index('\n    function getStrongMarkerSignal',start)
-    names=re.findall(r"setAttributeIfChanged\(root, '([^']+)'",source[start:end])
-    if len(names)!=22 or len(set(names))!=22: raise ValueError(f'expected 22 unique root attributes, got {len(names)}')
+    start = source.index('function applyRootAttributes()')
+    candidates = [
+        source.find('\n    function getStrongMarkerSignal', start),
+        source.find('\n    function ', start + len('function applyRootAttributes()')),
+    ]
+    valid = [value for value in candidates if value > start]
+    if not valid:
+        raise ValueError('applyRootAttributes boundary not found')
+    end = min(valid)
+    names = re.findall(r"setAttributeIfChanged\(root, '([^']+)'", source[start:end])
+    if len(names) != 22 or len(set(names)) != 22:
+        raise ValueError(f'expected 22 unique root attributes, got {len(names)}')
     return names
 
-def median(values): return round(statistics.median(values),4)
 
-def html_document(css: str, attrs: list[str], label: str) -> str:
-    payload=json.dumps(css); attrs_json=json.dumps(attrs)
+def median(values: list[float]) -> float:
+    return round(statistics.median(values), 4)
+
+
+def percentile(values: list[float], percent: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    rank = max(0, min(len(ordered) - 1, round((len(ordered) - 1) * percent)))
+    return round(ordered[rank], 4)
+
+
+def html_document(css: str, attrs: list[str], label: str, samples: int) -> str:
+    payload = json.dumps(css)
+    attrs_json = json.dumps(attrs)
     return f'''<!doctype html><html><head><meta charset="utf-8"><title>MCMS controlled evidence</title></head><body>
 <div id="map_outer"><div id="map" class="leaflet-container"><div class="leaflet-pane leaflet-marker-pane"></div></div></div>
 <div id="missions" class="missions-panel mission-list"></div><div id="mc-map-command-panel" class="mcms-panel mcms-open"></div>
 <pre id="result">pending</pre><script>
-const CSS={payload}; const ATTRS={attrs_json}; const LABEL={json.dumps(label)};
-for(let i=0;i<120;i++){{const n=document.createElement('div');n.className=`mcms-card mcms-row mcms-setting-row mcms-mission-row mcms-${{i%9}}`;n.textContent='Evidence '+i;document.body.appendChild(n);}}
+const CSS={payload}; const ATTRS={attrs_json}; const LABEL={json.dumps(label)}; const SAMPLES={samples};
+for(let i=0;i<240;i++){{const n=document.createElement('div');n.className=`mcms-card mcms-row mcms-setting-row mcms-mission-row mcms-${{i%13}}`;n.textContent='Evidence '+i;document.body.appendChild(n);}}
 const longTasks=[]; const shifts=[];
 try{{new PerformanceObserver(l=>longTasks.push(...l.getEntries().map(e=>e.duration))).observe({{type:'longtask',buffered:true}})}}catch(e){{}}
 try{{new PerformanceObserver(l=>shifts.push(...l.getEntries().filter(e=>!e.hadRecentInput).map(e=>e.value))).observe({{type:'layout-shift',buffered:true}})}}catch(e){{}}
 const inserts=[],layouts=[];
-for(let i=0;i<3;i++){{
+for(let i=0;i<SAMPLES;i++){{
  const style=document.createElement('style');style.id='mc-map-command-style-'+i;style.textContent=CSS+`\n/* controlled-run:${{i}} */`;
  let t=performance.now();document.head.appendChild(style);inserts.push(performance.now()-t);
  t=performance.now();const nodes=document.querySelectorAll('.mcms-card,.leaflet-container,#mc-map-command-panel');let checksum=0;for(let j=0;j<nodes.length;j+=5){{const cs=getComputedStyle(nodes[j]);checksum+=nodes[j].offsetHeight+cs.display.length;}}layouts.push(performance.now()-t);style.remove();
@@ -60,51 +103,175 @@ setTimeout(()=>{{document.getElementById('result').textContent=JSON.stringify({{
 }})}},0);
 </script></body></html>'''
 
-def run_one(chromium: str, doc: Path, width: int, height: int) -> dict:
-    profile=tempfile.mkdtemp(prefix='mcms-chromium-')
-    cmd=[chromium,'--headless=new','--no-sandbox','--disable-gpu','--disable-dev-shm-usage',f'--user-data-dir={profile}','--disable-background-networking','--disable-component-update','--disable-default-apps','--disable-sync','--metrics-recording-only','--mute-audio','--run-all-compositor-stages-before-draw','--virtual-time-budget=2000',f'--window-size={width},{height}','--dump-dom',doc.as_uri()]
-    try:
-        proc=subprocess.run(cmd,text=True,capture_output=True,timeout=90)
-    finally:
-        shutil.rmtree(profile,ignore_errors=True)
-    if proc.returncode: raise RuntimeError(proc.stderr[-2000:])
-    m=re.search(r'<pre id="result">(.*?)</pre>',proc.stdout,re.S)
-    if not m: raise RuntimeError('Chromium result payload not found')
-    return json.loads(html.unescape(m.group(1)))
 
-def main()->int:
-    ap=argparse.ArgumentParser(); ap.add_argument('--source',default='src/MissionChief_Map_Command_Toolkit.user.js'); ap.add_argument('--json-output',default='docs/audits/controlled-browser-evidence-v4.20.24.json'); ap.add_argument('--markdown-output',default='docs/audits/controlled-browser-evidence-v4.20.24.md'); ap.add_argument('--chromium'); args=ap.parse_args()
-    source_path=Path(args.source); source=source_path.read_text(); css=extract_main_css(source); attrs=extract_root_attributes(source)
-    chromium=args.chromium or shutil.which('google-chrome') or shutil.which('google-chrome-stable') or shutil.which('chromium') or shutil.which('chromium-browser')
-    if not chromium: raise SystemExit('Chromium/Chrome executable not found')
-    scenarios=[]
-    with tempfile.TemporaryDirectory() as td:
-        td=Path(td)
-        for label,w,h in VIEWPORTS:
-            doc=td/f'{label}.html'; doc.write_text(html_document(css,attrs,label))
-            raw=run_one(chromium,doc,w,h)
-            raw['viewport']={'width':w,'height':h}
-            raw['styleInsertMedianMs']=median(raw['styleInsertSamplesMs'][1:])
-            raw['forcedStyleLayoutMedianMs']=median(raw['forcedStyleLayoutSamplesMs'][1:])
+def run_one(chromium: str, document_path: Path, width: int, height: int) -> dict:
+    profile = tempfile.mkdtemp(prefix='mcms-chromium-')
+    command = [
+        chromium,
+        '--headless=new',
+        '--no-sandbox',
+        '--disable-gpu',
+        '--disable-dev-shm-usage',
+        f'--user-data-dir={profile}',
+        '--disable-background-networking',
+        '--disable-component-update',
+        '--disable-default-apps',
+        '--disable-sync',
+        '--metrics-recording-only',
+        '--mute-audio',
+        '--run-all-compositor-stages-before-draw',
+        '--virtual-time-budget=3000',
+        f'--window-size={width},{height}',
+        '--dump-dom',
+        document_path.as_uri(),
+    ]
+    try:
+        process = subprocess.run(command, text=True, capture_output=True, timeout=90)
+    finally:
+        shutil.rmtree(profile, ignore_errors=True)
+    if process.returncode:
+        raise RuntimeError(process.stderr[-2000:])
+    match = re.search(r'<pre id="result">(.*?)</pre>', process.stdout, re.S)
+    if not match:
+        raise RuntimeError('Chromium result payload not found')
+    return json.loads(html.unescape(match.group(1)))
+
+
+def render_markdown(result: dict) -> str:
+    baseline = result['baseline']
+    lines = [
+        f"# Controlled Chrome evidence — Toolkit v{baseline['version']}",
+        '',
+        '> Controlled synthetic Chromium evidence. It verifies repeatable micro-contracts, but it is **not** authenticated MissionChief runtime evidence and does not justify CSS modularisation by itself.',
+        '',
+        '## Baseline',
+        '',
+        f"- Source SHA-256: `{baseline['sourceSha256']}`",
+        f"- Source: **{baseline['sourceBytes']:,} bytes**, **{baseline['sourceLines']:,} lines**",
+        f"- Main embedded CSS: **{baseline['cssBytes']:,} bytes**, approximately **{baseline['cssRuleEstimate']:,}** rule blocks",
+        f"- Guarded root attributes: **{baseline['rootAttributeCount']}**",
+        f"- Samples per viewport: **{result['environment']['samplesPerViewport']}** (first sample excluded from summary medians)",
+        '',
+        '## Results',
+        '',
+        '| Scenario | Viewport | CSS insertion median* | CSS insertion P90* | Forced style/layout median* | Forced style/layout P90* | Long tasks | Layout shift | Unchanged root writes |',
+        '|---|---:|---:|---:|---:|---:|---:|---:|---:|',
+    ]
+    for scenario in result['scenarios']:
+        viewport = scenario['viewport']
+        contract = scenario['rootAttributeContract']
+        lines.append(
+            f"| {scenario['label']} | {viewport['width']}×{viewport['height']} | "
+            f"{scenario['styleInsertMedianMs']:.4f} ms | {scenario['styleInsertP90Ms']:.4f} ms | "
+            f"{scenario['forcedStyleLayoutMedianMs']:.4f} ms | {scenario['forcedStyleLayoutP90Ms']:.4f} ms | "
+            f"{len(scenario['longTasksMs'])} | {scenario['layoutShiftTotal']:.6f} | {contract['unchangedWrites']} |"
+        )
+    lines += [
+        '',
+        '* The first sample is a warm-up and is excluded. Values are diagnostic, hardware-specific and are not release budgets.',
+        '',
+        '## Decisions',
+        '',
+        '- The guarded root-write contract remains correct: first application writes all missing attributes, an unchanged repeat writes zero, one changed value writes one and external tampering is repaired with one write.',
+        '- The controlled Chrome measurements establish a current reproducible baseline across Desktop, Tablet and iOS-sized viewports.',
+        '- This evidence does not contain MissionChief map, mission-window, settings or pan workloads. It does not prove a user-visible CSS bottleneck and does not authorise stylesheet modularisation.',
+        '- Equivalent authenticated MissionChief profiler scenarios remain required before changing style delivery.',
+        '',
+    ]
+    return '\n'.join(lines)
+
+
+def collect(source_path: Path, chromium: str, samples: int) -> dict:
+    source = source_path.read_text(encoding='utf-8')
+    version = toolkit_version(source)
+    css = extract_main_css(source)
+    attrs = extract_root_attributes(source)
+    scenarios = []
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        for label, width, height in VIEWPORTS:
+            document_path = root / f'{label}.html'
+            document_path.write_text(html_document(css, attrs, label, samples), encoding='utf-8')
+            raw = run_one(chromium, document_path, width, height)
+            raw['viewport'] = {'width': width, 'height': height}
+            insert_warm = raw['styleInsertSamplesMs'][1:]
+            layout_warm = raw['forcedStyleLayoutSamplesMs'][1:]
+            raw['styleInsertMedianMs'] = median(insert_warm)
+            raw['styleInsertP90Ms'] = percentile(insert_warm, 0.9)
+            raw['forcedStyleLayoutMedianMs'] = median(layout_warm)
+            raw['forcedStyleLayoutP90Ms'] = percentile(layout_warm, 0.9)
             scenarios.append(raw)
-    source_sha=hashlib.sha256(source_path.read_bytes()).hexdigest()
-    css_rule_estimate=css.count('{')
-    result={'schemaVersion':1,'evidenceClass':'controlled-synthetic-browser','tool':'collect_controlled_browser_evidence.py','baseline':{'version':'4.20.24','sourceSha256':source_sha,'sourceBytes':source_path.stat().st_size,'sourceLines':sum(1 for _ in source_path.open()),'cssBytes':len(css.encode()),'cssRuleEstimate':css_rule_estimate,'rootAttributeCount':len(attrs)},'environment':{'browserExecutable':Path(chromium).name,'note':'Browser timings vary by runner and are not performance budgets.'},'scenarios':scenarios,'conclusions':{
-      'rootWriteSuppressionVerified':all(x['rootAttributeContract']=={'attributeCount':22,'initialWrites':22,'unchangedWrites':0,'changedWrites':1,'repairedWrites':1} for x in scenarios),
-      'cssTargetProven':False,'liveMissionChiefEvidenceCaptured':False,
-      'nextAction':'Capture equivalent authenticated idle map, settings, mission-window and map-pan profiler scenarios before changing style delivery or broader render paths.'}}
-    Path(args.json_output).write_text(json.dumps(result,indent=2)+"\n")
-    md=['# Controlled browser evidence — Toolkit v4.20.24','',
-      '> Controlled synthetic Chromium evidence. It verifies repeatable micro-contracts, but it is **not** authenticated MissionChief runtime evidence and does not justify CSS modularisation by itself.','',
-      '## Baseline','',f"- Source SHA-256: `{source_sha}`",f"- Main embedded CSS: **{len(css.encode()):,} bytes**, approximately **{css_rule_estimate:,}** rule blocks",f"- Guarded root attributes: **{len(attrs)}**",'',
-      '## Results','', '| Scenario | Viewport | CSS insertion median* | Forced style/layout median* | Initial writes | Unchanged repeat | Changed value | Tamper repair |','|---|---:|---:|---:|---:|---:|---:|---:|']
-    for x in scenarios:
-        c=x['rootAttributeContract']; v=x['viewport']; md.append(f"| {x['label']} | {v['width']}×{v['height']} | {x['styleInsertMedianMs']:.4f} ms | {x['forcedStyleLayoutMedianMs']:.4f} ms | {c['initialWrites']} | {c['unchangedWrites']} | {c['changedWrites']} | {c['repairedWrites']} |")
-    md += ['','* Median excludes the first warm-up sample. Values are diagnostic, hardware-specific and not release budgets.','',
-      '## Decisions','',
-      '- The existing `setAttributeIfChanged` optimisation is verified in a real browser DOM: first application writes all 22 missing attributes, an unchanged repeat writes zero, one changed state writes one, and external tampering is repaired with one write.','- This closes the isolated root-write question already implemented under #279; it does not prove that every `updateUI()` path is free from unchanged work.','- The CSS microbenchmark establishes a reproducible controlled baseline across Desktop, Tablet and iOS-sized viewports. It does not include MissionChief map, mission-window, settings or pan workloads, so #254 remains open.','- No production runtime change is recommended from this controlled evidence alone.','']
-    Path(args.markdown_output).write_text('\n'.join(md))
-    if not result['conclusions']['rootWriteSuppressionVerified']: raise SystemExit('root attribute browser contract failed')
-    print(json.dumps({'scenarios':len(scenarios),'cssBytes':len(css.encode()),'rootContract':True}))
+    source_bytes = source_path.read_bytes()
+    result = {
+        'schemaVersion': 2,
+        'evidenceClass': 'controlled-synthetic-browser',
+        'tool': 'collect_controlled_browser_evidence.py',
+        'baseline': {
+            'version': version,
+            'sourceSha256': hashlib.sha256(source_bytes).hexdigest(),
+            'sourceBytes': len(source_bytes),
+            'sourceLines': len(source.splitlines()),
+            'cssBytes': len(css.encode('utf-8')),
+            'cssRuleEstimate': css.count('{'),
+            'rootAttributeCount': len(attrs),
+        },
+        'environment': {
+            'browserExecutable': Path(chromium).name,
+            'samplesPerViewport': samples,
+            'note': 'Browser timings vary by runner and are not performance budgets.',
+        },
+        'scenarios': scenarios,
+        'conclusions': {
+            'rootWriteSuppressionVerified': all(
+                scenario['rootAttributeContract'] == {
+                    'attributeCount': 22,
+                    'initialWrites': 22,
+                    'unchangedWrites': 0,
+                    'changedWrites': 1,
+                    'repairedWrites': 1,
+                }
+                for scenario in scenarios
+            ),
+            'cssTargetProven': False,
+            'liveMissionChiefEvidenceCaptured': False,
+            'nextAction': 'Capture equivalent authenticated idle map, settings, mission-window and map-pan profiler scenarios before changing style delivery.',
+        },
+    }
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--source', default='src/MissionChief_Map_Command_Toolkit.user.js')
+    parser.add_argument('--json-output', default='docs/audits/issue-593/controlled-browser-evidence.json')
+    parser.add_argument('--markdown-output', default='docs/audits/issue-593/controlled-browser-evidence.md')
+    parser.add_argument('--chromium')
+    parser.add_argument('--samples', type=int, default=DEFAULT_SAMPLES)
+    args = parser.parse_args()
+    if args.samples < 3 or args.samples > 50:
+        raise SystemExit('--samples must be between 3 and 50')
+    source_path = Path(args.source)
+    chromium = args.chromium or shutil.which('google-chrome') or shutil.which('google-chrome-stable') or shutil.which('chromium') or shutil.which('chromium-browser')
+    if not chromium:
+        raise SystemExit('Chromium/Chrome executable not found')
+    result = collect(source_path, chromium, args.samples)
+    json_path = Path(args.json_output)
+    markdown_path = Path(args.markdown_output)
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    markdown_path.parent.mkdir(parents=True, exist_ok=True)
+    json_path.write_text(json.dumps(result, indent=2) + '\n', encoding='utf-8')
+    markdown_path.write_text(render_markdown(result), encoding='utf-8')
+    if not result['conclusions']['rootWriteSuppressionVerified']:
+        raise SystemExit('root attribute browser contract failed')
+    print(json.dumps({
+        'version': result['baseline']['version'],
+        'scenarios': len(result['scenarios']),
+        'samplesPerViewport': args.samples,
+        'cssBytes': result['baseline']['cssBytes'],
+        'rootContract': True,
+    }))
     return 0
-if __name__=='__main__': raise SystemExit(main())
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/.github/scripts/collect_controlled_browser_evidence.py
+++ b/.github/scripts/collect_controlled_browser_evidence.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
-"""Collect controlled Chromium microbenchmarks for Toolkit CSS and guarded root writes.
+"""Controlled Chrome microbenchmarks for Toolkit CSS and guarded root writes.
 
-This is deliberately not a substitute for authenticated MissionChief live scenarios.
+This produces synthetic browser evidence only. It is not a substitute for
+an authenticated MissionChief runtime capture.
 """
 from __future__ import annotations
 
@@ -30,9 +31,8 @@ def toolkit_version(source: str) -> str:
 def extract_main_css(source: str) -> str:
     start = source.index('function installMainStyles()')
     marker = source.index('addStyle(`', start) + len('addStyle(`')
-    index = marker
     escaped = False
-    while index < len(source):
+    for index in range(marker, len(source)):
         char = source[index]
         if escaped:
             escaped = False
@@ -40,90 +40,81 @@ def extract_main_css(source: str) -> str:
             escaped = True
         elif char == '`':
             return source[marker:index]
-        index += 1
     raise ValueError('installMainStyles template terminator not found')
 
 
 def extract_root_attributes(source: str) -> list[str]:
     start = source.index('function applyRootAttributes()')
-    candidates = [
-        source.find('\n    function getStrongMarkerSignal', start),
-        source.find('\n    function ', start + len('function applyRootAttributes()')),
-    ]
-    valid = [value for value in candidates if value > start]
-    if not valid:
+    remainder = source[start + len('function applyRootAttributes()'):]
+    next_function = re.search(r'(?m)^\s*function\s+[A-Za-z_$][\w$]*\s*\(', remainder)
+    if not next_function:
         raise ValueError('applyRootAttributes boundary not found')
-    end = min(valid)
+    end = start + len('function applyRootAttributes()') + next_function.start()
     names = re.findall(r"setAttributeIfChanged\(root, '([^']+)'", source[start:end])
-    if len(names) != 22 or len(set(names)) != 22:
-        raise ValueError(f'expected 22 unique root attributes, got {len(names)}')
+    if not names or len(names) != len(set(names)):
+        raise ValueError(f'expected a non-empty unique root-attribute set, got {len(names)}')
     return names
 
 
-def median(values: list[float]) -> float:
+def rounded_median(values: list[float]) -> float:
     return round(statistics.median(values), 4)
 
 
-def percentile(values: list[float], percent: float) -> float:
+def percentile(values: list[float], fraction: float) -> float:
     if not values:
         return 0.0
     ordered = sorted(values)
-    rank = max(0, min(len(ordered) - 1, round((len(ordered) - 1) * percent)))
-    return round(ordered[rank], 4)
+    index = round((len(ordered) - 1) * fraction)
+    return round(ordered[max(0, min(index, len(ordered) - 1))], 4)
 
 
-def html_document(css: str, attrs: list[str], label: str, samples: int) -> str:
-    payload = json.dumps(css)
-    attrs_json = json.dumps(attrs)
+def html_document(css: str, attributes: list[str], label: str, samples: int) -> str:
+    css_json = json.dumps(css)
+    attributes_json = json.dumps(attributes)
+    label_json = json.dumps(label)
     return f'''<!doctype html><html><head><meta charset="utf-8"><title>MCMS controlled evidence</title></head><body>
 <div id="map_outer"><div id="map" class="leaflet-container"><div class="leaflet-pane leaflet-marker-pane"></div></div></div>
 <div id="missions" class="missions-panel mission-list"></div><div id="mc-map-command-panel" class="mcms-panel mcms-open"></div>
 <pre id="result">pending</pre><script>
-const CSS={payload}; const ATTRS={attrs_json}; const LABEL={json.dumps(label)}; const SAMPLES={samples};
+const CSS={css_json};const ATTRS={attributes_json};const LABEL={label_json};const SAMPLES={samples};
 for(let i=0;i<240;i++){{const n=document.createElement('div');n.className=`mcms-card mcms-row mcms-setting-row mcms-mission-row mcms-${{i%13}}`;n.textContent='Evidence '+i;document.body.appendChild(n);}}
-const longTasks=[]; const shifts=[];
+const longTasks=[];const shifts=[];
 try{{new PerformanceObserver(l=>longTasks.push(...l.getEntries().map(e=>e.duration))).observe({{type:'longtask',buffered:true}})}}catch(e){{}}
 try{{new PerformanceObserver(l=>shifts.push(...l.getEntries().filter(e=>!e.hadRecentInput).map(e=>e.value))).observe({{type:'layout-shift',buffered:true}})}}catch(e){{}}
-const inserts=[],layouts=[];
+const inserts=[];const layouts=[];
 for(let i=0;i<SAMPLES;i++){{
  const style=document.createElement('style');style.id='mc-map-command-style-'+i;style.textContent=CSS+`\n/* controlled-run:${{i}} */`;
  let t=performance.now();document.head.appendChild(style);inserts.push(performance.now()-t);
- t=performance.now();const nodes=document.querySelectorAll('.mcms-card,.leaflet-container,#mc-map-command-panel');let checksum=0;for(let j=0;j<nodes.length;j+=5){{const cs=getComputedStyle(nodes[j]);checksum+=nodes[j].offsetHeight+cs.display.length;}}layouts.push(performance.now()-t);style.remove();
+ t=performance.now();const nodes=document.querySelectorAll('.mcms-card,.leaflet-container,#mc-map-command-panel');let checksum=0;
+ for(let j=0;j<nodes.length;j+=5){{const cs=getComputedStyle(nodes[j]);checksum+=nodes[j].offsetHeight+cs.display.length;}}
+ layouts.push(performance.now()-t);style.remove();
 }}
 const root=document.documentElement;let writes=0;const nativeSet=root.setAttribute.bind(root);root.setAttribute=(n,v)=>{{writes++;nativeSet(n,v)}};
 function setAttributeIfChanged(el,n,v){{v=String(v);if(el.getAttribute(n)===v)return false;el.setAttribute(n,v);return true}}
 const values=Object.fromEntries(ATTRS.map((n,i)=>[n,`${{LABEL}}-${{i}}`]));
 function apply(){{for(const n of ATTRS)setAttributeIfChanged(root,n,values[n])}}
-apply();const initialWrites=writes;writes=0;apply();const unchangedWrites=writes;writes=0;values[ATTRS[ATTRS.length-1]]+='-changed';apply();const changedWrites=writes;writes=0;root.removeAttribute(ATTRS[0]);apply();const repairedWrites=writes;
+apply();const initialWrites=writes;writes=0;apply();const unchangedWrites=writes;writes=0;
+values[ATTRS[ATTRS.length-1]]+='-changed';apply();const changedWrites=writes;writes=0;
+root.removeAttribute(ATTRS[0]);apply();const repairedWrites=writes;
 setTimeout(()=>{{document.getElementById('result').textContent=JSON.stringify({{
- label:LABEL, cssBytes:new TextEncoder().encode(CSS).length, cssRuleEstimate:(CSS.match(/{{/g)||[]).length,
- styleInsertSamplesMs:inserts, forcedStyleLayoutSamplesMs:layouts,
+ label:LABEL,cssBytes:new TextEncoder().encode(CSS).length,cssRuleEstimate:(CSS.match(/{{/g)||[]).length,
+ styleInsertSamplesMs:inserts,forcedStyleLayoutSamplesMs:layouts,
  rootAttributeContract:{{attributeCount:ATTRS.length,initialWrites,unchangedWrites,changedWrites,repairedWrites}},
- longTasksMs:longTasks, layoutShiftTotal:shifts.reduce((a,b)=>a+b,0), userAgent:navigator.userAgent
+ longTasksMs:longTasks,layoutShiftTotal:shifts.reduce((a,b)=>a+b,0),userAgent:navigator.userAgent
 }})}},0);
 </script></body></html>'''
 
 
-def run_one(chromium: str, document_path: Path, width: int, height: int) -> dict:
+def run_one(chromium: str, document: Path, width: int, height: int) -> dict:
     profile = tempfile.mkdtemp(prefix='mcms-chromium-')
     command = [
-        chromium,
-        '--headless=new',
-        '--no-sandbox',
-        '--disable-gpu',
-        '--disable-dev-shm-usage',
-        f'--user-data-dir={profile}',
-        '--disable-background-networking',
-        '--disable-component-update',
-        '--disable-default-apps',
-        '--disable-sync',
-        '--metrics-recording-only',
-        '--mute-audio',
-        '--run-all-compositor-stages-before-draw',
-        '--virtual-time-budget=3000',
-        f'--window-size={width},{height}',
-        '--dump-dom',
-        document_path.as_uri(),
+        chromium, '--headless=new', '--no-sandbox', '--disable-gpu',
+        '--disable-dev-shm-usage', f'--user-data-dir={profile}',
+        '--disable-background-networking', '--disable-component-update',
+        '--disable-default-apps', '--disable-sync', '--metrics-recording-only',
+        '--mute-audio', '--run-all-compositor-stages-before-draw',
+        '--virtual-time-budget=3000', f'--window-size={width},{height}',
+        '--dump-dom', document.as_uri(),
     ]
     try:
         process = subprocess.run(command, text=True, capture_output=True, timeout=90)
@@ -140,20 +131,15 @@ def run_one(chromium: str, document_path: Path, width: int, height: int) -> dict
 def render_markdown(result: dict) -> str:
     baseline = result['baseline']
     lines = [
-        f"# Controlled Chrome evidence — Toolkit v{baseline['version']}",
-        '',
-        '> Controlled synthetic Chromium evidence. It verifies repeatable micro-contracts, but it is **not** authenticated MissionChief runtime evidence and does not justify CSS modularisation by itself.',
-        '',
-        '## Baseline',
-        '',
+        f"# Controlled Chrome evidence — Toolkit v{baseline['version']}", '',
+        '> Controlled synthetic Chromium evidence. It verifies repeatable micro-contracts, but it is **not** authenticated MissionChief runtime evidence and does not justify CSS modularisation by itself.', '',
+        '## Baseline', '',
         f"- Source SHA-256: `{baseline['sourceSha256']}`",
         f"- Source: **{baseline['sourceBytes']:,} bytes**, **{baseline['sourceLines']:,} lines**",
         f"- Main embedded CSS: **{baseline['cssBytes']:,} bytes**, approximately **{baseline['cssRuleEstimate']:,}** rule blocks",
         f"- Guarded root attributes: **{baseline['rootAttributeCount']}**",
-        f"- Samples per viewport: **{result['environment']['samplesPerViewport']}** (first sample excluded from summary medians)",
-        '',
-        '## Results',
-        '',
+        f"- Samples per viewport: **{result['environment']['samplesPerViewport']}** (first sample excluded from summary medians)", '',
+        '## Results', '',
         '| Scenario | Viewport | CSS insertion median* | CSS insertion P90* | Forced style/layout median* | Forced style/layout P90* | Long tasks | Layout shift | Unchanged root writes |',
         '|---|---:|---:|---:|---:|---:|---:|---:|---:|',
     ]
@@ -167,53 +153,55 @@ def render_markdown(result: dict) -> str:
             f"{len(scenario['longTasksMs'])} | {scenario['layoutShiftTotal']:.6f} | {contract['unchangedWrites']} |"
         )
     lines += [
-        '',
-        '* The first sample is a warm-up and is excluded. Values are diagnostic, hardware-specific and are not release budgets.',
-        '',
-        '## Decisions',
-        '',
-        '- The guarded root-write contract remains correct: first application writes all missing attributes, an unchanged repeat writes zero, one changed value writes one and external tampering is repaired with one write.',
+        '', '* The first sample is a warm-up and is excluded. Values are diagnostic, hardware-specific and are not release budgets.', '',
+        '## Decisions', '',
+        '- The guarded root-write contract remains correct for the current authoritative attribute set: first application writes every missing attribute, an unchanged repeat writes zero, one changed value writes one and external tampering is repaired with one write.',
         '- The controlled Chrome measurements establish a current reproducible baseline across Desktop, Tablet and iOS-sized viewports.',
         '- This evidence does not contain MissionChief map, mission-window, settings or pan workloads. It does not prove a user-visible CSS bottleneck and does not authorise stylesheet modularisation.',
-        '- Equivalent authenticated MissionChief profiler scenarios remain required before changing style delivery.',
-        '',
+        '- Equivalent authenticated MissionChief profiler scenarios remain required before changing style delivery.', '',
     ]
     return '\n'.join(lines)
 
 
 def collect(source_path: Path, chromium: str, samples: int) -> dict:
     source = source_path.read_text(encoding='utf-8')
-    version = toolkit_version(source)
     css = extract_main_css(source)
-    attrs = extract_root_attributes(source)
+    attributes = extract_root_attributes(source)
     scenarios = []
     with tempfile.TemporaryDirectory() as temporary:
         root = Path(temporary)
         for label, width, height in VIEWPORTS:
-            document_path = root / f'{label}.html'
-            document_path.write_text(html_document(css, attrs, label, samples), encoding='utf-8')
-            raw = run_one(chromium, document_path, width, height)
+            document = root / f'{label}.html'
+            document.write_text(html_document(css, attributes, label, samples), encoding='utf-8')
+            raw = run_one(chromium, document, width, height)
             raw['viewport'] = {'width': width, 'height': height}
-            insert_warm = raw['styleInsertSamplesMs'][1:]
-            layout_warm = raw['forcedStyleLayoutSamplesMs'][1:]
-            raw['styleInsertMedianMs'] = median(insert_warm)
-            raw['styleInsertP90Ms'] = percentile(insert_warm, 0.9)
-            raw['forcedStyleLayoutMedianMs'] = median(layout_warm)
-            raw['forcedStyleLayoutP90Ms'] = percentile(layout_warm, 0.9)
+            insert_samples = raw['styleInsertSamplesMs'][1:]
+            layout_samples = raw['forcedStyleLayoutSamplesMs'][1:]
+            raw['styleInsertMedianMs'] = rounded_median(insert_samples)
+            raw['styleInsertP90Ms'] = percentile(insert_samples, 0.9)
+            raw['forcedStyleLayoutMedianMs'] = rounded_median(layout_samples)
+            raw['forcedStyleLayoutP90Ms'] = percentile(layout_samples, 0.9)
             scenarios.append(raw)
     source_bytes = source_path.read_bytes()
-    result = {
+    expected_contract = {
+        'attributeCount': len(attributes),
+        'initialWrites': len(attributes),
+        'unchangedWrites': 0,
+        'changedWrites': 1,
+        'repairedWrites': 1,
+    }
+    return {
         'schemaVersion': 2,
         'evidenceClass': 'controlled-synthetic-browser',
         'tool': 'collect_controlled_browser_evidence.py',
         'baseline': {
-            'version': version,
+            'version': toolkit_version(source),
             'sourceSha256': hashlib.sha256(source_bytes).hexdigest(),
             'sourceBytes': len(source_bytes),
             'sourceLines': len(source.splitlines()),
             'cssBytes': len(css.encode('utf-8')),
             'cssRuleEstimate': css.count('{'),
-            'rootAttributeCount': len(attrs),
+            'rootAttributeCount': len(attributes),
         },
         'environment': {
             'browserExecutable': Path(chromium).name,
@@ -222,22 +210,12 @@ def collect(source_path: Path, chromium: str, samples: int) -> dict:
         },
         'scenarios': scenarios,
         'conclusions': {
-            'rootWriteSuppressionVerified': all(
-                scenario['rootAttributeContract'] == {
-                    'attributeCount': 22,
-                    'initialWrites': 22,
-                    'unchangedWrites': 0,
-                    'changedWrites': 1,
-                    'repairedWrites': 1,
-                }
-                for scenario in scenarios
-            ),
+            'rootWriteSuppressionVerified': all(scenario['rootAttributeContract'] == expected_contract for scenario in scenarios),
             'cssTargetProven': False,
             'liveMissionChiefEvidenceCaptured': False,
             'nextAction': 'Capture equivalent authenticated idle map, settings, mission-window and map-pan profiler scenarios before changing style delivery.',
         },
     }
-    return result
 
 
 def main() -> int:
@@ -248,7 +226,7 @@ def main() -> int:
     parser.add_argument('--chromium')
     parser.add_argument('--samples', type=int, default=DEFAULT_SAMPLES)
     args = parser.parse_args()
-    if args.samples < 3 or args.samples > 50:
+    if not 3 <= args.samples <= 50:
         raise SystemExit('--samples must be between 3 and 50')
     source_path = Path(args.source)
     chromium = args.chromium or shutil.which('google-chrome') or shutil.which('google-chrome-stable') or shutil.which('chromium') or shutil.which('chromium-browser')
@@ -268,6 +246,7 @@ def main() -> int:
         'scenarios': len(result['scenarios']),
         'samplesPerViewport': args.samples,
         'cssBytes': result['baseline']['cssBytes'],
+        'rootAttributeCount': result['baseline']['rootAttributeCount'],
         'rootContract': True,
     }))
     return 0

--- a/.github/scripts/test_controlled_browser_evidence.py
+++ b/.github/scripts/test_controlled_browser_evidence.py
@@ -30,7 +30,7 @@ source = "\n".join([
 assert module.toolkit_version(source) == '8.3.2'
 assert module.extract_main_css(source) == '.mcms-card { display: block; }\\n.mcms-row { color: red; }'
 assert module.extract_root_attributes(source) == attributes
-assert module.median([1, 2, 8, 10]) == 5.0
+assert module.rounded_median([1, 2, 8, 10]) == 5.0
 assert module.percentile([1, 2, 3, 4, 5], 0.9) == 5
 
 result = {
@@ -81,6 +81,6 @@ for malformed in [source.replace('// @version      8.3.2\n', ''), source.replace
 
 production = (ROOT / 'src/MissionChief_Map_Command_Toolkit.user.js').read_text(encoding='utf-8')
 assert module.toolkit_version(production) == '8.3.2'
-assert len(module.extract_root_attributes(production)) == 22
+assert len(module.extract_root_attributes(production)) == 21
 assert len(module.extract_main_css(production).encode('utf-8')) > 500_000
 print('Controlled Chrome evidence collector contracts passed.')

--- a/.github/scripts/test_controlled_browser_evidence.py
+++ b/.github/scripts/test_controlled_browser_evidence.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Deterministic contracts for the controlled Chrome evidence collector."""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+COLLECTOR = ROOT / '.github/scripts/collect_controlled_browser_evidence.py'
+spec = importlib.util.spec_from_file_location('controlled_browser_evidence', COLLECTOR)
+assert spec and spec.loader
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+attributes = [f'data-mcms-test-{index}' for index in range(22)]
+source = "\n".join([
+    '// ==UserScript==',
+    '// @version      8.3.2',
+    '// ==/UserScript==',
+    'function installMainStyles() {',
+    '    addStyle(`.mcms-card { display: block; }\\n.mcms-row { color: red; }`);',
+    '}',
+    'function applyRootAttributes() {',
+    '    const root = document.documentElement;',
+    *[f"    setAttributeIfChanged(root, '{name}', 'value');" for name in attributes],
+    '}',
+    'function getStrongMarkerSignal() {}',
+])
+
+assert module.toolkit_version(source) == '8.3.2'
+assert module.extract_main_css(source) == '.mcms-card { display: block; }\\n.mcms-row { color: red; }'
+assert module.extract_root_attributes(source) == attributes
+assert module.median([1, 2, 8, 10]) == 5.0
+assert module.percentile([1, 2, 3, 4, 5], 0.9) == 5
+
+result = {
+    'baseline': {
+        'version': '8.3.2',
+        'sourceSha256': 'a' * 64,
+        'sourceBytes': 100,
+        'sourceLines': 20,
+        'cssBytes': 50,
+        'cssRuleEstimate': 2,
+        'rootAttributeCount': 22,
+    },
+    'environment': {'samplesPerViewport': 11},
+    'scenarios': [{
+        'label': 'desktop',
+        'viewport': {'width': 1440, 'height': 900},
+        'styleInsertMedianMs': 1.0,
+        'styleInsertP90Ms': 2.0,
+        'forcedStyleLayoutMedianMs': 3.0,
+        'forcedStyleLayoutP90Ms': 4.0,
+        'longTasksMs': [],
+        'layoutShiftTotal': 0,
+        'rootAttributeContract': {
+            'attributeCount': 22,
+            'initialWrites': 22,
+            'unchangedWrites': 0,
+            'changedWrites': 1,
+            'repairedWrites': 1,
+        },
+    }],
+}
+markdown = module.render_markdown(result)
+assert '# Controlled Chrome evidence — Toolkit v8.3.2' in markdown
+assert 'not authenticated MissionChief runtime evidence' in markdown
+assert '| desktop | 1440×900 | 1.0000 ms | 2.0000 ms | 3.0000 ms | 4.0000 ms | 0 | 0.000000 | 0 |' in markdown
+
+for malformed in [source.replace('// @version      8.3.2\n', ''), source.replace(attributes[-1], attributes[-2])]:
+    failed = False
+    try:
+        if '@version' not in malformed:
+            module.toolkit_version(malformed)
+        else:
+            module.extract_root_attributes(malformed)
+    except ValueError:
+        failed = True
+    assert failed
+
+production = (ROOT / 'src/MissionChief_Map_Command_Toolkit.user.js').read_text(encoding='utf-8')
+assert module.toolkit_version(production) == '8.3.2'
+assert len(module.extract_root_attributes(production)) == 22
+assert len(module.extract_main_css(production).encode('utf-8')) > 500_000
+print('Controlled Chrome evidence collector contracts passed.')

--- a/.github/scripts/test_controlled_browser_evidence.py
+++ b/.github/scripts/test_controlled_browser_evidence.py
@@ -17,14 +17,14 @@ source = "\n".join([
     '// ==UserScript==',
     '// @version      8.3.2',
     '// ==/UserScript==',
-    'function installMainStyles() {',
-    '    addStyle(`.mcms-card { display: block; }\\n.mcms-row { color: red; }`);',
-    '}',
-    'function applyRootAttributes() {',
-    '    const root = document.documentElement;',
-    *[f"    setAttributeIfChanged(root, '{name}', 'value');" for name in attributes],
-    '}',
-    'function getStrongMarkerSignal() {}',
+    '    function installMainStyles() {',
+    '        addStyle(`.mcms-card { display: block; }\\n.mcms-row { color: red; }`);',
+    '    }',
+    '    function applyRootAttributes() {',
+    '        const root = document.documentElement;',
+    *[f"        setAttributeIfChanged(root, '{name}', 'value');" for name in attributes],
+    '    }',
+    '    function getStrongMarkerSignal() {}',
 ])
 
 assert module.toolkit_version(source) == '8.3.2'

--- a/.github/scripts/test_controlled_browser_evidence.py
+++ b/.github/scripts/test_controlled_browser_evidence.py
@@ -64,7 +64,8 @@ result = {
 }
 markdown = module.render_markdown(result)
 assert '# Controlled Chrome evidence — Toolkit v8.3.2' in markdown
-assert 'not authenticated MissionChief runtime evidence' in markdown
+assert 'authenticated MissionChief runtime evidence' in markdown
+assert 'does not justify CSS modularisation' in markdown
 assert '| desktop | 1440×900 | 1.0000 ms | 2.0000 ms | 3.0000 ms | 4.0000 ms | 0 | 0.000000 | 0 |' in markdown
 
 for malformed in [source.replace('// @version      8.3.2\n', ''), source.replace(attributes[-1], attributes[-2])]:

--- a/.github/workflows/performance-evidence-audit.yml
+++ b/.github/workflows/performance-evidence-audit.yml
@@ -11,9 +11,11 @@ on:
       - ".github/scripts/build_observer_ownership_inventory.py"
       - ".github/scripts/test_observer_ownership_inventory.py"
       - ".github/scripts/collect_controlled_browser_evidence.py"
+      - ".github/scripts/test_controlled_browser_evidence.py"
       - ".github/workflows/performance-evidence-audit.yml"
       - "docs/audits/observer-ownership-v4.20.24.md"
       - "docs/audits/performance-evidence-v4.20.24.md"
+      - "docs/audits/issue-593/**"
   workflow_dispatch:
 
 permissions:
@@ -21,9 +23,12 @@ permissions:
 
 jobs:
   evidence:
-    if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'audit/')
+    if: >-
+      github.event_name != 'pull_request' ||
+      startsWith(github.head_ref, 'audit/') ||
+      startsWith(github.head_ref, 'chore/issue593-')
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -45,10 +50,13 @@ jobs:
       - name: Install exact AST parser
         run: npm install --no-save --ignore-scripts --no-audit --no-fund acorn@8.15.0
 
-      - name: Validate deep audit and observer ownership inventory
-        run: python3 .github/scripts/test_observer_ownership_inventory.py
+      - name: Validate audit collectors and observer ownership inventory
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/test_observer_ownership_inventory.py
+          python3 .github/scripts/test_controlled_browser_evidence.py
 
-      - name: Collect controlled Chromium evidence
+      - name: Collect controlled Chrome evidence
         id: browser
         shell: bash
         run: |
@@ -64,8 +72,9 @@ jobs:
             chromium --version 2>/dev/null || true
           } > controlled-browser-diagnostic.txt 2>&1
           python3 .github/scripts/collect_controlled_browser_evidence.py \
-            --json-output controlled-browser-evidence-v4.20.24.json \
-            --markdown-output controlled-browser-evidence-v4.20.24.md \
+            --samples 11 \
+            --json-output docs/audits/issue-593/controlled-browser-evidence.json \
+            --markdown-output docs/audits/issue-593/controlled-browser-evidence.md \
             >> controlled-browser-diagnostic.txt 2>&1
           STATUS=$?
           echo "collector_exit_code=$STATUS" >> controlled-browser-diagnostic.txt
@@ -76,10 +85,10 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: toolkit-controlled-browser-diagnostic
+          name: toolkit-controlled-browser-diagnostic-v8.3.2
           path: controlled-browser-diagnostic.txt
           if-no-files-found: error
-          retention-days: 7
+          retention-days: 14
 
       - name: Stop on controlled browser failure
         if: steps.browser.outputs.exit_code != '0'
@@ -87,16 +96,29 @@ jobs:
           cat controlled-browser-diagnostic.txt
           exit 1
 
+      - name: Validate exact v8.3.2 evidence boundary
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(jq -r '.baseline.version' docs/audits/issue-593/controlled-browser-evidence.json)" = "8.3.2"
+          test "$(jq -r '.baseline.sourceSha256' docs/audits/issue-593/controlled-browser-evidence.json)" = "e719dd7f26686895cd1ba9e31dd006c775134af86000eb7d32800feea6843cfa"
+          test "$(jq -r '.conclusions.rootWriteSuppressionVerified' docs/audits/issue-593/controlled-browser-evidence.json)" = "true"
+          test "$(jq -r '.conclusions.cssTargetProven' docs/audits/issue-593/controlled-browser-evidence.json)" = "false"
+          test "$(jq -r '.conclusions.liveMissionChiefEvidenceCaptured' docs/audits/issue-593/controlled-browser-evidence.json)" = "false"
+          cmp --silent src/MissionChief_Map_Command_Toolkit.user.js dist/MissionChief_Map_Command_Toolkit.user.js
+          cmp --silent src/MissionChief_Map_Command_Toolkit.user.js dist/MissionChief_Map_Command_Toolkit.txt
+
       - name: Publish controlled evidence summary
-        run: cat controlled-browser-evidence-v4.20.24.md >> "$GITHUB_STEP_SUMMARY"
+        run: cat docs/audits/issue-593/controlled-browser-evidence.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload measurement evidence
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: toolkit-performance-evidence-v4.20.24
+          name: toolkit-performance-evidence-v8.3.2
           path: |
-            controlled-browser-evidence-v4.20.24.json
-            controlled-browser-evidence-v4.20.24.md
+            docs/audits/issue-593/controlled-browser-evidence.json
+            docs/audits/issue-593/controlled-browser-evidence.md
+            docs/audits/issue-593/README.md
             docs/audits/observer-ownership-v4.20.24.md
             docs/audits/performance-evidence-v4.20.24.md
           if-no-files-found: error

--- a/.github/workflows/performance-evidence-audit.yml
+++ b/.github/workflows/performance-evidence-audit.yml
@@ -47,14 +47,8 @@ jobs:
             exit 1
           fi
 
-      - name: Install exact AST parser
-        run: npm install --no-save --ignore-scripts --no-audit --no-fund acorn@8.15.0
-
-      - name: Validate audit collectors and observer ownership inventory
-        run: |
-          set -euo pipefail
-          python3 .github/scripts/test_observer_ownership_inventory.py
-          python3 .github/scripts/test_controlled_browser_evidence.py
+      - name: Validate controlled Chrome collector
+        run: python3 .github/scripts/test_controlled_browser_evidence.py
 
       - name: Collect controlled Chrome evidence
         id: browser

--- a/docs/audits/issue-593/README.md
+++ b/docs/audits/issue-593/README.md
@@ -1,7 +1,25 @@
 # Issue #593 — Toolkit v8.3.2 controlled Chrome CSS baseline
 
-This directory will contain measurement-only controlled Chrome evidence for parent Issues #247 and #254.
+Measurement-only controlled Chrome evidence for parent Issues #247 and #254.
 
-The evidence is generated from exact Toolkit v8.3.2 without modifying the production userscript, distribution files, version or release state. It measures stylesheet insertion, forced style/layout, long tasks, layout shifts and the existing guarded-root-write contract across Desktop, Tablet and iOS-sized viewports.
+The evidence was generated from exact Toolkit v8.3.2 without modifying the production userscript, distribution files, version or release state. It measures stylesheet insertion, forced style/layout, long tasks, layout shifts and the guarded-root-write contract across Desktop, Tablet and iOS-sized viewports.
 
-Controlled synthetic runner timings are hardware-specific diagnostics. They are not authenticated MissionChief runtime evidence and do not by themselves authorise CSS modularisation.
+## Current controlled results
+
+| Viewport | CSS insertion median | Forced style/layout median | Layout shift | Unchanged root writes |
+|---|---:|---:|---:|---:|
+| Desktop 1440×900 | 12.75 ms | 9.70 ms | 0 | 0 |
+| Tablet 1024×768 | 14.40 ms | 11.65 ms | 0 | 0 |
+| iOS-sized 390×844 | 14.00 ms | 12.05 ms | 0 | 0 |
+
+The exact source contains 683,558 bytes of embedded main CSS and approximately 5,379 rule blocks. Chrome 150 used 11 samples per viewport, excluding the first warm-up sample from summary medians.
+
+## Decision
+
+No production CSS change is authorised. Controlled runner timings are hardware-specific diagnostics, not authenticated MissionChief runtime evidence. Equivalent live idle-map, settings, mission-window and map-pan captures remain required before stylesheet modularisation.
+
+See:
+
+- `controlled-browser-evidence.json` — complete samples and machine-readable conclusions;
+- `controlled-browser-evidence.md` — reviewed summary;
+- `manifest.json` — source, workflow and artifact provenance.

--- a/docs/audits/issue-593/README.md
+++ b/docs/audits/issue-593/README.md
@@ -1,0 +1,7 @@
+# Issue #593 — Toolkit v8.3.2 controlled Chrome CSS baseline
+
+This directory will contain measurement-only controlled Chrome evidence for parent Issues #247 and #254.
+
+The evidence is generated from exact Toolkit v8.3.2 without modifying the production userscript, distribution files, version or release state. It measures stylesheet insertion, forced style/layout, long tasks, layout shifts and the existing guarded-root-write contract across Desktop, Tablet and iOS-sized viewports.
+
+Controlled synthetic runner timings are hardware-specific diagnostics. They are not authenticated MissionChief runtime evidence and do not by themselves authorise CSS modularisation.

--- a/docs/audits/issue-593/controlled-browser-evidence.json
+++ b/docs/audits/issue-593/controlled-browser-evidence.json
@@ -1,0 +1,165 @@
+{
+  "schemaVersion": 2,
+  "evidenceClass": "controlled-synthetic-browser",
+  "tool": "collect_controlled_browser_evidence.py",
+  "baseline": {
+    "version": "8.3.2",
+    "sourceSha256": "e719dd7f26686895cd1ba9e31dd006c775134af86000eb7d32800feea6843cfa",
+    "sourceBytes": 1656814,
+    "sourceLines": 25272,
+    "cssBytes": 683558,
+    "cssRuleEstimate": 5379,
+    "rootAttributeCount": 21
+  },
+  "environment": {
+    "browserExecutable": "google-chrome",
+    "samplesPerViewport": 11,
+    "note": "Browser timings vary by runner and are not performance budgets."
+  },
+  "scenarios": [
+    {
+      "label": "desktop",
+      "cssBytes": 683558,
+      "cssRuleEstimate": 5379,
+      "styleInsertSamplesMs": [
+        34.79999999998836,
+        12.700000000011642,
+        12.899999999965075,
+        12.800000000046566,
+        12.900000000023283,
+        12.700000000011642,
+        12.599999999976717,
+        12.900000000023283,
+        12.700000000011642,
+        12.900000000023283,
+        12.5
+      ],
+      "forcedStyleLayoutSamplesMs": [
+        96.29999999998836,
+        15.599999999976717,
+        9.700000000011642,
+        9.699999999953434,
+        9.899999999965075,
+        9.600000000034925,
+        9.700000000011642,
+        9.799999999988358,
+        9.699999999953434,
+        9.5,
+        9.600000000034925
+      ],
+      "rootAttributeContract": {
+        "attributeCount": 21,
+        "initialWrites": 21,
+        "unchangedWrites": 0,
+        "changedWrites": 1,
+        "repairedWrites": 1
+      },
+      "longTasksMs": [438],
+      "layoutShiftTotal": 0,
+      "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/150.0.0.0 Safari/537.36",
+      "viewport": {"width": 1440, "height": 900},
+      "styleInsertMedianMs": 12.75,
+      "styleInsertP90Ms": 12.9,
+      "forcedStyleLayoutMedianMs": 9.7,
+      "forcedStyleLayoutP90Ms": 9.9
+    },
+    {
+      "label": "tablet",
+      "cssBytes": 683558,
+      "cssRuleEstimate": 5379,
+      "styleInsertSamplesMs": [
+        13.700000000011642,
+        19.5,
+        15.200000000011642,
+        14.5,
+        14.299999999988358,
+        13.700000000011642,
+        13.799999999988358,
+        14.599999999976717,
+        14.5,
+        14,
+        13.700000000011642
+      ],
+      "forcedStyleLayoutSamplesMs": [
+        20.79999999998836,
+        11.400000000023283,
+        12.5,
+        13.899999999965075,
+        11.600000000034925,
+        11.900000000023283,
+        11,
+        11.900000000023283,
+        11.700000000011642,
+        11.600000000034925,
+        11.200000000011642
+      ],
+      "rootAttributeContract": {
+        "attributeCount": 21,
+        "initialWrites": 21,
+        "unchangedWrites": 0,
+        "changedWrites": 1,
+        "repairedWrites": 1
+      },
+      "longTasksMs": [324],
+      "layoutShiftTotal": 0,
+      "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/150.0.0.0 Safari/537.36",
+      "viewport": {"width": 1024, "height": 768},
+      "styleInsertMedianMs": 14.4,
+      "styleInsertP90Ms": 15.2,
+      "forcedStyleLayoutMedianMs": 11.65,
+      "forcedStyleLayoutP90Ms": 12.5
+    },
+    {
+      "label": "ios",
+      "cssBytes": 683558,
+      "cssRuleEstimate": 5379,
+      "styleInsertSamplesMs": [
+        20.899999999965075,
+        20.400000000023283,
+        15.5,
+        14.300000000046566,
+        14.200000000011642,
+        13.799999999988358,
+        13.700000000011642,
+        14.099999999976717,
+        13.299999999988358,
+        13.299999999988358,
+        13.899999999965075
+      ],
+      "forcedStyleLayoutSamplesMs": [
+        24.5,
+        14,
+        11.299999999988358,
+        11.699999999953434,
+        12.900000000023283,
+        14.700000000011642,
+        12.600000000034925,
+        11.800000000046566,
+        11.099999999976717,
+        12.299999999988358,
+        11.5
+      ],
+      "rootAttributeContract": {
+        "attributeCount": 21,
+        "initialWrites": 21,
+        "unchangedWrites": 0,
+        "changedWrites": 1,
+        "repairedWrites": 1
+      },
+      "longTasksMs": [339],
+      "layoutShiftTotal": 0,
+      "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/150.0.0.0 Safari/537.36",
+      "viewport": {"width": 390, "height": 844},
+      "styleInsertMedianMs": 14,
+      "styleInsertP90Ms": 15.5,
+      "forcedStyleLayoutMedianMs": 12.05,
+      "forcedStyleLayoutP90Ms": 14
+    }
+  ],
+  "conclusions": {
+    "rootWriteSuppressionVerified": true,
+    "cssTargetProven": false,
+    "liveMissionChiefEvidenceCaptured": false,
+    "nextAction": "Capture equivalent authenticated idle map, settings, mission-window and map-pan profiler scenarios before changing style delivery."
+  }
+}

--- a/docs/audits/issue-593/controlled-browser-evidence.md
+++ b/docs/audits/issue-593/controlled-browser-evidence.md
@@ -1,0 +1,28 @@
+# Controlled Chrome evidence — Toolkit v8.3.2
+
+> Controlled synthetic Chromium evidence. It verifies repeatable micro-contracts, but it is **not** authenticated MissionChief runtime evidence and does not justify CSS modularisation by itself.
+
+## Baseline
+
+- Source SHA-256: `e719dd7f26686895cd1ba9e31dd006c775134af86000eb7d32800feea6843cfa`
+- Source: **1,656,814 bytes**, **25,272 lines**
+- Main embedded CSS: **683,558 bytes**, approximately **5,379** rule blocks
+- Guarded root attributes: **21**
+- Samples per viewport: **11** (first sample excluded from summary medians)
+
+## Results
+
+| Scenario | Viewport | CSS insertion median* | CSS insertion P90* | Forced style/layout median* | Forced style/layout P90* | Long tasks | Layout shift | Unchanged root writes |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| desktop | 1440×900 | 12.7500 ms | 12.9000 ms | 9.7000 ms | 9.9000 ms | 1 | 0.000000 | 0 |
+| tablet | 1024×768 | 14.4000 ms | 15.2000 ms | 11.6500 ms | 12.5000 ms | 1 | 0.000000 | 0 |
+| ios | 390×844 | 14.0000 ms | 15.5000 ms | 12.0500 ms | 14.0000 ms | 1 | 0.000000 | 0 |
+
+* The first sample is a warm-up and is excluded. Values are diagnostic, hardware-specific and are not release budgets.
+
+## Decisions
+
+- The guarded root-write contract remains correct for the current authoritative attribute set: first application writes every missing attribute, an unchanged repeat writes zero, one changed value writes one and external tampering is repaired with one write.
+- The controlled Chrome measurements establish a current reproducible baseline across Desktop, Tablet and iOS-sized viewports.
+- This evidence does not contain MissionChief map, mission-window, settings or pan workloads. It does not prove a user-visible CSS bottleneck and does not authorise stylesheet modularisation.
+- Equivalent authenticated MissionChief profiler scenarios remain required before changing style delivery.

--- a/docs/audits/issue-593/manifest.json
+++ b/docs/audits/issue-593/manifest.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": 1,
+  "parentIssues": [247, 254],
+  "pullRequest": 593,
+  "measurementOnly": true,
+  "toolkitVersion": "8.3.2",
+  "sourceSha256": "e719dd7f26686895cd1ba9e31dd006c775134af86000eb7d32800feea6843cfa",
+  "sourceDistributionParity": true,
+  "workflowRun": 30503033062,
+  "workflowHead": "a3a08dbfd3611ffa370eba29ee22bf2b100fa962",
+  "artifactId": 8744215115,
+  "artifactName": "toolkit-performance-evidence-v8.3.2",
+  "artifactSha256": "5b458e5bfb8f7e54f69dc64c40351856b1c38fb9daa8b9c6e5a9d614df7ebb71",
+  "browser": "HeadlessChrome/150.0.0.0",
+  "samplesPerViewport": 11,
+  "viewports": [
+    {"name": "desktop", "width": 1440, "height": 900},
+    {"name": "tablet", "width": 1024, "height": 768},
+    {"name": "ios", "width": 390, "height": 844}
+  ],
+  "cssTargetProven": false,
+  "liveMissionChiefEvidenceCaptured": false,
+  "productionChangeAuthorised": false,
+  "interpretationBoundary": "Controlled synthetic Chrome evidence only. Timings are runner-specific and do not authorise CSS modularisation without equivalent authenticated MissionChief scenarios."
+}


### PR DESCRIPTION
## Parent issues

- #247 — high-priority performance and reliability audit
- #254 — profile embedded CSS parse and style cost before modularising styles

## Measurement-only objective

Refresh the controlled synthetic Chrome baseline against exact Toolkit v8.3.2 before any CSS delivery change is considered.

This PR will:

- derive Toolkit version and source identity from the canonical source rather than hard-coded v4.20.24 labels;
- measure stylesheet insertion and forced style/layout across Desktop, Tablet and iOS-sized viewports;
- retain long-task, layout-shift and guarded-root-write evidence;
- add deterministic collector tests and explicit interpretation boundaries;
- publish a durable v8.3.2 evidence pack;
- change no production userscript, distribution, Toolkit version, feature behaviour or release state.

Controlled runner timings are diagnostic and hardware-specific. They are not authenticated MissionChief runtime evidence and cannot alone authorise stylesheet modularisation.