### PR TITLE
Audit: Build one-file v8.3.2 authenticated performance capture

### DIFF
--- a/.github/scripts/test_live_performance_capture_bundle.mjs
+++ b/.github/scripts/test_live_performance_capture_bundle.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+"use strict";
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { buildCaptureBundle, CAPTURE_PROFILE, REQUIRED_SCENARIOS } from "../../tools/build-live-performance-capture.mjs";
+import { validateReport } from "../../tools/validate-live-performance-report.mjs";
+
+const root = path.resolve(import.meta.dirname, "../..");
+const sourcePath = path.join(root, "src/MissionChief_Map_Command_Toolkit.user.js");
+const profilerPath = path.join(root, "tools/mcms-performance-profiler.user.js");
+const sourceBefore = fs.readFileSync(sourcePath, "utf8");
+const profiler = fs.readFileSync(profilerPath, "utf8");
+const result = buildCaptureBundle(sourceBefore, profiler);
+
+assert.equal(result.manifest.profile, CAPTURE_PROFILE);
+assert.equal(result.manifest.toolkitVersion, "8.3.2");
+assert.equal(result.manifest.canonicalSourceSha256, "e719dd7f26686895cd1ba9e31dd006c775134af86000eb7d32800feea6843cfa");
+assert.deepEqual(result.manifest.instrumentedFunctions, ["renderOperationalPanels", "updateUI"]);
+assert.deepEqual(result.manifest.requiredScenarios, REQUIRED_SCENARIOS.map(([name]) => name));
+assert.equal(result.manifest.stableUpdateUrlsRemoved, true);
+assert.equal(result.manifest.productionSourceModified, false);
+assert.equal(result.manifest.requiresStableToolkitDisabled, true);
+assert.match(result.bundle, /@name\s+MissionChief Toolkit v8\.3\.2 Authenticated Performance Capture/u);
+assert.match(result.bundle, /@namespace\s+https:\/\/github\.com\/Conroy1988\/missionchief-toolkit-assets\/performance-capture/u);
+assert.match(result.bundle, /@version\s+8\.3\.2-capture\.1/u);
+assert.doesNotMatch(result.bundle, /^\/\/\s*@(downloadURL|updateURL)\s+/mu);
+assert.match(result.bundle, /captureSourceSha256/u);
+assert.match(result.bundle, /Finish and export report/u);
+assert.match(result.bundle, /Disable the normal MissionChief Map Command Toolkit userscript/u);
+assert.match(result.bundle, /beginRender\?\.\("updateUI"\)/u);
+assert.match(result.bundle, /beginRender\?\.\("renderOperationalPanels"\)/u);
+assert.equal(fs.readFileSync(sourcePath, "utf8"), sourceBefore, "canonical source must remain byte-identical");
+
+const temporary = fs.mkdtempSync(path.join(os.tmpdir(), "mcms-live-capture-"));
+const output = path.join(temporary, "capture.user.js");
+fs.writeFileSync(output, result.bundle, "utf8");
+execFileSync(process.execPath, ["--check", output], { stdio: "inherit" });
+
+const transitions = REQUIRED_SCENARIOS.map(([scenario], index) => ({ at: index * 20_000, scenario }));
+const measurements = REQUIRED_SCENARIOS.map(([scenario], index) => ({
+  scenario,
+  path: "updateUI",
+  attempts: 4 + index,
+  changedAttempts: 1,
+  unchangedAttempts: 3 + index,
+  totalDurationMs: 10,
+  maxDurationMs: 3,
+  mutationRecords: 2,
+  unchangedRatio: 0.75,
+  averageDurationMs: 2,
+}));
+const report = {
+  schemaVersion: 2,
+  profilerVersion: result.manifest.profilerVersion,
+  active: false,
+  startedAt: 1,
+  finishedAt: 120_001,
+  durationMs: 120_000,
+  page: { host: "www.missionchief.co.uk", pathClass: "other" },
+  browser: { userAgent: "test" },
+  startupMetrics: {
+    captureProfile: result.manifest.profile,
+    captureToolkitVersion: result.manifest.toolkitVersion,
+    captureSourceSha256: result.manifest.canonicalSourceSha256,
+    captureProfilerVersion: result.manifest.profilerVersion,
+  },
+  longTasks: [{ startTime: 1, durationMs: 60 }],
+  layoutShifts: [{ startTime: 2, value: 0.01, hadRecentInput: false }],
+  mutations: [{ at: 3, records: 1 }],
+  runtimeSamples: [{ at: 1, present: true }, { at: 2, present: true }],
+  visibility: [],
+  resources: [{ host: "missionchief.co.uk", initiatorType: "script", count: 1, durationMs: 1, transferBytes: 0 }],
+  droppedResourceGroups: 0,
+  currentScenario: "layout-change",
+  scenarioTransitions: transitions,
+  renderEvents: [],
+  renderMeasurements: measurements,
+  limits: {},
+};
+const validation = validateReport(report, result.manifest);
+assert.equal(validation.valid, true, validation.errors.join("\n"));
+assert.equal(validation.updateUiMeasurements.length, REQUIRED_SCENARIOS.length);
+
+const active = validateReport({ ...report, active: true }, result.manifest);
+assert.equal(active.valid, false);
+assert.ok(active.errors.some(error => /Stop the profiler/u.test(error)));
+const missingScenario = validateReport({ ...report, scenarioTransitions: transitions.slice(0, -1) }, result.manifest);
+assert.equal(missingScenario.valid, false);
+assert.ok(missingScenario.errors.some(error => /layout-change/u.test(error)));
+assert.throws(() => validateReport({ ...report, cookie: "forbidden" }, result.manifest), /Forbidden sensitive field/u);
+
+fs.rmSync(temporary, { recursive: true, force: true });
+console.log("Authenticated live performance capture bundle and report validator contracts passed.");

--- a/.github/scripts/test_live_performance_capture_bundle.mjs
+++ b/.github/scripts/test_live_performance_capture_bundle.mjs
@@ -30,7 +30,7 @@ assert.match(result.bundle, /@version\s+8\.3\.2-capture\.1/u);
 assert.doesNotMatch(result.bundle, /^\/\/\s*@(downloadURL|updateURL)\s+/mu);
 assert.match(result.bundle, /captureSourceSha256/u);
 assert.match(result.bundle, /Finish and export report/u);
-assert.match(result.bundle, /Disable the normal MissionChief Map Command Toolkit userscript/u);
+assert.match(result.bundle, /keep the normal Toolkit userscript disabled/u);
 assert.match(result.bundle, /beginRender\?\.\("updateUI"\)/u);
 assert.match(result.bundle, /beginRender\?\.\("renderOperationalPanels"\)/u);
 assert.equal(fs.readFileSync(sourcePath, "utf8"), sourceBefore, "canonical source must remain byte-identical");

--- a/.github/workflows/live-performance-capture-bundle.yml
+++ b/.github/workflows/live-performance-capture-bundle.yml
@@ -1,0 +1,87 @@
+name: Live Performance Capture Bundle
+
+run-name: Live capture bundle · ${{ github.event_name }}
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "tools/build-live-performance-capture.mjs"
+      - "tools/validate-live-performance-report.mjs"
+      - "tools/build-render-probe-userscript.mjs"
+      - "tools/mcms-performance-profiler.user.js"
+      - ".github/scripts/test_live_performance_capture_bundle.mjs"
+      - ".github/workflows/live-performance-capture-bundle.yml"
+      - "docs/audits/live-performance-capture-v8.3.2.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build exact v8.3.2 capture bundle
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out exact repository state
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          show-progress: false
+
+      - name: Prove development-only boundary
+        if: github.event_name == 'pull_request'
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          if ! git diff --quiet "$BASE_SHA" HEAD -- src dist MissionChief_Map_Command_Toolkit.user.js status; then
+            echo "::error::Live capture tooling must not change production source, distribution or release state."
+            git diff --stat "$BASE_SHA" HEAD -- src dist MissionChief_Map_Command_Toolkit.user.js status
+            exit 1
+          fi
+
+      - name: Install exact JavaScript parser
+        run: npm install --no-save --package-lock=false --ignore-scripts --no-audit --no-fund acorn@8.15.0
+
+      - name: Validate capture tooling
+        run: |
+          set -euo pipefail
+          node --check tools/build-live-performance-capture.mjs
+          node --check tools/validate-live-performance-report.mjs
+          node --check .github/scripts/test_live_performance_capture_bundle.mjs
+          node .github/scripts/test_live_performance_capture_bundle.mjs
+
+      - name: Build authenticated capture package
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p capture-output
+          node tools/build-live-performance-capture.mjs \
+            --source src/MissionChief_Map_Command_Toolkit.user.js \
+            --profiler tools/mcms-performance-profiler.user.js \
+            --output capture-output/MissionChief_Toolkit_v8.3.2_Authenticated_Performance_Capture.user.js \
+            --manifest capture-output/capture-manifest.json \
+            --instructions capture-output/INSTRUCTIONS.md
+          cp tools/validate-live-performance-report.mjs capture-output/validate-live-performance-report.mjs
+          node --check capture-output/MissionChief_Toolkit_v8.3.2_Authenticated_Performance_Capture.user.js
+          test "$(jq -r '.toolkitVersion' capture-output/capture-manifest.json)" = "8.3.2"
+          test "$(jq -r '.canonicalSourceSha256' capture-output/capture-manifest.json)" = "e719dd7f26686895cd1ba9e31dd006c775134af86000eb7d32800feea6843cfa"
+          test "$(jq -r '.stableUpdateUrlsRemoved' capture-output/capture-manifest.json)" = "true"
+          test "$(jq -r '.productionSourceModified' capture-output/capture-manifest.json)" = "false"
+          ! grep -Eq '^//[[:space:]]*@(downloadURL|updateURL)[[:space:]]+' capture-output/MissionChief_Toolkit_v8.3.2_Authenticated_Performance_Capture.user.js
+          cmp --silent src/MissionChief_Map_Command_Toolkit.user.js dist/MissionChief_Map_Command_Toolkit.user.js
+          cmp --silent src/MissionChief_Map_Command_Toolkit.user.js dist/MissionChief_Map_Command_Toolkit.txt
+          sha256sum capture-output/* > capture-output/SHA256SUMS.txt
+
+      - name: Upload authenticated capture bundle
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: missionchief-toolkit-v8.3.2-authenticated-performance-capture
+          path: capture-output/
+          if-no-files-found: error
+          retention-days: 90

--- a/docs/audits/live-performance-capture-v8.3.2.md
+++ b/docs/audits/live-performance-capture-v8.3.2.md
@@ -1,0 +1,51 @@
+# Authenticated MissionChief performance capture — Toolkit v8.3.2
+
+This is the remaining browser-only evidence stage for Issues #247, #254 and #255.
+
+## Capture authority
+
+- Toolkit version: `8.3.2`
+- Canonical source SHA-256: `e719dd7f26686895cd1ba9e31dd006c775134af86000eb7d32800feea6843cfa`
+- Profiler: development-only, privacy-bounded and excluded from all stable update channels
+- Production source and distribution: unchanged
+
+## Bundle
+
+The `Live Performance Capture Bundle` workflow creates one installable userscript containing:
+
+- an exact disposable copy of Toolkit v8.3.2;
+- AST instrumentation around `updateUI()` and `renderOperationalPanels()`;
+- the bounded performance profiler;
+- an automatic six-stage capture guide;
+- exact source/profile markers embedded in the exported report;
+- no `@downloadURL` or `@updateURL` metadata.
+
+The bundle uses a distinct userscript name and namespace. The normal Toolkit userscript must be disabled during the controlled session to prevent two Toolkit runtimes from mounting concurrently.
+
+## Required scenarios
+
+1. **idle-map** — leave the map idle for at least 20 seconds;
+2. **settings-open-close** — open and close Settings five times without changing settings;
+3. **mission-open-close** — open and close at least three active mission windows;
+4. **unit-selection** — select and deselect several units without dispatching;
+5. **map-pan-zoom** — pan and zoom repeatedly;
+6. **layout-change** — resize, rotate or change Tablet layout, then restore it.
+
+The capture starts automatically. The bottom-right panel advances through the scenarios and exports a JSON report at completion.
+
+## Privacy boundary
+
+The report contains aggregate timing, mutation, resource-host and runtime-ownership counts. It does not contain mission titles, addresses, coordinates, vehicle or personnel names, alliance messages, cookies, local-storage values, authorization material or Discord webhook contents.
+
+## Validation
+
+`tools/validate-live-performance-report.mjs` rejects reports unless they:
+
+- match the exact capture profile, Toolkit version and canonical source hash;
+- are stopped before export and run for at least 60 seconds;
+- include all six scenario transitions in order;
+- include `updateUI()` measurements for each scenario;
+- include bounded runtime, mutation, long-task and layout-shift arrays;
+- contain no forbidden sensitive fields.
+
+A valid report is evidence for review, not automatic authority to modularise CSS or change render scheduling. Any production optimisation still requires an isolated implementation, before/after evidence, behaviour parity and a clean rollback boundary.

--- a/tools/build-live-performance-capture.mjs
+++ b/tools/build-live-performance-capture.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+"use strict";
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { instrumentSource } from "./build-render-probe-userscript.mjs";
+
+export const CAPTURE_PROFILE = "issue247-v832-live-performance";
+export const REQUIRED_SCENARIOS = Object.freeze([
+  ["idle-map", "Leave the map idle for at least 20 seconds."],
+  ["settings-open-close", "Open and close Toolkit Settings five times, changing no settings."],
+  ["mission-open-close", "Open and close at least three active mission windows."],
+  ["unit-selection", "Open a mission and select/deselect several vehicles without dispatching."],
+  ["map-pan-zoom", "Pan the map repeatedly and zoom in/out several levels."],
+  ["layout-change", "Resize the browser or change orientation/Tablet layout, then restore it."],
+]);
+
+function sha256(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+function stripUserscriptMetadata(source) {
+  const marker = "// ==/UserScript==";
+  const end = source.indexOf(marker);
+  if (end < 0) throw new Error("Profiler metadata terminator not found");
+  return source.slice(end + marker.length).replace(/^\s+/u, "");
+}
+
+function metadataValue(source, name) {
+  const match = source.match(new RegExp(`^//\\s*@${name}\\s+([^\\n]+)$`, "mu"));
+  return match?.[1]?.trim() || null;
+}
+
+function replaceMetadata(source, name, value) {
+  const pattern = new RegExp(`^//\\s*@${name}\\s+[^\\n]+$`, "mu");
+  if (!pattern.test(source)) throw new Error(`Missing metadata field: ${name}`);
+  return source.replace(pattern, `// @${name.padEnd(12)} ${value}`);
+}
+
+function captureGuideSource() {
+  return `
+(function installMcmsCaptureGuide() {
+    'use strict';
+    const profile = ${JSON.stringify(REQUIRED_SCENARIOS)};
+    const profiler = globalThis.__MCMS_PROFILER__;
+    if (!profiler) throw new Error('MCMS capture profiler failed to initialise');
+    let index = 0;
+    profiler.setScenario(profile[0][0]);
+    profiler.start();
+
+    function installGuide() {
+        const panel = document.getElementById('mcms-development-profiler');
+        if (!panel || panel.querySelector('[data-mcms-capture-guide]')) return;
+        const guide = document.createElement('section');
+        guide.dataset.mcmsCaptureGuide = 'true';
+        guide.style.cssText = 'flex:1 1 100%;border-top:1px solid #555;padding-top:7px;display:grid;gap:5px';
+        const warning = document.createElement('strong');
+        warning.style.color = '#ffcf66';
+        warning.textContent = 'Capture bundle active — keep the normal Toolkit userscript disabled during this session.';
+        const stage = document.createElement('span');
+        const instruction = document.createElement('span');
+        instruction.style.color = '#d8e7ef';
+        const controls = document.createElement('div');
+        controls.style.cssText = 'display:flex;gap:6px;flex-wrap:wrap';
+        const next = document.createElement('button');
+        const restart = document.createElement('button');
+        for (const button of [next, restart]) {
+            button.type = 'button';
+            button.style.cssText = 'font:inherit;padding:5px 8px;cursor:pointer';
+        }
+        restart.textContent = 'Restart capture';
+
+        function sync() {
+            const [name, text] = profile[index];
+            profiler.setScenario(name);
+            const selector = panel.querySelector('select[aria-label="Profiler scenario"]');
+            if (selector) selector.value = name;
+            const status = panel.querySelector('strong');
+            if (status) status.textContent = 'Profiler running · ' + name;
+            stage.textContent = 'Stage ' + (index + 1) + '/' + profile.length + ': ' + name;
+            instruction.textContent = text;
+            next.textContent = index === profile.length - 1 ? 'Finish and export report' : 'Mark complete — next stage';
+        }
+
+        next.addEventListener('click', () => {
+            if (index < profile.length - 1) {
+                index += 1;
+                sync();
+                return;
+            }
+            profiler.stop();
+            const status = panel.querySelector('strong');
+            if (status) status.textContent = 'Profiler stopped · capture complete';
+            stage.textContent = 'Capture complete';
+            instruction.textContent = 'Save the downloaded JSON report and upload it for validation.';
+            next.disabled = true;
+            profiler.export();
+        });
+        restart.addEventListener('click', () => {
+            profiler.reset();
+            index = 0;
+            profiler.setScenario(profile[0][0]);
+            profiler.start();
+            next.disabled = false;
+            sync();
+        });
+        controls.append(next, restart);
+        guide.append(warning, stage, instruction, controls);
+        panel.appendChild(guide);
+        sync();
+    }
+
+    if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', installGuide, { once: true });
+    else installGuide();
+})();
+`;
+}
+
+export function buildCaptureBundle(toolkitSource, profilerSource) {
+  const toolkitVersion = metadataValue(toolkitSource, "version");
+  if (!toolkitVersion) throw new Error("Toolkit version missing");
+  const canonicalSourceSha256 = sha256(toolkitSource);
+  const profilerVersion = metadataValue(profilerSource, "version");
+  if (!profilerVersion) throw new Error("Profiler version missing");
+
+  const instrumented = instrumentSource(toolkitSource);
+  let bundle = instrumented.generated;
+  bundle = replaceMetadata(bundle, "name", `MissionChief Toolkit v${toolkitVersion} Authenticated Performance Capture`);
+  bundle = replaceMetadata(bundle, "namespace", "https://github.com/Conroy1988/missionchief-toolkit-assets/performance-capture");
+  bundle = replaceMetadata(bundle, "version", `${toolkitVersion}-capture.1`);
+  bundle = replaceMetadata(bundle, "description", "Development-only authenticated MissionChief performance capture. Disable the stable Toolkit while installed.");
+  bundle = bundle.replace(/^//\s*@(?:downloadURL|updateURL)\s+[^\n]+\n?/gmu, "");
+
+  let profilerBody = stripUserscriptMetadata(profilerSource);
+  const startupAnchor = "getStartupMetrics: () => window.__MCMS_STARTUP_METRICS__ || {},";
+  if ((profilerBody.match(new RegExp(startupAnchor.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "gu")) || []).length !== 1) {
+    throw new Error("Profiler startup-metrics anchor drifted");
+  }
+  profilerBody = profilerBody.replace(
+    startupAnchor,
+    `getStartupMetrics: () => ({ ...(window.__MCMS_STARTUP_METRICS__ || {}), captureProfile: ${JSON.stringify(CAPTURE_PROFILE)}, captureToolkitVersion: ${JSON.stringify(toolkitVersion)}, captureSourceSha256: ${JSON.stringify(canonicalSourceSha256)}, captureProfilerVersion: ${JSON.stringify(profilerVersion)} }),`,
+  );
+
+  const metadataEndMarker = "// ==/UserScript==";
+  const metadataEnd = bundle.indexOf(metadataEndMarker);
+  if (metadataEnd < 0) throw new Error("Generated Toolkit metadata terminator missing");
+  const insertion = metadataEnd + metadataEndMarker.length;
+  const prelude = `\n// Development capture profile: ${CAPTURE_PROFILE}\n${profilerBody}\n${captureGuideSource()}\n`;
+  bundle = bundle.slice(0, insertion) + prelude + bundle.slice(insertion);
+
+  if (/^\/\/\s*@(downloadURL|updateURL)\s+/mu.test(bundle)) throw new Error("Capture bundle must not carry stable update URLs");
+  if (!bundle.includes("globalThis.__MCMS_PROFILER__?.beginRender?.(\"updateUI\")")) throw new Error("updateUI probe missing");
+  if (!bundle.includes("globalThis.__MCMS_PROFILER__?.beginRender?.(\"renderOperationalPanels\")")) throw new Error("operational render probe missing");
+  if (!bundle.includes(canonicalSourceSha256)) throw new Error("Canonical source authority missing from capture bundle");
+
+  return {
+    bundle,
+    manifest: {
+      schemaVersion: 1,
+      profile: CAPTURE_PROFILE,
+      toolkitVersion,
+      canonicalSourceSha256,
+      profilerVersion,
+      profilerSourceSha256: sha256(profilerSource),
+      bundleSha256: sha256(bundle),
+      instrumentedFunctions: instrumented.targets,
+      requiredScenarios: REQUIRED_SCENARIOS.map(([name]) => name),
+      stableUpdateUrlsRemoved: true,
+      productionSourceModified: false,
+      requiresStableToolkitDisabled: true,
+    },
+  };
+}
+
+function parseArgs(argv) {
+  const result = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = argv[index];
+    if (!key.startsWith("--")) throw new Error(`Unexpected argument: ${key}`);
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) throw new Error(`Missing value for ${key}`);
+    result[key.slice(2)] = value;
+    index += 1;
+  }
+  return result;
+}
+
+function instructions(manifest, bundleName) {
+  return `# MissionChief Toolkit authenticated performance capture\n\n` +
+    `- Toolkit authority: **v${manifest.toolkitVersion}**\n` +
+    `- Canonical source SHA-256: \`${manifest.canonicalSourceSha256}\`\n` +
+    `- Capture bundle SHA-256: \`${manifest.bundleSha256}\`\n\n` +
+    `## One controlled session\n\n` +
+    `1. Disable the normal MissionChief Map Command Toolkit userscript.\n` +
+    `2. Install \`${bundleName}\`. It has a separate identity and no update URL.\n` +
+    `3. Reload MissionChief. The profiler starts automatically on **idle-map**.\n` +
+    `4. Follow the six stages displayed in the bottom-right capture panel.\n` +
+    `5. Press **Finish and export report**.\n` +
+    `6. Remove/disable the capture bundle and re-enable the stable Toolkit.\n` +
+    `7. Upload the exported \`mcms-performance-*.json\` report for validation.\n\n` +
+    `The capture collects aggregate timing, mutation and runtime-resource counts only. It does not collect mission titles, addresses, coordinates, vehicle/personnel names, alliance messages, cookies, storage values or webhook contents.\n`;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  for (const required of ["source", "profiler", "output", "manifest", "instructions"]) {
+    if (!args[required]) throw new Error(`Missing --${required}`);
+  }
+  const toolkitPath = path.resolve(args.source);
+  const profilerPath = path.resolve(args.profiler);
+  const outputPath = path.resolve(args.output);
+  const manifestPath = path.resolve(args.manifest);
+  const instructionsPath = path.resolve(args.instructions);
+  if ([profilerPath, manifestPath, instructionsPath].includes(outputPath)) throw new Error("Capture output paths must be distinct");
+  const toolkitSource = fs.readFileSync(toolkitPath, "utf8");
+  const profilerSource = fs.readFileSync(profilerPath, "utf8");
+  const result = buildCaptureBundle(toolkitSource, profilerSource);
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.mkdirSync(path.dirname(manifestPath), { recursive: true });
+  fs.mkdirSync(path.dirname(instructionsPath), { recursive: true });
+  fs.writeFileSync(outputPath, result.bundle, "utf8");
+  fs.writeFileSync(manifestPath, JSON.stringify(result.manifest, null, 2) + "\n", "utf8");
+  fs.writeFileSync(instructionsPath, instructions(result.manifest, path.basename(outputPath)), "utf8");
+  console.log(JSON.stringify(result.manifest, null, 2));
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(new URL(import.meta.url).pathname)) {
+  try { main(); } catch (error) { console.error(error.stack || error.message); process.exit(1); }
+}

--- a/tools/build-live-performance-capture.mjs
+++ b/tools/build-live-performance-capture.mjs
@@ -39,6 +39,16 @@ function replaceMetadata(source, name, value) {
   return source.replace(pattern, `// @${name.padEnd(12)} ${value}`);
 }
 
+function removeStableUpdateMetadata(source) {
+  return source
+    .split("\n")
+    .filter(line => {
+      const trimmed = line.trimStart();
+      return !trimmed.startsWith("// @downloadURL") && !trimmed.startsWith("// @updateURL");
+    })
+    .join("\n");
+}
+
 function captureGuideSource() {
   return `
 (function installMcmsCaptureGuide() {
@@ -131,11 +141,11 @@ export function buildCaptureBundle(toolkitSource, profilerSource) {
   bundle = replaceMetadata(bundle, "namespace", "https://github.com/Conroy1988/missionchief-toolkit-assets/performance-capture");
   bundle = replaceMetadata(bundle, "version", `${toolkitVersion}-capture.1`);
   bundle = replaceMetadata(bundle, "description", "Development-only authenticated MissionChief performance capture. Disable the stable Toolkit while installed.");
-  bundle = bundle.replace(/^//\s*@(?:downloadURL|updateURL)\s+[^\n]+\n?/gmu, "");
+  bundle = removeStableUpdateMetadata(bundle);
 
   let profilerBody = stripUserscriptMetadata(profilerSource);
   const startupAnchor = "getStartupMetrics: () => window.__MCMS_STARTUP_METRICS__ || {},";
-  if ((profilerBody.match(new RegExp(startupAnchor.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "gu")) || []).length !== 1) {
+  if (profilerBody.split(startupAnchor).length - 1 !== 1) {
     throw new Error("Profiler startup-metrics anchor drifted");
   }
   profilerBody = profilerBody.replace(
@@ -150,7 +160,10 @@ export function buildCaptureBundle(toolkitSource, profilerSource) {
   const prelude = `\n// Development capture profile: ${CAPTURE_PROFILE}\n${profilerBody}\n${captureGuideSource()}\n`;
   bundle = bundle.slice(0, insertion) + prelude + bundle.slice(insertion);
 
-  if (/^\/\/\s*@(downloadURL|updateURL)\s+/mu.test(bundle)) throw new Error("Capture bundle must not carry stable update URLs");
+  const metadataBlock = bundle.slice(0, bundle.indexOf(metadataEndMarker));
+  if (metadataBlock.includes("@downloadURL") || metadataBlock.includes("@updateURL")) {
+    throw new Error("Capture bundle must not carry stable update URLs");
+  }
   if (!bundle.includes("globalThis.__MCMS_PROFILER__?.beginRender?.(\"updateUI\")")) throw new Error("updateUI probe missing");
   if (!bundle.includes("globalThis.__MCMS_PROFILER__?.beginRender?.(\"renderOperationalPanels\")")) throw new Error("operational render probe missing");
   if (!bundle.includes(canonicalSourceSha256)) throw new Error("Canonical source authority missing from capture bundle");

--- a/tools/validate-live-performance-report.mjs
+++ b/tools/validate-live-performance-report.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+"use strict";
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const ALLOWED_HOSTS = new Set([
+  "missionchief.co.uk", "www.missionchief.co.uk",
+  "missionchief.com", "www.missionchief.com",
+  "leitstellenspiel.de", "www.leitstellenspiel.de",
+  "meldkamerspel.com", "www.meldkamerspel.com",
+]);
+const REQUIRED_SCENARIOS = [
+  "idle-map", "settings-open-close", "mission-open-close",
+  "unit-selection", "map-pan-zoom", "layout-change",
+];
+const FORBIDDEN_KEYS = /(?:cookie|authorization|webhook|token|missionTitle|address|coordinate|vehicleName|personnelName|allianceMessage|storageValue)/iu;
+
+function parseArgs(argv) {
+  const result = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = argv[index];
+    if (!key.startsWith("--")) throw new Error(`Unexpected argument: ${key}`);
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) throw new Error(`Missing value for ${key}`);
+    result[key.slice(2)] = value;
+    index += 1;
+  }
+  return result;
+}
+
+function scanKeys(value, pathName = "report") {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => scanKeys(item, `${pathName}[${index}]`));
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+  for (const [key, child] of Object.entries(value)) {
+    if (FORBIDDEN_KEYS.test(key)) throw new Error(`Forbidden sensitive field: ${pathName}.${key}`);
+    scanKeys(child, `${pathName}.${key}`);
+  }
+}
+
+function orderedScenarioCoverage(report) {
+  const observed = (report.scenarioTransitions || []).map(item => String(item?.scenario || ""));
+  let position = -1;
+  for (const required of REQUIRED_SCENARIOS) {
+    const next = observed.indexOf(required, position + 1);
+    if (next < 0) throw new Error(`Missing or out-of-order scenario transition: ${required}`);
+    position = next;
+  }
+  return observed;
+}
+
+function renderCoverage(report) {
+  const measurements = Array.isArray(report.renderMeasurements) ? report.renderMeasurements : [];
+  const updateRows = measurements.filter(item => item?.path === "updateUI" && Number(item?.attempts) > 0);
+  if (!updateRows.length) throw new Error("No updateUI render measurements were captured");
+  const covered = new Set(updateRows.map(item => String(item.scenario || "")));
+  const missing = REQUIRED_SCENARIOS.filter(name => !covered.has(name));
+  if (missing.length) throw new Error(`No updateUI render evidence for: ${missing.join(", ")}`);
+  return { measurements, updateRows };
+}
+
+export function validateReport(report, manifest) {
+  const errors = [];
+  const assert = (condition, message) => { if (!condition) errors.push(message); };
+  assert(report && typeof report === "object", "Report must be a JSON object");
+  if (!report || typeof report !== "object") return { valid: false, errors };
+
+  scanKeys(report);
+  assert(report.schemaVersion === 2, "Profiler schemaVersion must be 2");
+  assert(report.profilerVersion === manifest.profilerVersion, "Profiler version does not match capture manifest");
+  assert(report.active === false, "Stop the profiler before exporting the report");
+  assert(Number(report.durationMs) >= 60_000, "Capture duration must be at least 60 seconds");
+  assert(ALLOWED_HOSTS.has(String(report.page?.host || "")), "Report host is not an allowed MissionChief domain");
+  assert(["other", "mission", "building", "vehicle", "alliance"].includes(String(report.page?.pathClass || "")), "Invalid pathClass");
+  assert(report.startupMetrics?.captureProfile === manifest.profile, "Capture profile marker missing");
+  assert(report.startupMetrics?.captureToolkitVersion === manifest.toolkitVersion, "Toolkit version marker mismatch");
+  assert(report.startupMetrics?.captureSourceSha256 === manifest.canonicalSourceSha256, "Canonical source hash marker mismatch");
+  assert(report.startupMetrics?.captureProfilerVersion === manifest.profilerVersion, "Profiler marker mismatch");
+  assert(Array.isArray(report.runtimeSamples) && report.runtimeSamples.length >= 2, "At least two runtime resource samples are required");
+  assert(Array.isArray(report.longTasks), "longTasks must be an array");
+  assert(Array.isArray(report.layoutShifts), "layoutShifts must be an array");
+  assert(Array.isArray(report.mutations), "mutations must be an array");
+  assert(Array.isArray(report.resources), "resources must be an array");
+
+  let scenarios = [];
+  let render = { measurements: [], updateRows: [] };
+  try { scenarios = orderedScenarioCoverage(report); } catch (error) { errors.push(error.message); }
+  try { render = renderCoverage(report); } catch (error) { errors.push(error.message); }
+
+  const summary = {
+    valid: errors.length === 0,
+    errors,
+    capture: {
+      profile: manifest.profile,
+      toolkitVersion: manifest.toolkitVersion,
+      canonicalSourceSha256: manifest.canonicalSourceSha256,
+      bundleSha256: manifest.bundleSha256,
+    },
+    durationMs: Number(report.durationMs) || 0,
+    scenarioTransitions: scenarios,
+    updateUiMeasurements: render.updateRows.map(item => ({
+      scenario: item.scenario,
+      attempts: item.attempts,
+      unchangedAttempts: item.unchangedAttempts,
+      changedAttempts: item.changedAttempts,
+      unchangedRatio: item.unchangedRatio,
+      averageDurationMs: item.averageDurationMs,
+      maxDurationMs: item.maxDurationMs,
+      mutationRecords: item.mutationRecords,
+    })),
+    longTaskCount: report.longTasks?.length || 0,
+    longTaskTotalMs: (report.longTasks || []).reduce((sum, item) => sum + Math.max(0, Number(item?.durationMs) || 0), 0),
+    layoutShiftTotal: (report.layoutShifts || []).filter(item => item?.hadRecentInput !== true).reduce((sum, item) => sum + Math.max(0, Number(item?.value) || 0), 0),
+    mutationBatches: report.mutations?.length || 0,
+    runtimeSamples: report.runtimeSamples?.length || 0,
+  };
+  return summary;
+}
+
+function renderMarkdown(summary) {
+  const lines = [
+    "# MissionChief Toolkit live performance report validation",
+    "",
+    `- **Result:** ${summary.valid ? "PASS" : "FAIL"}`,
+    `- **Toolkit:** ${summary.capture.toolkitVersion}`,
+    `- **Source SHA-256:** \`${summary.capture.canonicalSourceSha256}\``,
+    `- **Duration:** ${(summary.durationMs / 1000).toFixed(1)} seconds`,
+    `- **Long tasks:** ${summary.longTaskCount} / ${summary.longTaskTotalMs.toFixed(1)} ms total`,
+    `- **Layout shift total:** ${summary.layoutShiftTotal.toFixed(6)}`,
+    `- **Mutation batches:** ${summary.mutationBatches}`,
+    `- **Runtime samples:** ${summary.runtimeSamples}`,
+    "",
+    "## updateUI scenario evidence",
+    "",
+    "| Scenario | Attempts | Unchanged | Changed | Unchanged ratio | Average | Maximum | Mutation records |",
+    "|---|---:|---:|---:|---:|---:|---:|---:|",
+    ...summary.updateUiMeasurements.map(row => `| ${row.scenario} | ${row.attempts} | ${row.unchangedAttempts} | ${row.changedAttempts} | ${Number(row.unchangedRatio || 0).toFixed(4)} | ${Number(row.averageDurationMs || 0).toFixed(3)} ms | ${Number(row.maxDurationMs || 0).toFixed(3)} ms | ${row.mutationRecords} |`),
+    "",
+    "## Validation errors",
+    "",
+    ...(summary.errors.length ? summary.errors.map(error => `- ${error}`) : ["- None."]),
+    "",
+  ];
+  return lines.join("\n");
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.report || !args.manifest) throw new Error("Usage: validate-live-performance-report.mjs --report REPORT.json --manifest capture-manifest.json [--json-output FILE] [--markdown-output FILE]");
+  const report = JSON.parse(fs.readFileSync(path.resolve(args.report), "utf8"));
+  const manifest = JSON.parse(fs.readFileSync(path.resolve(args.manifest), "utf8"));
+  const summary = validateReport(report, manifest);
+  const json = JSON.stringify(summary, null, 2) + "\n";
+  const markdown = renderMarkdown(summary);
+  if (args["json-output"]) fs.writeFileSync(path.resolve(args["json-output"]), json, "utf8");
+  if (args["markdown-output"]) fs.writeFileSync(path.resolve(args["markdown-output"]), markdown, "utf8");
+  console.log(json);
+  if (!summary.valid) process.exitCode = 1;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(new URL(import.meta.url).pathname)) {
+  try { main(); } catch (error) { console.error(error.stack || error.message); process.exit(1); }
+}


### PR DESCRIPTION
## Parent issues

- #247 — high-priority performance and reliability audit
- #254 — CSS parse/style evidence
- #255 — unchanged-state render evidence

## Objective

Reduce the remaining owner-only authenticated MissionChief evidence step to one controlled session with one installable development userscript.

## Package

The workflow builds an artifact containing:

- an exact disposable v8.3.2 Toolkit copy;
- AST probes around `updateUI()` and `renderOperationalPanels()`;
- the privacy-bounded development profiler;
- automatic startup and a six-stage scenario guide;
- report source/profile markers;
- a strict report validator;
- instructions, manifest and checksums.

The capture bundle has a distinct userscript identity and no stable update URLs. The normal Toolkit must be disabled only during the capture session.

## Safety

- no production `src`, `dist`, root stable userscript, version or release-state change;
- no production release;
- no monkeypatching of MissionChief APIs, fetch, XHR, Leaflet or event targets;
- no mission titles, addresses, coordinates, vehicle/personnel names, messages, cookies, storage values or webhook contents collected;
- exact v8.3.2 source SHA authority enforced;
- all six scenarios and `updateUI()` evidence required before a report validates.

This PR prepares evidence tooling only. It does not authorise a CSS or scheduling change.