### PR TITLE
Fix v10.2.1 validation candidate packaging

### DIFF
--- a/.github/scripts/test_validation_candidate_pipeline.py
+++ b/.github/scripts/test_validation_candidate_pipeline.py
@@ -39,6 +39,7 @@ def main() -> int:
     generator = DASHBOARD_GENERATOR.read_text(encoding="utf-8")
     reconciler = RETIRED_RECONCILER.read_text(encoding="utf-8")
     dashboard = json.loads(DASHBOARD.read_text(encoding="utf-8"))
+    manifest = json.loads((ROOT / "dist/release-manifest.json").read_text(encoding="utf-8"))
 
     require(validation, [
         "permissions:\n  contents: read",
@@ -49,6 +50,11 @@ def main() -> int:
         "headCommit: $headCommit",
         "pullRequest: $pullRequest",
         "missionchief-toolkit-validation-candidate-${{ github.sha }}",
+        "dist/MissionChief_Map_Command_Toolkit.install.user.js",
+        "dist/MissionChief_Map_Command_Toolkit.update.user.js",
+        "dist/MissionChief_Map_Command_Toolkit.meta.js",
+        "dist/MissionChief_Map_Command_Toolkit.greasyfork.user.js",
+        "dist/MissionChief_Map_Command_Toolkit.css",
         "publicMainChanged: false",
         "releaseDashboardChanged: false",
         "verify_validation_candidate.py --self-test",
@@ -70,6 +76,16 @@ def main() -> int:
         "github-actions[bot]",
         "  push:\n",
     ], "Canonical validation workflow")
+    expected_candidate_files = {
+        *manifest["distributionFiles"],
+        "dist/SHA256SUMS.txt",
+        "dist/release-manifest.json",
+    }
+    if set(manifest.get("validationCandidateFiles", [])) != expected_candidate_files:
+        raise AssertionError("Release manifest validation-candidate inventory is incomplete")
+    for path in expected_candidate_files:
+        if path not in validation:
+            raise AssertionError(f"Canonical validation artifact omits declared file: {path}")
 
     require(automatic, [
         "types:\n      - closed",

--- a/.github/scripts/validate_userscript.py
+++ b/.github/scripts/validate_userscript.py
@@ -300,6 +300,11 @@ def main() -> int:
         "version": version,
         "source": str(SOURCE.relative_to(ROOT)),
         "distributionFiles": [str(path.relative_to(ROOT)) for path in distribution_files],
+        "validationCandidateFiles": [
+            *(str(path.relative_to(ROOT)) for path in distribution_files),
+            str(SUMS.relative_to(ROOT)),
+            str(MANIFEST.relative_to(ROOT)),
+        ],
         "sha256": user_hash,
         "bytes": len(raw),
         "lines": text.count("\n") + 1,

--- a/.github/workflows/validate-userscript.yml
+++ b/.github/workflows/validate-userscript.yml
@@ -311,6 +311,11 @@ jobs:
             validation-candidate/validation-candidate.json
             dist/MissionChief_Map_Command_Toolkit.user.js
             dist/MissionChief_Map_Command_Toolkit.txt
+            dist/MissionChief_Map_Command_Toolkit.install.user.js
+            dist/MissionChief_Map_Command_Toolkit.update.user.js
+            dist/MissionChief_Map_Command_Toolkit.meta.js
+            dist/MissionChief_Map_Command_Toolkit.greasyfork.user.js
+            dist/MissionChief_Map_Command_Toolkit.css
             dist/SHA256SUMS.txt
             dist/release-manifest.json
             release-bundle/

--- a/dist/release-manifest.json
+++ b/dist/release-manifest.json
@@ -11,6 +11,17 @@
     "dist/MissionChief_Map_Command_Toolkit.greasyfork.user.js",
     "dist/MissionChief_Map_Command_Toolkit.css"
   ],
+  "validationCandidateFiles": [
+    "dist/MissionChief_Map_Command_Toolkit.user.js",
+    "dist/MissionChief_Map_Command_Toolkit.txt",
+    "dist/MissionChief_Map_Command_Toolkit.install.user.js",
+    "dist/MissionChief_Map_Command_Toolkit.update.user.js",
+    "dist/MissionChief_Map_Command_Toolkit.meta.js",
+    "dist/MissionChief_Map_Command_Toolkit.greasyfork.user.js",
+    "dist/MissionChief_Map_Command_Toolkit.css",
+    "dist/SHA256SUMS.txt",
+    "dist/release-manifest.json"
+  ],
   "sha256": "91099941cf510ab506076cccc32c7255fba6f6b552c58c61848c5f5244578d7d",
   "bytes": 2109504,
   "lines": 31749,


### PR DESCRIPTION
## What changed

- packages every distribution file declared by the v10.2.1 release manifest in the immutable validation candidate
- records the complete candidate inventory in the generated release manifest
- adds an executable contract that fails when the manifest and upload workflow diverge

## Root cause

Automatic release run #641 resolved the exact green PR #628 validation artifact, but that artifact uploaded only the two legacy distribution files. Candidate verification correctly rejected it because the new TKB install, update, metadata, Greasy Fork mirror and stylesheet assets were missing.

## Safety

No runtime code, settings or released v10.2.1 bytes change. The fix affects validation artifact packaging only. The generated manifest change makes this PR a release candidate so its own exact green artifact can promote v10.2.1 after merge.

## Validation

- validation candidate verifier and pipeline contracts: passed
- release, Greasy Fork, announcement, recovery, update-manifest and consolidated-gate contracts: passed
- Actions security audit: passed
- all 9 manifest-declared validation candidate files exist
- remote tree exactly matches local validated tree `b530de15ed2fd02b8e4a65649e5ce2ed6a6eb821`

Related: #627
Failed run: https://github.com/Conroy1988/missionchief-toolkit-assets/actions/runs/30706186243