### PR TITLE
Fix promoted v10.2.1 candidate packaging

### DIFF
--- a/.github/scripts/test_validation_candidate_pipeline.py
+++ b/.github/scripts/test_validation_candidate_pipeline.py
@@ -81,11 +81,13 @@ def main() -> int:
         "dist/SHA256SUMS.txt",
         "dist/release-manifest.json",
     }
-    if set(manifest.get("validationCandidateFiles", [])) != expected_candidate_files:
-        raise AssertionError("Release manifest validation-candidate inventory is incomplete")
+    if set(manifest.get("candidateArtifactFiles", [])) != expected_candidate_files:
+        raise AssertionError("Release manifest candidate-artifact inventory is incomplete")
     for path in expected_candidate_files:
         if path not in validation:
             raise AssertionError(f"Canonical validation artifact omits declared file: {path}")
+        if path not in automatic:
+            raise AssertionError(f"Promoted validation artifact omits declared file: {path}")
 
     require(automatic, [
         "types:\n      - closed",

--- a/.github/scripts/validate_userscript.py
+++ b/.github/scripts/validate_userscript.py
@@ -300,7 +300,7 @@ def main() -> int:
         "version": version,
         "source": str(SOURCE.relative_to(ROOT)),
         "distributionFiles": [str(path.relative_to(ROOT)) for path in distribution_files],
-        "validationCandidateFiles": [
+        "candidateArtifactFiles": [
             *(str(path.relative_to(ROOT)) for path in distribution_files),
             str(SUMS.relative_to(ROOT)),
             str(MANIFEST.relative_to(ROOT)),

--- a/.github/workflows/auto-release-after-validation.yml
+++ b/.github/workflows/auto-release-after-validation.yml
@@ -226,6 +226,11 @@ jobs:
             validation-candidate/validation-candidate.json
             dist/MissionChief_Map_Command_Toolkit.user.js
             dist/MissionChief_Map_Command_Toolkit.txt
+            dist/MissionChief_Map_Command_Toolkit.install.user.js
+            dist/MissionChief_Map_Command_Toolkit.update.user.js
+            dist/MissionChief_Map_Command_Toolkit.meta.js
+            dist/MissionChief_Map_Command_Toolkit.greasyfork.user.js
+            dist/MissionChief_Map_Command_Toolkit.css
             dist/SHA256SUMS.txt
             dist/release-manifest.json
             release-bundle/

--- a/dist/release-manifest.json
+++ b/dist/release-manifest.json
@@ -11,7 +11,7 @@
     "dist/MissionChief_Map_Command_Toolkit.greasyfork.user.js",
     "dist/MissionChief_Map_Command_Toolkit.css"
   ],
-  "validationCandidateFiles": [
+  "candidateArtifactFiles": [
     "dist/MissionChief_Map_Command_Toolkit.user.js",
     "dist/MissionChief_Map_Command_Toolkit.txt",
     "dist/MissionChief_Map_Command_Toolkit.install.user.js",


### PR DESCRIPTION
## What changed

- packages every manifest-declared distribution file when the validated PR artifact is promoted to the merged-main candidate
- uses one generic `candidateArtifactFiles` manifest inventory for both validation and promotion
- strengthens the executable contract so both workflow upload stages must include all nine declared files

## Root cause

PR #629 fixed the canonical validation artifact, allowing automatic release run #642 to promote it successfully. The promotion workflow then repackaged that complete artifact with its own legacy two-file upload list, and production correctly rejected the incomplete promoted copy.

## Safety

No runtime userscript bytes or settings change. The release still consumes only an exact green PR tree and verifies it again after promotion.

## Validation

- two-stage package contract: all 9 declared files exist in both upload inventories
- candidate verifier, release, Greasy Fork, announcement, recovery, update-manifest and consolidated-gate contracts: passed
- Actions security audit: passed
- remote tree exactly matches local validated tree `ce26c5968be8dc90cace4b88029f7747f68c3b48`

Related: #627, #629
Failed run: https://github.com/Conroy1988/missionchief-toolkit-assets/actions/runs/30706484103