### PR TITLE
Fix release-state dot-path parsing after v10.3.3

### DIFF
--- a/.github/scripts/release_state_branch.py
+++ b/.github/scripts/release_state_branch.py
@@ -37,7 +37,10 @@ def git(*args: str, cwd: Path = ROOT, capture: bool = True) -> str:
     if result.returncode != 0:
         detail = (result.stderr or result.stdout or "git command failed").strip()
         raise ReleaseStateError(f"git {' '.join(args)} failed: {detail}")
-    return result.stdout.strip() if capture else ""
+    # Preserve leading porcelain status columns and dot-prefixed paths.  Only
+    # line terminators are disposable; generic whitespace stripping corrupts
+    # entries such as `` M .github/release-announcement-version.txt``.
+    return result.stdout.rstrip("\r\n") if capture else ""
 
 
 def load_role(worktree: Path) -> dict:
@@ -132,8 +135,7 @@ def prepare(worktree: Path) -> None:
     print(f"Prepared governed {TARGET_BRANCH} worktree at {worktree} ({before})")
 
 
-def status_paths(worktree: Path) -> set[str]:
-    raw = git("status", "--porcelain=v1", "-z", cwd=worktree)
+def parse_status_paths(raw: str) -> set[str]:
     if not raw:
         return set()
     entries = raw.split("\0")
@@ -155,6 +157,10 @@ def status_paths(worktree: Path) -> set[str]:
             index += 1
         paths.add(path)
     return paths
+
+
+def status_paths(worktree: Path) -> set[str]:
+    return parse_status_paths(git("status", "--porcelain=v1", "-z", cwd=worktree))
 
 
 def authorization_header(token: str) -> str:
@@ -293,6 +299,13 @@ def self_test() -> None:
 
     assert PUSH_REF == "HEAD:refs/heads/release-state"
     assert "main" not in PUSH_REF
+    assert parse_status_paths(
+        " M .github/release-announcement-version.txt\0"
+        "?? status/new-release-state.json\0"
+    ) == {
+        ".github/release-announcement-version.txt",
+        "status/new-release-state.json",
+    }
     print("Release-state branch writer self-tests passed.")
 
 


### PR DESCRIPTION
## Summary

Fixes the Issue #41 authoritative release-state writer after the otherwise successful v10.3.3 production run.

`git()` used generic whitespace stripping on NUL-delimited porcelain output. A worktree-only entry such as ` M .github/release-announcement-version.txt` therefore lost its leading status-column space and was misparsed as `github/release-announcement-version.txt`.

This change:

- removes only CR/LF terminators while preserving porcelain status columns
- extracts status parsing into a directly testable helper
- adds regression fixtures for a dot-prefixed tracked path and an untracked status path
- leaves the release-state allowlist, no-force-push guarantee and zero-`main`-writer topology unchanged

## Incident evidence

Automatic release run `30750269261` successfully completed:

- GitHub Release v10.3.3
- live TKB install/update/metadata verification
- private backup `c44ab3ca2e8411aa267070bd9417fc54705aae6d`
- Discord message `1533468921959550990`

It then failed only while parsing the six-file release-state commit. The production release will not be republished and Discord will not be reposted; the missing authoritative state is reconciled separately from those preserved identities.

## Validation

- release-state writer self-tests
- release announcement pipeline contract
- release recovery pipeline contract
- branch-write inventory: 0 direct main writers
- release authority contract
- update-manifest pipeline contract
- Actions security audit

Part of #41.