### PR TITLE
Keep authoritative release-state source identity current

### DIFF
--- a/.github/scripts/release_recovery_state.py
+++ b/.github/scripts/release_recovery_state.py
@@ -258,6 +258,9 @@ def rebuild_dashboard(
 
     completed = now()
     dashboard["currentVersion"] = version
+    source = dashboard.setdefault("source", {})
+    source["validatedSha256"] = sha256
+    source["state"] = "validated-canonical-source"
     status = dashboard.setdefault("status", {})
     status.pop("greasyForkSync", None)
     status.update(

--- a/.github/scripts/test_release_pipeline_v4.py
+++ b/.github/scripts/test_release_pipeline_v4.py
@@ -32,6 +32,8 @@ assert "gh run watch" not in p
 assert "git push origin HEAD:main" not in p
 assert "Prepare authoritative release-state worktree" in p
 assert "release_state_branch.py commit" in p
+assert ".source.validatedSha256=$hash" in p
+assert '.source.state="validated-canonical-source"' in p
 assert 'validated_sha: ${{ needs.authorize.outputs.expected_main }}' in o
 assert '"candidateCommit":a.source' in rec and 'previous["recordedCommit"]=previous.pop("sourceSha256")' in rec
 h=json.loads((r/"status/release-speed-history.json").read_text())

--- a/.github/scripts/test_release_recovery_state_pipeline.py
+++ b/.github/scripts/test_release_recovery_state_pipeline.py
@@ -138,6 +138,8 @@ def main() -> int:
             "build_manifest(state_root)",
             "commit_state",
             'status.pop("greasyForkSync", None)',
+            'source["validatedSha256"] = sha256',
+            'source["state"] = "validated-canonical-source"',
             "Discord recovery claim changed before finalization",
             "Release recovery state self-tests passed.",
         ],

--- a/.github/workflows/release-toolkit.yml
+++ b/.github/workflows/release-toolkit.yml
@@ -402,6 +402,8 @@ jobs:
              .status.backup="private-repository-verified" |
              .status.discordRelease="posted" |
              .status.releaseReadiness="passed" |
+             .source.validatedSha256=$hash |
+             .source.state="validated-canonical-source" |
              .releaseReadiness={version:$version,state:"passed",requiredSecrets:true,privateRepositoryReadWrite:true,tkbDistributionVerified:true,distributionAuthority:"tkb-website-only",publicReleaseCreated:true,completedAt:$now} |
              .latestRelease={version:$version,sha256:$hash,githubRelease:$releaseUrl,tkbDistributionVerified:true,distributionAuthority:"tkb-website-only",privateBackupCommit:$backupCommit,discordMessageId:$discordMessageId,discordChannelId:$discordChannelId,discordPosted:true,completedAt:$now} |
              .lastUpdated=$now' \


### PR DESCRIPTION
## Summary

Keeps the authoritative release-state source identity synchronized with the verified release.

The v10.3.3 reconciliation exposed that both the normal release recorder and the controlled dashboard rebuild advanced `currentVersion` and `latestRelease.sha256` without also advancing `source.validatedSha256`. That could render a current version beside the previous canonical-source hash.

This infrastructure-only change:

- writes the verified release hash into `source.validatedSha256`
- reasserts `source.state=validated-canonical-source`
- applies the same invariant in normal release recording and controlled dashboard recovery
- adds static contracts for both paths
- does not change the userscript or create a new release

## Validation

- Release Pipeline v4 contract
- release recovery state contract
- release authority contract
- release announcement state contract
- atomic update-manifest contract
- branch-write inventory: 0 direct main writers

Part of #41.