### PR TITLE
Refresh Pages after controlled release-state recovery

### DIFF
--- a/.github/actions-security-policy.json
+++ b/.github/actions-security-policy.json
@@ -35,6 +35,7 @@
       "issues"
     ],
     ".github/workflows/release-recovery.yml": [
+      "actions",
       "contents"
     ],
     ".github/workflows/release-toolkit.yml": [

--- a/.github/scripts/test_pages_release_deploy_contract.py
+++ b/.github/scripts/test_pages_release_deploy_contract.py
@@ -30,6 +30,8 @@ def main() -> int:
         "release_state_sha=$RELEASE_STATE_SHA",
         'grep -Fq "${{ steps.production.outputs.release_version }}" _site/index.html',
         ".github/scripts/test_pages_release_deploy_contract.py",
+        '".github/scripts/release_recovery_state.py"',
+        '".github/workflows/release-recovery.yml"',
     ]
     missing = [fragment for fragment in required if fragment not in pages]
     assert not missing, f"Pages production deployment contract fragments missing: {missing}"

--- a/.github/scripts/test_release_recovery_state_pipeline.py
+++ b/.github/scripts/test_release_recovery_state_pipeline.py
@@ -79,7 +79,7 @@ def main() -> int:
         workflow,
         [
             "name: Release Recovery",
-            "permissions:\n  contents: write",
+            "permissions:\n  actions: write\n  contents: write",
             "group: toolkit-production-release",
             "Check out latest main authority",
             "ref: main",
@@ -100,9 +100,12 @@ def main() -> int:
             "finalize-discord",
             "Rebuild verified release dashboard on release-state",
             "rebuild-dashboard",
+            "Refresh Pages after release-state recovery",
+            "gh workflow run github-pages.yml --ref main",
             "Repair stable GitHub Release assets",
             "Recovery ledger: \\`release-state\\`",
             "Public main changed: no",
+            "Pages refresh follows successful release-state recovery: yes",
         ],
         "Release recovery workflow",
     )

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -11,8 +11,10 @@ on:
     paths:
       - ".github/scripts/build_pages_site.py"
       - ".github/scripts/build_download_stats.py"
+      - ".github/scripts/release_recovery_state.py"
       - ".github/scripts/test_pages_release_deploy_contract.py"
       - ".github/workflows/github-pages.yml"
+      - ".github/workflows/release-recovery.yml"
       - ".github/release-settings.json"
       - "docs/site-data.json"
       - "docs/site-assets/**"

--- a/.github/workflows/release-recovery.yml
+++ b/.github/workflows/release-recovery.yml
@@ -33,6 +33,7 @@ on:
         type: string
 
 permissions:
+  actions: write
   contents: write
 
 concurrency:
@@ -290,6 +291,19 @@ jobs:
             --backup-commit "$BACKUP_COMMIT" \
             --discord-state "$DISCORD_STATE"
 
+      - name: Refresh Pages after release-state recovery
+        if: >-
+          inputs.operation == 'retry-private-backup' ||
+          inputs.operation == 'retry-discord' ||
+          inputs.operation == 'rebuild-dashboard'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh workflow run github-pages.yml --ref main
+          echo "GitHub Pages refresh dispatched from the recovered release-state ledger."
+
       - name: Repair stable GitHub Release assets
         if: inputs.operation == 'repair-stable-assets'
         env:
@@ -341,4 +355,5 @@ jobs:
             echo "- Recovery ledger: \`release-state\`"
             echo "- Public main changed: no"
             echo "- No new GitHub Release was created"
+            echo "- Pages refresh follows successful release-state recovery: yes"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Completes the Issue #41 recovery handoff by refreshing GitHub Pages after any controlled release-state recovery that changes the live ledger.

The v10.3.3 release completed TKB verification, backup and Discord, then failed before the normal Pages dispatch. Its six-file authoritative state was reconciled at `c5235da4e86970c9e8b2200acacb978462e36f01`.

This change:

- grants the recovery workflow only the additional `actions: write` permission required to dispatch Pages
- dispatches `github-pages.yml` after backup, Discord or dashboard release-state recovery
- keeps the dispatch asynchronous and non-blocking
- records the recovery/Pages relationship in the summary and contract tests
- makes recovery workflow/helper changes part of the Pages deployment path filter
- triggers a production Pages build on merge so the reconciled v10.3.3 ledger becomes visible

It does not republish v10.3.3, repost Discord, change the userscript, or write release state to `main`.

## Validation

- release recovery contract
- Pages deployment contract
- Release Pipeline v4 contract
- branch-write inventory: 0 direct main writers
- Actions security audit with the narrowed permission allowlist

Part of #41.