### PR TITLE
Read live asset-health expectations from release-state

### DIFF
--- a/.github/scripts/test_asset_health.py
+++ b/.github/scripts/test_asset_health.py
@@ -328,6 +328,21 @@ def test_repository_audio_contract() -> None:
     )
     assert not report["failures"], report
 
+
+def test_asset_health_workflow_uses_release_state() -> None:
+    workflow = (REPOSITORY_ROOT / ".github/workflows/asset-health-monitor.yml").read_text(
+        encoding="utf-8"
+    )
+    for marker in [
+        "persist-credentials: false",
+        "Overlay authoritative release-state status",
+        "+refs/heads/release-state:refs/remotes/origin/release-state",
+        "git restore --source=refs/remotes/origin/release-state",
+        "status/release-dashboard.json",
+        "status/update-manifest.json",
+    ]:
+        assert marker in workflow, marker
+
 def main() -> None:
     tests = [
         test_live_success_and_optional_warning,
@@ -340,7 +355,8 @@ def main() -> None:
         test_audio_alias_contract_hash_mismatch,
         test_audio_alias_contract_undeclared_duplicate,
         test_audio_alias_contract_orphan_audio,
-        test_repository_audio_contract
+        test_repository_audio_contract,
+        test_asset_health_workflow_uses_release_state
     ]
     for test in tests:
         test()

--- a/.github/workflows/asset-health-monitor.yml
+++ b/.github/workflows/asset-health-monitor.yml
@@ -25,6 +25,20 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
+
+      - name: Overlay authoritative release-state status
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=1 origin \
+            +refs/heads/release-state:refs/remotes/origin/release-state
+          git restore --source=refs/remotes/origin/release-state -- \
+            status/release-dashboard.json \
+            status/README.md \
+            status/update-manifest.json \
+            status/release-speed-history.json \
+            status/RELEASE_SPEED.md
 
       - name: Resolve check mode
         id: mode


### PR DESCRIPTION
## Summary

Moves Asset Health's live release expectations to the authoritative `release-state` ledger.

Issue #626 was opened during the v10.3.3 cutover because the monitor compared correctly updated TKB endpoints against the intentionally frozen v10.3.2 dashboard on `main`. The runtime, Pages and other production consumers already use `release-state`; Asset Health was the remaining live status reader.

This change:

- overlays the five authoritative release-state status files before live/static mode resolution
- disables persisted checkout credentials
- retains reviewed code and media discovery from `main`
- adds a contract preventing the monitor from returning to frozen `main` expectations
- changes no userscript or release artifact

## Validation

- all 12 Asset Health self-tests
- release authority contract
- Actions security audit

Part of #41. Resolves the cause of #626.