### PR TITLE
Add guarded audited branch cleanup

### DIFF
--- a/.github/actions-security-policy.json
+++ b/.github/actions-security-policy.json
@@ -22,6 +22,9 @@
     ".github/workflows/discord-release-preview.yml": [
       "issues"
     ],
+    ".github/workflows/execute-audited-branch-cleanup.yml": [
+      "contents"
+    ],
     ".github/workflows/github-pages.yml": [
       "id-token",
       "pages"

--- a/.github/branch-write-inventory.json
+++ b/.github/branch-write-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "reviewedAt": "2026-08-02",
-  "reviewedMainCommit": "c9fb4222465014dbe51809f3cade9ff4131b1a4a",
+  "reviewedAt": "2026-08-03",
+  "reviewedMainCommit": "94c25e574d24ad7b758e1fc5c448bcfe89b61c28",
   "strictProtectionEnabled": false,
   "directMainWriters": [],
   "indirectMainWriteOrchestrators": [
@@ -165,8 +165,22 @@
       "replacementIdentity": "narrowly scoped GitHub App"
     }
   ],
+  "branchMaintenanceWriters": [
+    {
+      "workflow": ".github/workflows/execute-audited-branch-cleanup.yml",
+      "sourceAuthority": "owner-pushed exact branch names and immutable audited head SHAs",
+      "target": "obsolete non-operational branch refs plus the transient command branch",
+      "credential": "github.token",
+      "actor": "repository owner only",
+      "openPullRequestDeletionAllowed": false,
+      "mainMutationAllowed": false,
+      "operationalBranchMutationAllowed": false,
+      "forcePushAllowed": false
+    }
+  ],
   "contentsWriteAuthority": [
     ".github/workflows/auto-release-after-validation.yml",
+    ".github/workflows/execute-audited-branch-cleanup.yml",
     ".github/workflows/owner-release-command.yml",
     ".github/workflows/release-recovery.yml",
     ".github/workflows/release-toolkit.yml"

--- a/.github/scripts/test_branch_write_inventory.py
+++ b/.github/scripts/test_branch_write_inventory.py
@@ -88,11 +88,13 @@ def main() -> int:
     external_entries = inventory.get("externalRepositoryMainPushSources") or []
     review_entries = inventory.get("reviewBranchWriters") or []
     shadow_entries = inventory.get("shadowBranchWriters") or []
+    maintenance_entries = inventory.get("branchMaintenanceWriters") or []
 
     direct = workflow_set(direct_entries)
     orchestrators = workflow_set(orchestrator_entries)
     artifacts = workflow_set(artifact_entries)
     state_writers = workflow_set(state_entries)
+    maintenance_writers = workflow_set(maintenance_entries)
 
     expected_direct: set[str] = set()
     expected_orchestrators = {
@@ -111,6 +113,9 @@ def main() -> int:
         ".github/workflows/release-toolkit.yml",
         ".github/workflows/release-recovery.yml",
     }
+    expected_maintenance_writers = {
+        ".github/workflows/execute-audited-branch-cleanup.yml",
+    }
     if direct != expected_direct:
         fail(f"Unexpected direct public-main writers: {sorted(direct)}")
     if orchestrators != expected_orchestrators:
@@ -119,8 +124,10 @@ def main() -> int:
         fail(f"Unexpected artifact-only workflows: {sorted(artifacts)}")
     if state_writers != expected_state_writers:
         fail(f"Unexpected release-state writers: {sorted(state_writers)}")
+    if maintenance_writers != expected_maintenance_writers:
+        fail(f"Unexpected branch-maintenance writers: {sorted(maintenance_writers)}")
 
-    groups = [direct, orchestrators, artifacts, state_writers]
+    groups = [direct, orchestrators, artifacts, state_writers, maintenance_writers]
     for index, left in enumerate(groups):
         for right in groups[index + 1 :]:
             if left & right:
@@ -132,7 +139,7 @@ def main() -> int:
         if "contents" in (permissions or [])
     }
     inventory_contents = set(inventory.get("contentsWriteAuthority") or [])
-    classified_contents = direct | orchestrators | state_writers
+    classified_contents = direct | orchestrators | state_writers | maintenance_writers
     if approved_contents != inventory_contents:
         fail("Actions security contents-write authority differs from inventory")
     if classified_contents != inventory_contents:
@@ -154,7 +161,7 @@ def main() -> int:
             f"authority-only={sorted(inventory_contents - declared_contents)}"
         )
 
-    for workflow in sorted(direct | orchestrators | artifacts | state_writers):
+    for workflow in sorted(direct | orchestrators | artifacts | state_writers | maintenance_writers):
         path = ROOT / workflow
         if not path.is_file():
             fail(f"Classified workflow is missing: {workflow}")
@@ -198,6 +205,43 @@ def main() -> int:
         text = (ROOT / workflow).read_text(encoding="utf-8")
         require(text, ["permissions:\n  contents: read", "persist-credentials: false", marker], workflow)
         forbid(text, ["contents: write", "git push origin HEAD:main", "git push origin HEAD:refs/heads/main"], workflow)
+
+    if len(maintenance_entries) != 1:
+        fail(f"Expected one branch-maintenance writer, found {len(maintenance_entries)}")
+    maintenance_entry = maintenance_entries[0]
+    expected_maintenance_entry = {
+        "workflow": ".github/workflows/execute-audited-branch-cleanup.yml",
+        "sourceAuthority": "owner-pushed exact branch names and immutable audited head SHAs",
+        "target": "obsolete non-operational branch refs plus the transient command branch",
+        "credential": "github.token",
+        "actor": "repository owner only",
+        "openPullRequestDeletionAllowed": False,
+        "mainMutationAllowed": False,
+        "operationalBranchMutationAllowed": False,
+        "forcePushAllowed": False,
+    }
+    if maintenance_entry != expected_maintenance_entry:
+        fail("Branch-maintenance writer inventory changed")
+
+    maintenance_workflow = (ROOT / maintenance_entry["workflow"]).read_text(encoding="utf-8")
+    require(
+        maintenance_workflow,
+        [
+            "branches:\n      - automation/branch-cleanup",
+            "if: github.actor == github.repository_owner",
+            "Branch moved after audit",
+            "Open pull request protects branch",
+            "recoverable from a closed PR nor contained in main",
+            "main release-state distribution automation/releases automation/development-packages automation/branch-cleanup",
+            "--method DELETE",
+        ],
+        maintenance_entry["workflow"],
+    )
+    forbid(
+        maintenance_workflow,
+        ["force: true", "git push --force", "refs/heads/main"],
+        maintenance_entry["workflow"],
+    )
 
     if len(state_entries) != 2:
         fail(f"Expected two release-state writers, found {len(state_entries)}")

--- a/.github/workflows/execute-audited-branch-cleanup.yml
+++ b/.github/workflows/execute-audited-branch-cleanup.yml
@@ -1,0 +1,200 @@
+name: Execute Audited Branch Cleanup
+
+run-name: Delete audited obsolete branches
+
+on:
+  push:
+    branches:
+      - automation/branch-cleanup
+    paths:
+      - .github/automation-commands/branch-cleanup.json
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: audited-branch-cleanup
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    if: github.actor == github.repository_owner
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Load and validate owner command
+        id: command
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMAND_REF: ${{ github.sha }}
+          REPOSITORY: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          gh api \
+            -H "Accept: application/vnd.github.raw+json" \
+            "repos/${REPOSITORY}/contents/.github/automation-commands/branch-cleanup.json?ref=${COMMAND_REF}" \
+            > "$RUNNER_TEMP/branch-cleanup.json"
+
+          jq -e \
+            --arg repository "$REPOSITORY" \
+            '
+              type == "object" and
+              .schemaVersion == 1 and
+              .mode == "delete-audited-obsolete-branches" and
+              .repository == $repository and
+              (.branches | type == "array") and
+              (.branches | length > 0 and length <= 100) and
+              ([.branches[].name] | length == (unique | length)) and
+              all(
+                .branches[];
+                (.name | type == "string" and test("^[A-Za-z0-9._/-]+$")) and
+                (.expectedSha | type == "string" and test("^[0-9a-f]{40}$"))
+              )
+            ' \
+            "$RUNNER_TEMP/branch-cleanup.json" \
+            > /dev/null
+
+          jq -r '.branches | length' "$RUNNER_TEMP/branch-cleanup.json" \
+            | sed 's/^/count=/' >> "$GITHUB_OUTPUT"
+
+      - name: Preflight every branch without mutation
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          protected=' main release-state distribution automation/releases automation/development-packages automation/branch-cleanup '
+          : > "$RUNNER_TEMP/validated-branches.tsv"
+
+          while IFS=$'\t' read -r branch expected_sha; do
+            [[ "$protected" != *" $branch "* ]] || {
+              echo "::error::Protected operational branch requested: $branch"
+              exit 1
+            }
+
+            actual_sha="$(
+              gh api "repos/${REPOSITORY}/git/ref/heads/${branch}" --jq '.object.sha'
+            )"
+            [[ "$actual_sha" == "$expected_sha" ]] || {
+              echo "::error::Branch moved after audit: $branch"
+              exit 1
+            }
+
+            open_prs="$(
+              gh pr list \
+                --repo "$REPOSITORY" \
+                --state open \
+                --head "$branch" \
+                --limit 1 \
+                --json number \
+                --jq 'length'
+            )"
+            [[ "$open_prs" == "0" ]] || {
+              echo "::error::Open pull request protects branch: $branch"
+              exit 1
+            }
+
+            closed_prs="$(
+              gh pr list \
+                --repo "$REPOSITORY" \
+                --state closed \
+                --head "$branch" \
+                --limit 1 \
+                --json number \
+                --jq 'length'
+            )"
+
+            if [[ "$closed_prs" == "0" ]]; then
+              relation="$(
+                gh api \
+                  "repos/${REPOSITORY}/compare/${actual_sha}...main" \
+                  --jq '.status'
+              )"
+              [[ "$relation" == "ahead" || "$relation" == "identical" ]] || {
+                echo "::error::Branch is neither recoverable from a closed PR nor contained in main: $branch"
+                exit 1
+              }
+            fi
+
+            printf '%s\t%s\n' "$branch" "$actual_sha" \
+              >> "$RUNNER_TEMP/validated-branches.tsv"
+          done < <(
+            jq -r '.branches[] | [.name, .expectedSha] | @tsv' \
+              "$RUNNER_TEMP/branch-cleanup.json"
+          )
+
+          validated_count="$(wc -l < "$RUNNER_TEMP/validated-branches.tsv")"
+          requested_count="$(jq -r '.branches | length' "$RUNNER_TEMP/branch-cleanup.json")"
+          [[ "$validated_count" == "$requested_count" ]] || {
+            echo "::error::Validated branch count does not match the command"
+            exit 1
+          }
+
+      - name: Delete only the preflighted refs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          while IFS=$'\t' read -r branch expected_sha; do
+            actual_sha="$(
+              gh api "repos/${REPOSITORY}/git/ref/heads/${branch}" --jq '.object.sha'
+            )"
+            [[ "$actual_sha" == "$expected_sha" ]] || {
+              echo "::error::Branch moved between preflight and deletion: $branch"
+              exit 1
+            }
+
+            gh api \
+              --method DELETE \
+              "repos/${REPOSITORY}/git/refs/heads/${branch}"
+            echo "Deleted $branch"
+          done < "$RUNNER_TEMP/validated-branches.tsv"
+
+      - name: Verify cleanup and remove command branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          COMMAND_SHA: ${{ github.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          while IFS=$'\t' read -r branch _expected_sha; do
+            if gh api "repos/${REPOSITORY}/git/ref/heads/${branch}" \
+              > /dev/null 2>&1; then
+              echo "::error::Deleted branch is still present: $branch"
+              exit 1
+            fi
+          done < "$RUNNER_TEMP/validated-branches.tsv"
+
+          command_branch_sha="$(
+            gh api \
+              "repos/${REPOSITORY}/git/ref/heads/automation/branch-cleanup" \
+              --jq '.object.sha'
+          )"
+          [[ "$command_branch_sha" == "$COMMAND_SHA" ]] || {
+            echo "::error::Command branch moved during cleanup"
+            exit 1
+          }
+
+          gh api \
+            --method DELETE \
+            "repos/${REPOSITORY}/git/refs/heads/automation/branch-cleanup"
+
+          {
+            echo '## Audited branch cleanup completed'
+            echo
+            echo "- Deleted audited obsolete branches: ${{ steps.command.outputs.count }}"
+            echo '- Preserved all release tags'
+            echo '- Preserved main and every operational branch'
+            echo '- Removed the one-shot command branch'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/BRANCH_WRITE_INVENTORY.md
+++ b/docs/BRANCH_WRITE_INVENTORY.md
@@ -1,6 +1,6 @@
 # Protected-branch write inventory
 
-**Reviewed:** 2 August 2026
+**Reviewed:** 3 August 2026
 **Issue:** #41 — TKB-only release-state cutover and strict `main` protection
 
 ## Current conclusion
@@ -85,6 +85,12 @@ Canonical validation, release dry runs, repository audits, dashboard projection,
 
 The exact artifact-only workflows are `validate-userscript.yml`, `release-toolkit-dry-run.yml`, `repository-audit.yml`, `update-release-dashboard.yml`, `reconcile-release-announcement-state.yml` and `publish-update-manifest.yml`.
 
+## Audited branch maintenance
+
+`execute-audited-branch-cleanup.yml` is the only branch-maintenance writer. It accepts an owner-pushed command only on the transient `automation/branch-cleanup` branch and requires an exact audited SHA for every requested ref.
+
+Before any deletion, the workflow verifies the complete command without mutation, rejects `main` and every operational branch, rejects branches with an open pull request, and requires each candidate to be recoverable from a closed pull request or already contained in `main`. It then rechecks every SHA immediately before deletion, verifies every removal, and deletes the transient command branch last. It cannot force-push or mutate source, release-state, distribution or automation authority.
+
 ## Distribution branch rehearsal
 
 The `distribution` branch remains non-live and mirror-only. `.github/workflows/sync-shadow-branches.yml` may synchronize only `distribution` from an exact reviewed `main` SHA, using the temporary `DEVELOPMENT_PR_TOKEN` in an owner-confirmed manual rehearsal.
@@ -103,6 +109,7 @@ The read-only `verify-shadow-branch-parity.yml` still validates both branch role
 | Artifact-only evidence | Six read-only workflows | Workflow artifacts |
 | Review-branch writers | Development-package and rollback workflows | Owner PR branches only |
 | Distribution rehearsal | `sync-shadow-branches.yml` | `distribution` only |
+| Audited branch maintenance | `execute-audited-branch-cleanup.yml` | Proven obsolete non-operational refs only |
 | External backup | `backup_release_to_private_repo.sh` | Private repository `main` |
 
 ## Migration evidence


### PR DESCRIPTION
## Purpose

Add an owner-only, SHA-leased cleanup path for obsolete repository branches so historical development refs can be removed without risking `main`, release state, distribution or automation authority.

## Safety model

- accepts commands only from `automation/branch-cleanup` pushed by the repository owner;
- validates every requested branch and immutable audited head SHA before any mutation;
- rejects `main`, `release-state`, `distribution`, both automation authority branches and the command branch;
- refuses branches with an open pull request;
- requires every candidate to be recoverable from a closed PR or already contained in `main`;
- rechecks every SHA immediately before deletion;
- verifies every removed ref and deletes the transient command branch last;
- uses no force push and cannot change source or production state.

## Governance

Adds the branch-maintenance writer to the Actions security policy, machine-readable branch-write inventory, enforced inventory test and human inventory document.

## Validation

- JSON and workflow YAML parsed successfully
- `git diff --check`
- branch-write inventory test passed
- GitHub Actions security audit passed with zero failures
- automation record hygiene test passed