### PR TITLE
Refresh authenticated performance capture for v10.5.4

### DIFF
--- a/.github/scripts/test_live_performance_capture_bundle.mjs
+++ b/.github/scripts/test_live_performance_capture_bundle.mjs
@@ -6,7 +6,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
-import { buildCaptureBundle, CAPTURE_PROFILE, REQUIRED_SCENARIOS } from "../../tools/build-live-performance-capture.mjs";
+import { buildCaptureBundle, CAPTURE_PROFILE, CAPTURE_TARGETS, REQUIRED_SCENARIOS } from "../../tools/build-live-performance-capture.mjs";
 import { validateReport } from "../../tools/validate-live-performance-report.mjs";
 
 const root = path.resolve(import.meta.dirname, "../..");
@@ -17,22 +17,25 @@ const profiler = fs.readFileSync(profilerPath, "utf8");
 const result = buildCaptureBundle(sourceBefore, profiler);
 
 assert.equal(result.manifest.profile, CAPTURE_PROFILE);
-assert.equal(result.manifest.toolkitVersion, "10.3.1");
-assert.equal(result.manifest.canonicalSourceSha256, "b318a72d2bb20c03db75406ed76ecfcf4500a739e32ce9de91490dc02bd5e829");
-assert.deepEqual(result.manifest.instrumentedFunctions, ["renderOperationalPanels", "updateUI"]);
+assert.equal(result.manifest.toolkitVersion, "10.5.4");
+assert.equal(result.manifest.canonicalSourceSha256, "3b7f344883f9d44980a7a416cba3dfff1d68cfa5571ce9612a9565390fc21a77");
+assert.deepEqual(result.manifest.instrumentedFunctions, [...CAPTURE_TARGETS].sort());
 assert.deepEqual(result.manifest.requiredScenarios, REQUIRED_SCENARIOS.map(([name]) => name));
 assert.equal(result.manifest.stableUpdateUrlsRemoved, true);
 assert.equal(result.manifest.productionSourceModified, false);
 assert.equal(result.manifest.requiresStableToolkitDisabled, true);
-assert.match(result.bundle, /@name\s+MissionChief Toolkit v10\.3\.1 Authenticated Performance Capture/u);
+assert.match(result.bundle, /@name\s+MissionChief Toolkit v10\.5\.4 Authenticated Performance Capture/u);
 assert.match(result.bundle, /@namespace\s+https:\/\/github\.com\/Conroy1988\/missionchief-toolkit-assets\/performance-capture/u);
-assert.match(result.bundle, /@version\s+10\.3\.1-capture\.1/u);
+assert.match(result.bundle, /@version\s+10\.5\.4-capture\.1/u);
 assert.doesNotMatch(result.bundle, /^\/\/\s*@(downloadURL|updateURL)\s+/mu);
 assert.match(result.bundle, /captureSourceSha256/u);
 assert.match(result.bundle, /Finish and export report/u);
 assert.match(result.bundle, /keep the normal Toolkit userscript disabled/u);
 assert.match(result.bundle, /beginRender\?\.\("updateUI"\)/u);
 assert.match(result.bundle, /beginRender\?\.\("renderOperationalPanels"\)/u);
+assert.match(result.bundle, /beginRender\?\.\("renderMajorIncidentFeed"\)/u);
+assert.match(result.bundle, /beginRender\?\.\("positionMajorIncidentFeed"\)/u);
+assert.match(result.bundle, /beginRender\?\.\("ensureUi"\)/u);
 assert.equal(fs.readFileSync(sourcePath, "utf8"), sourceBefore, "canonical source must remain byte-identical");
 
 const temporary = fs.mkdtempSync(path.join(os.tmpdir(), "mcms-live-capture-"));
@@ -52,6 +55,18 @@ const measurements = REQUIRED_SCENARIOS.map(([scenario], index) => ({
   mutationRecords: 2,
   unchangedRatio: 0.75,
   averageDurationMs: 2,
+}));
+const feedMeasurements = REQUIRED_SCENARIOS.map(([scenario], index) => ({
+  scenario,
+  path: "renderMajorIncidentFeed",
+  attempts: 8 + index,
+  changedAttempts: 1,
+  unchangedAttempts: 7 + index,
+  totalDurationMs: 8,
+  maxDurationMs: 2,
+  mutationRecords: 1,
+  unchangedRatio: 0.875,
+  averageDurationMs: 1,
 }));
 const report = {
   schemaVersion: 2,
@@ -78,12 +93,13 @@ const report = {
   currentScenario: "layout-change",
   scenarioTransitions: transitions,
   renderEvents: [],
-  renderMeasurements: measurements,
+  renderMeasurements: [...measurements, ...feedMeasurements],
   limits: {},
 };
 const validation = validateReport(report, result.manifest);
 assert.equal(validation.valid, true, validation.errors.join("\n"));
 assert.equal(validation.updateUiMeasurements.length, REQUIRED_SCENARIOS.length);
+assert.equal(validation.feedMeasurements.length, REQUIRED_SCENARIOS.length);
 
 const active = validateReport({ ...report, active: true }, result.manifest);
 assert.equal(active.valid, false);

--- a/.github/workflows/live-performance-capture-bundle.yml
+++ b/.github/workflows/live-performance-capture-bundle.yml
@@ -14,6 +14,7 @@ on:
       - ".github/scripts/test_live_performance_capture_bundle.mjs"
       - ".github/workflows/live-performance-capture-bundle.yml"
       - "docs/audits/live-performance-capture-v10.3.1.md"
+      - "docs/audits/live-performance-capture-v10.5.4.md"
   workflow_dispatch:
 
 permissions:
@@ -21,7 +22,7 @@ permissions:
 
 jobs:
   build:
-    name: Build exact v10.3.1 capture bundle
+    name: Build exact v10.5.4 capture bundle
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -64,16 +65,16 @@ jobs:
           node tools/build-live-performance-capture.mjs \
             --source src/MissionChief_Map_Command_Toolkit.user.js \
             --profiler tools/mcms-performance-profiler.user.js \
-            --output capture-output/MissionChief_Toolkit_v10.3.1_Authenticated_Performance_Capture.user.js \
+            --output capture-output/MissionChief_Toolkit_v10.5.4_Authenticated_Performance_Capture.user.js \
             --manifest capture-output/capture-manifest.json \
             --instructions capture-output/INSTRUCTIONS.md
           cp tools/validate-live-performance-report.mjs capture-output/validate-live-performance-report.mjs
-          node --check capture-output/MissionChief_Toolkit_v10.3.1_Authenticated_Performance_Capture.user.js
-          test "$(jq -r '.toolkitVersion' capture-output/capture-manifest.json)" = "10.3.1"
-          test "$(jq -r '.canonicalSourceSha256' capture-output/capture-manifest.json)" = "b318a72d2bb20c03db75406ed76ecfcf4500a739e32ce9de91490dc02bd5e829"
+          node --check capture-output/MissionChief_Toolkit_v10.5.4_Authenticated_Performance_Capture.user.js
+          test "$(jq -r '.toolkitVersion' capture-output/capture-manifest.json)" = "10.5.4"
+          test "$(jq -r '.canonicalSourceSha256' capture-output/capture-manifest.json)" = "3b7f344883f9d44980a7a416cba3dfff1d68cfa5571ce9612a9565390fc21a77"
           test "$(jq -r '.stableUpdateUrlsRemoved' capture-output/capture-manifest.json)" = "true"
           test "$(jq -r '.productionSourceModified' capture-output/capture-manifest.json)" = "false"
-          ! grep -Eq '^//[[:space:]]*@(downloadURL|updateURL)[[:space:]]+' capture-output/MissionChief_Toolkit_v10.3.1_Authenticated_Performance_Capture.user.js
+          ! grep -Eq '^//[[:space:]]*@(downloadURL|updateURL)[[:space:]]+' capture-output/MissionChief_Toolkit_v10.5.4_Authenticated_Performance_Capture.user.js
           cmp --silent src/MissionChief_Map_Command_Toolkit.user.js dist/MissionChief_Map_Command_Toolkit.user.js
           cmp --silent src/MissionChief_Map_Command_Toolkit.user.js dist/MissionChief_Map_Command_Toolkit.txt
           sha256sum capture-output/* > capture-output/SHA256SUMS.txt
@@ -81,7 +82,7 @@ jobs:
       - name: Upload authenticated capture bundle
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: missionchief-toolkit-v10.3.1-authenticated-performance-capture
+          name: missionchief-toolkit-v10.5.4-authenticated-performance-capture
           path: capture-output/
           if-no-files-found: error
           retention-days: 90

--- a/docs/audits/live-performance-capture-v10.3.1.md
+++ b/docs/audits/live-performance-capture-v10.3.1.md
@@ -1,6 +1,6 @@
 # Authenticated MissionChief performance capture — Toolkit v10.3.1
 
-This is the remaining browser-only evidence stage for Issues #247, #254 and #255.
+This historical capture has been superseded by `live-performance-capture-v10.5.4.md` and must not be used as the current performance baseline.
 
 ## Capture authority
 

--- a/docs/audits/live-performance-capture-v10.5.4.md
+++ b/docs/audits/live-performance-capture-v10.5.4.md
@@ -1,0 +1,43 @@
+# Authenticated MissionChief performance capture — Toolkit v10.5.4
+
+This measurement-only capture refresh is the evidence gate for Issues #247, #255 and #687. It does not change the production userscript, distribution assets, version or release channel.
+
+## Capture authority
+
+- Toolkit version: `10.5.4`
+- Canonical production merge: `06396e63b3f5473cdde73c68791f7cfaa0afba16`
+- Canonical source SHA-256: `3b7f344883f9d44980a7a416cba3dfff1d68cfa5571ce9612a9565390fc21a77`
+- Capture profile: `issue247-v1054-feed-performance`
+- Profiler: development-only, privacy-bounded and excluded from stable update channels
+- Production source, distribution and release state: unchanged
+
+## Instrumented paths
+
+The disposable bundle records aggregate timings and mutation counts around:
+
+- `updateUI()`;
+- `renderOperationalPanels()`;
+- `ensureUi()`;
+- `renderMajorIncidentFeed()`;
+- `positionMajorIncidentFeed()`.
+
+The Feed-specific paths expose the v10.5.4 healthy-state baseline before Issue #687 can change runtime scheduling.
+
+## Required scenarios
+
+1. **idle-map** — leave the map idle for at least 20 seconds;
+2. **settings-open-close** — open and close Settings five times without changing settings;
+3. **mission-open-close** — open and close at least three active mission windows;
+4. **unit-selection** — select and deselect several units without dispatching;
+5. **map-pan-zoom** — pan and zoom repeatedly;
+6. **layout-change** — resize, rotate or change Tablet layout, then restore it.
+
+The validator requires ordered coverage for all six scenarios from both `updateUI()` and `renderMajorIncidentFeed()`. Feed positioning and UI-integrity measurements remain reported when they occur, but are not fabricated when a scenario legitimately produces no call.
+
+## Privacy boundary
+
+The report contains aggregate timing, mutation, resource-host and runtime-ownership counts. It does not contain mission titles, addresses, coordinates, vehicle or personnel names, alliance messages, cookies, local-storage values, authorization material or Discord webhook contents.
+
+## Release boundary
+
+A valid v10.5.4 report is baseline evidence only. Issue #687 must produce an equivalent candidate report, deterministic regression fixtures, identical feature behaviour and a clean rollback boundary before production landing. The v10.3.1 capture remains historical and must not be used as the current baseline.

--- a/tools/build-live-performance-capture.mjs
+++ b/tools/build-live-performance-capture.mjs
@@ -7,7 +7,14 @@ import path from "node:path";
 import process from "node:process";
 import { instrumentSource } from "./build-render-probe-userscript.mjs";
 
-export const CAPTURE_PROFILE = "issue247-v1031-live-performance";
+export const CAPTURE_PROFILE = "issue247-v1054-feed-performance";
+export const CAPTURE_TARGETS = Object.freeze([
+  "ensureUi",
+  "positionMajorIncidentFeed",
+  "renderMajorIncidentFeed",
+  "renderOperationalPanels",
+  "updateUI",
+]);
 export const REQUIRED_SCENARIOS = Object.freeze([
   ["idle-map", "Leave the map idle for at least 20 seconds."],
   ["settings-open-close", "Open and close Toolkit Settings five times, changing no settings."],
@@ -135,7 +142,7 @@ export function buildCaptureBundle(toolkitSource, profilerSource) {
   const profilerVersion = metadataValue(profilerSource, "version");
   if (!profilerVersion) throw new Error("Profiler version missing");
 
-  const instrumented = instrumentSource(toolkitSource);
+  const instrumented = instrumentSource(toolkitSource, CAPTURE_TARGETS);
   let bundle = instrumented.generated;
   bundle = replaceMetadata(bundle, "name", `MissionChief Toolkit v${toolkitVersion} Authenticated Performance Capture`);
   bundle = replaceMetadata(bundle, "namespace", "https://github.com/Conroy1988/missionchief-toolkit-assets/performance-capture");
@@ -166,6 +173,9 @@ export function buildCaptureBundle(toolkitSource, profilerSource) {
   }
   if (!bundle.includes("globalThis.__MCMS_PROFILER__?.beginRender?.(\"updateUI\")")) throw new Error("updateUI probe missing");
   if (!bundle.includes("globalThis.__MCMS_PROFILER__?.beginRender?.(\"renderOperationalPanels\")")) throw new Error("operational render probe missing");
+  if (!bundle.includes("globalThis.__MCMS_PROFILER__?.beginRender?.(\"renderMajorIncidentFeed\")")) throw new Error("Major Incident Feed render probe missing");
+  if (!bundle.includes("globalThis.__MCMS_PROFILER__?.beginRender?.(\"positionMajorIncidentFeed\")")) throw new Error("Major Incident Feed layout probe missing");
+  if (!bundle.includes("globalThis.__MCMS_PROFILER__?.beginRender?.(\"ensureUi\")")) throw new Error("UI integrity probe missing");
   if (!bundle.includes(canonicalSourceSha256)) throw new Error("Canonical source authority missing from capture bundle");
 
   return {

--- a/tools/validate-live-performance-report.mjs
+++ b/tools/validate-live-performance-report.mjs
@@ -57,10 +57,14 @@ function renderCoverage(report) {
   const measurements = Array.isArray(report.renderMeasurements) ? report.renderMeasurements : [];
   const updateRows = measurements.filter(item => item?.path === "updateUI" && Number(item?.attempts) > 0);
   if (!updateRows.length) throw new Error("No updateUI render measurements were captured");
-  const covered = new Set(updateRows.map(item => String(item.scenario || "")));
-  const missing = REQUIRED_SCENARIOS.filter(name => !covered.has(name));
-  if (missing.length) throw new Error(`No updateUI render evidence for: ${missing.join(", ")}`);
-  return { measurements, updateRows };
+  const feedRows = measurements.filter(item => item?.path === "renderMajorIncidentFeed" && Number(item?.attempts) > 0);
+  if (!feedRows.length) throw new Error("No Major Incident Feed render measurements were captured");
+  for (const [label, rows] of [["updateUI", updateRows], ["Major Incident Feed", feedRows]]) {
+    const covered = new Set(rows.map(item => String(item.scenario || "")));
+    const missing = REQUIRED_SCENARIOS.filter(name => !covered.has(name));
+    if (missing.length) throw new Error(`No ${label} render evidence for: ${missing.join(", ")}`);
+  }
+  return { measurements, updateRows, feedRows };
 }
 
 export function validateReport(report, manifest) {
@@ -87,7 +91,7 @@ export function validateReport(report, manifest) {
   assert(Array.isArray(report.resources), "resources must be an array");
 
   let scenarios = [];
-  let render = { measurements: [], updateRows: [] };
+  let render = { measurements: [], updateRows: [], feedRows: [] };
   try { scenarios = orderedScenarioCoverage(report); } catch (error) { errors.push(error.message); }
   try { render = renderCoverage(report); } catch (error) { errors.push(error.message); }
 
@@ -103,6 +107,16 @@ export function validateReport(report, manifest) {
     durationMs: Number(report.durationMs) || 0,
     scenarioTransitions: scenarios,
     updateUiMeasurements: render.updateRows.map(item => ({
+      scenario: item.scenario,
+      attempts: item.attempts,
+      unchangedAttempts: item.unchangedAttempts,
+      changedAttempts: item.changedAttempts,
+      unchangedRatio: item.unchangedRatio,
+      averageDurationMs: item.averageDurationMs,
+      maxDurationMs: item.maxDurationMs,
+      mutationRecords: item.mutationRecords,
+    })),
+    feedMeasurements: render.feedRows.map(item => ({
       scenario: item.scenario,
       attempts: item.attempts,
       unchangedAttempts: item.unchangedAttempts,
@@ -139,6 +153,12 @@ function renderMarkdown(summary) {
     "| Scenario | Attempts | Unchanged | Changed | Unchanged ratio | Average | Maximum | Mutation records |",
     "|---|---:|---:|---:|---:|---:|---:|---:|",
     ...summary.updateUiMeasurements.map(row => `| ${row.scenario} | ${row.attempts} | ${row.unchangedAttempts} | ${row.changedAttempts} | ${Number(row.unchangedRatio || 0).toFixed(4)} | ${Number(row.averageDurationMs || 0).toFixed(3)} ms | ${Number(row.maxDurationMs || 0).toFixed(3)} ms | ${row.mutationRecords} |`),
+    "",
+    "## Major Incident Feed scenario evidence",
+    "",
+    "| Scenario | Attempts | Unchanged | Changed | Unchanged ratio | Average | Maximum | Mutation records |",
+    "|---|---:|---:|---:|---:|---:|---:|---:|",
+    ...summary.feedMeasurements.map(row => `| ${row.scenario} | ${row.attempts} | ${row.unchangedAttempts} | ${row.changedAttempts} | ${Number(row.unchangedRatio || 0).toFixed(4)} | ${Number(row.averageDurationMs || 0).toFixed(3)} ms | ${Number(row.maxDurationMs || 0).toFixed(3)} ms | ${row.mutationRecords} |`),
     "",
     "## Validation errors",
     "",


### PR DESCRIPTION
## Summary

Refresh the authenticated, disposable performance-capture bundle from Toolkit v10.3.1 to the exact v10.5.4 production baseline and add Major Incident Feed/UI-integrity probes for the Issue #687 evidence gate.

## Scope

- pins the capture authority to v10.5.4 commit `06396e63b3f5473cdde73c68791f7cfaa0afba16`
- verifies canonical source SHA-256 `3b7f344883f9d44980a7a416cba3dfff1d68cfa5571ce9612a9565390fc21a77`
- instruments `ensureUi`, `renderMajorIncidentFeed` and `positionMajorIncidentFeed` in addition to the retained UI probes
- requires all six established scenarios for both `updateUI` and `renderMajorIncidentFeed`
- documents the privacy boundary and the before/after release gate

## Production boundary

This is measurement-only. It does **not** change the production userscript, distribution copies, Toolkit version, release state or supported TKB channel. The production source and both distribution copies remain byte-identical at the v10.5.4 SHA above.

## Validation

- focused capture syntax and contract checks: passed
- authenticated package-build reproduction: passed
- complete repository preflight (`run_userscript_preflight.sh --all`): passed
- remote tree matches the locally reviewed tree exactly

Supports #247, #255 and #687.