### PR TITLE
Refresh Toolkit GitHub Action pins from current main

### DIFF
--- a/.github/workflows/actions-security-audit.yml
+++ b/.github/workflows/actions-security-audit.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/apply-development-package.yml
+++ b/.github/workflows/apply-development-package.yml
@@ -242,7 +242,7 @@ jobs:
 
       - name: Check out exact authorized commit
         if: steps.state.outputs.skip != 'true'
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ needs.command.outputs.expected }}
           fetch-depth: 0

--- a/.github/workflows/asset-health-monitor.yml
+++ b/.github/workflows/asset-health-monitor.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/auto-release-after-validation.yml
+++ b/.github/workflows/auto-release-after-validation.yml
@@ -38,7 +38,7 @@ jobs:
       validation_completed_at: ${{ steps.candidate.outputs.validation_completed_at }}
     steps:
       - name: Check out exact merged main commit
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: 0
@@ -292,7 +292,7 @@ jobs:
       version: ${{ steps.candidate.outputs.version }}
     steps:
       - name: Check out exact fallback validation commit
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0

--- a/.github/workflows/branch-cleanup-audit.yml
+++ b/.github/workflows/branch-cleanup-audit.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Check out latest main
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: main
           fetch-depth: 0

--- a/.github/workflows/code-integrity-audit.yml
+++ b/.github/workflows/code-integrity-audit.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/deep-performance-audit.yml
+++ b/.github/workflows/deep-performance-audit.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/discord-release-preview.yml
+++ b/.github/workflows/discord-release-preview.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Check out trusted main
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: main
           fetch-depth: 1
@@ -186,7 +186,7 @@ jobs:
 
     steps:
       - name: Check out trusted main
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: main
           fetch-depth: 1

--- a/.github/workflows/documentation-drift-check.yml
+++ b/.github/workflows/documentation-drift-check.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/full-userscript-audit.yml
+++ b/.github/workflows/full-userscript-audit.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
@@ -122,7 +122,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.sha }}
           persist-credentials: false
@@ -143,7 +143,7 @@ jobs:
 
     steps:
       - name: Check out current production source
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: main
           fetch-depth: 1

--- a/.github/workflows/live-performance-capture-bundle.yml
+++ b/.github/workflows/live-performance-capture-bundle.yml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out exact repository state
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/owner-release-command.yml
+++ b/.github/workflows/owner-release-command.yml
@@ -106,7 +106,7 @@ jobs:
           echo "expected_main=$EXPECTED_MAIN" >> "$GITHUB_OUTPUT"
 
       - name: Check out exact authorized main candidate
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ steps.command.outputs.expected_main }}
           fetch-depth: 0

--- a/.github/workflows/pages-production-monitor.yml
+++ b/.github/workflows/pages-production-monitor.yml
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Check out monitored source
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || 'main' }}
           persist-credentials: false

--- a/.github/workflows/performance-evidence-audit.yml
+++ b/.github/workflows/performance-evidence-audit.yml
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/performance-regression-check.yml
+++ b/.github/workflows/performance-regression-check.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/prepare-release-rollback.yml
+++ b/.github/workflows/prepare-release-rollback.yml
@@ -43,7 +43,7 @@ jobs:
           }
 
       - name: Check out latest main with owner identity
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: main
           fetch-depth: 0

--- a/.github/workflows/publish-update-manifest.yml
+++ b/.github/workflows/publish-update-manifest.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Check out exact repository state
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
           show-progress: false

--- a/.github/workflows/reconcile-release-announcement-state.yml
+++ b/.github/workflows/reconcile-release-announcement-state.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Check out exact verified state
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event_name == 'workflow_run' && 'main' || github.sha }}
           fetch-depth: 1

--- a/.github/workflows/recover-development-package.yml
+++ b/.github/workflows/recover-development-package.yml
@@ -111,7 +111,7 @@ jobs:
           [[ -n "$OWNER_TOKEN" ]] || { echo "::error::DEVELOPMENT_PR_TOKEN is required."; exit 1; }
 
       - name: Check out exact authorized package head
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ steps.resolve.outputs.expected_head }}
           fetch-depth: 0

--- a/.github/workflows/release-planning.yml
+++ b/.github/workflows/release-planning.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Check out planning source
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || 'main' }}
           fetch-depth: 0

--- a/.github/workflows/release-readiness-check.yml
+++ b/.github/workflows/release-readiness-check.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Check out latest main
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: main
           fetch-depth: 0

--- a/.github/workflows/release-recovery-validation.yml
+++ b/.github/workflows/release-recovery-validation.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/release-recovery.yml
+++ b/.github/workflows/release-recovery.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Check out latest main authority
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: main
           fetch-depth: 0

--- a/.github/workflows/release-toolkit-dry-run.yml
+++ b/.github/workflows/release-toolkit-dry-run.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Check out latest main without write credentials
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: main
           fetch-depth: 0

--- a/.github/workflows/release-toolkit.yml
+++ b/.github/workflows/release-toolkit.yml
@@ -113,7 +113,7 @@ jobs:
 
     steps:
       - name: Check out latest main
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ inputs.validated_sha != '' && inputs.validated_sha || 'main' }}
           fetch-depth: 0

--- a/.github/workflows/repository-audit.yml
+++ b/.github/workflows/repository-audit.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Check out latest main without write credentials
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: main
           fetch-depth: 0

--- a/.github/workflows/sync-repository-labels.yml
+++ b/.github/workflows/sync-repository-labels.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Validate label catalogue
         shell: bash

--- a/.github/workflows/sync-shadow-branches.yml
+++ b/.github/workflows/sync-shadow-branches.yml
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Check out exact main authority
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: main
           fetch-depth: 0

--- a/.github/workflows/unchanged-render-evidence.yml
+++ b/.github/workflows/unchanged-render-evidence.yml
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 12
     steps:
       - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/update-release-dashboard.yml
+++ b/.github/workflows/update-release-dashboard.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Check out exact repository state
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
           persist-credentials: false

--- a/.github/workflows/userscript-structural-audit.yml
+++ b/.github/workflows/userscript-structural-audit.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Run auditor self-tests
         run: python3 .github/scripts/audit_userscript_structure.py --self-test

--- a/.github/workflows/v7-incident-command-wire.yml
+++ b/.github/workflows/v7-incident-command-wire.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
       - run: python3 .github/scripts/test_issue517_incident_command_wire.py

--- a/.github/workflows/v7-native-toolkit-boundary.yml
+++ b/.github/workflows/v7-native-toolkit-boundary.yml
@@ -7,7 +7,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - run: python3 .github/scripts/test_v7_retirement.py

--- a/.github/workflows/validate-development-package-workflow.yml
+++ b/.github/workflows/validate-development-package-workflow.yml
@@ -55,7 +55,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           show-progress: false
 
@@ -80,7 +80,7 @@ jobs:
 
       - name: Upload policy diagnostics
         if: steps.policy.outcome != 'success'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: workflow-policy-diagnostic
           path: ${{ runner.temp }}/workflow-policy.log

--- a/.github/workflows/validate-issue-intake.yml
+++ b/.github/workflows/validate-issue-intake.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Validate managed label catalogue
         shell: bash

--- a/.github/workflows/validate-userscript.yml
+++ b/.github/workflows/validate-userscript.yml
@@ -34,7 +34,7 @@ jobs:
       exhaustivePerformance: ${{ steps.paths.outputs.exhaustivePerformance }}
     steps:
       - name: Check out exact repository state
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -81,7 +81,7 @@ jobs:
     timeout-minutes: 12
     steps:
       - name: Check out exact repository state
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -126,7 +126,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Check out exact repository state
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -350,7 +350,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out exact repository state
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -448,7 +448,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Check out exact repository state
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/verify-shadow-branch-parity.yml
+++ b/.github/workflows/verify-shadow-branch-parity.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Check out exact repository state
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
           persist-credentials: false


### PR DESCRIPTION
Supersedes #549.

Reapplies the verified Dependabot action refresh on top of the current v10.6.4 `main`, allowing the protected hotfix gate to register against an owner branch.

- `actions/checkout` → v7.0.1 immutable commit
- `actions/upload-artifact` → v7.0.1 immutable commit
- 38 workflow files; no Toolkit source, release, asset or documentation change
- no protection bypass