### PR TITLE
fix(asset-health): bypass stale TKB intermediary responses

### DIFF
--- a/.github/scripts/check_asset_health.py
+++ b/.github/scripts/check_asset_health.py
@@ -361,6 +361,16 @@ def content_type_base(value: str | None) -> str:
     return (value or "").split(";", 1)[0].strip().lower()
 
 
+def cache_bust(url: str) -> str:
+    """Bypass stale intermediary copies of TKB's dynamic first-party routes."""
+    parsed = urllib.parse.urlparse(url)
+    if parsed.hostname != "tkb-gaming.scot":
+        return url
+    query = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
+    query.append(("asset_health", str(time.time_ns())))
+    return urllib.parse.urlunparse(parsed._replace(query=urllib.parse.urlencode(query)))
+
+
 def request_once(url: str, method: str, timeout: float, user_agent: str, range_prefix: int | None = None) -> tuple[int, dict[str, str], bytes, str]:
     headers = {
         "User-Agent": user_agent,
@@ -370,7 +380,7 @@ def request_once(url: str, method: str, timeout: float, user_agent: str, range_p
     }
     if range_prefix is not None:
         headers["Range"] = f"bytes=0-{max(0, range_prefix - 1)}"
-    request = urllib.request.Request(url, headers=headers, method=method)
+    request = urllib.request.Request(cache_bust(url), headers=headers, method=method)
     with urllib.request.urlopen(request, timeout=timeout) as response:
         status = int(getattr(response, "status", response.getcode()))
         response_headers = {key.lower(): value for key, value in response.headers.items()}

--- a/.github/scripts/test_asset_health.py
+++ b/.github/scripts/test_asset_health.py
@@ -133,6 +133,18 @@ def assert_has(report: dict, code: str, severity: str = "failure") -> None:
     assert any(item["code"] == code for item in items), (code, report)
 
 
+def test_first_party_live_requests_are_cache_busted() -> None:
+    original = "https://tkb-gaming.scot/mission-chief-scripts/map-command-toolkit/install/?channel=stable"
+    busted = asset_health.cache_bust(original)
+    parsed = asset_health.urllib.parse.urlparse(busted)
+    query = dict(asset_health.urllib.parse.parse_qsl(parsed.query, keep_blank_values=True))
+
+    assert parsed.path == "/mission-chief-scripts/map-command-toolkit/install/"
+    assert query["channel"] == "stable"
+    assert query["asset_health"].isdigit()
+    assert asset_health.cache_bust("https://example.com/script.user.js") == "https://example.com/script.user.js"
+
+
 def test_live_success_and_optional_warning() -> None:
     userscript = b"// ==UserScript==\n// @version 1.2.3\n// ==/UserScript==\nconsole.log('ok');\n"
     digest = hashlib.sha256(userscript).hexdigest()
@@ -345,6 +357,7 @@ def test_asset_health_workflow_uses_release_state() -> None:
 
 def main() -> None:
     tests = [
+        test_first_party_live_requests_are_cache_busted,
         test_live_success_and_optional_warning,
         test_wrong_release_hash_fails,
         test_missing_stable_raw_path_fails_static,


### PR DESCRIPTION
## Summary

Harden the live Asset Health monitor against stale intermediary copies of TKB's dynamic first-party routes.

- appends a unique `asset_health` query value to live `tkb-gaming.scot` requests;
- preserves any existing query parameters and the canonical endpoint recorded in reports;
- leaves non-TKB endpoints unchanged;
- adds regression coverage for the cache-busting contract.

## Incident context

The production installer repair in Conroy1988/TKB-Website#302 is deployed and byte-exact. The post-deploy installer audit and repeated direct probes return 2,362,461 bytes with SHA-256 `09f6806a2029ec5abe568492923c28f7027f0670135b55fd8da91c136623486a` for current and legacy routes under both bot and Asset Health user agents.

GitHub Actions continued replaying the poisoned pre-repair body for the bare legacy URL despite `Cache-Control: no-cache`. The distribution parity checker already avoids this class of false result by cache-busting TKB routes. This change gives the main Asset Health fetcher the same current-production guarantee.

Related incident: #626

## Validation

- [x] `python3 .github/scripts/test_asset_health.py` — 13 tests pass
- [x] `python3 .github/scripts/check_distribution_body_parity.py --self-test`
- [x] static Asset Health — 61 endpoints, 52 media files, 0 failures, 0 warnings
- [x] `python3 -m py_compile .github/scripts/check_asset_health.py .github/scripts/test_asset_health.py`
- [x] `git diff --check`
