### PR TITLE
fix(asset-health): rotate poisoned monitor cache identity

### DIFF
--- a/.github/asset-health-policy.json
+++ b/.github/asset-health-policy.json
@@ -160,12 +160,12 @@
     "retryBackoffSeconds": 2,
     "signatureBytes": 65536,
     "timeoutSeconds": 30,
-    "userAgent": "MissionChief-Toolkit-Asset-Health/1.0 (+https://github.com/Conroy1988/missionchief-toolkit-assets)"
+    "userAgent": "MissionChief-Toolkit-Asset-Health/2.0 (+https://github.com/Conroy1988/missionchief-toolkit-assets)"
   },
   "repository": {
     "stableRef": "main"
   },
-  "revision": "2026-08-01-tkb-first-party-distribution",
+  "revision": "2026-08-16-asset-health-v2-cache-cutover",
   "scanFiles": [
     "src/MissionChief_Map_Command_Toolkit.user.js",
     ".github/release-settings.json",


### PR DESCRIPTION
## Summary

Rotate Asset Health's explicit HTTP identity from v1 to v2 after an intermediary retained the corrupted pre-repair response under the exact v1 user-agent cache key.

- changes only the monitor identity and policy revision;
- retains the contact URL and all endpoint, hash, retry, and reporting policy;
- builds on #710, which already cache-busts TKB dynamic routes.

## Incident evidence

- TKB installer repair: Conroy1988/TKB-Website#302
- TKB deployment: run `31977944759` — passed
- Four-route post-deploy installer audit: run `31978250489` — passed
- Exact current/legacy body: 2,362,461 bytes, SHA-256 `09f6806a2029ec5abe568492923c28f7027f0670135b55fd8da91c136623486a`
- Asset Health v1 runs `31978416195`, `31978569292`, and `31979284204` replayed the same 2,364,776-byte poisoned copy despite cache-busting, proving the intermediary key is tied to the exact v1 identity.

Related incident: #626

## Validation

- [x] JSON syntax validation
- [x] Asset Health self-tests — 13 passed
- [x] distribution-body parity self-test
- [x] static Asset Health — 61 endpoints, 52 media files, 0 failures, 0 warnings
- [x] `git diff --check`
