### PR TITLE
fix(asset-health): use the production-tested installer identity

### DIFF
--- a/.github/asset-health-policy.json
+++ b/.github/asset-health-policy.json
@@ -160,12 +160,12 @@
     "retryBackoffSeconds": 2,
     "signatureBytes": 65536,
     "timeoutSeconds": 30,
-    "userAgent": "MissionChief-Toolkit-Asset-Health/2.0 (+https://github.com/Conroy1988/missionchief-toolkit-assets)"
+    "userAgent": "MissionChief-Toolkit-Asset-Health/1.0"
   },
   "repository": {
     "stableRef": "main"
   },
-  "revision": "2026-08-16-asset-health-v2-cache-cutover",
+  "revision": "2026-08-16-tested-installer-audit-identity",
   "scanFiles": [
     "src/MissionChief_Map_Command_Toolkit.user.js",
     ".github/release-settings.json",


### PR DESCRIPTION
## Summary

Align the Asset Health monitor with the exact user-agent identity exercised by TKB's post-deploy installer audit.

- uses `MissionChief-Toolkit-Asset-Health/1.0`, the identity proven against both current and legacy production routes;
- keeps #710's per-request cache-busting and every existing health policy control;
- records the identity cutover in the policy revision.

## Evidence

- TKB deployment run `31977944759` passed.
- TKB installer audit run `31978250489` passed current and legacy routes using `MissionChief-Toolkit-Asset-Health/1.0`.
- Both routes returned 2,362,461 bytes with SHA-256 `09f6806a2029ec5abe568492923c28f7027f0670135b55fd8da91c136623486a`.
- Contact-form identities in Asset Health runs `31979284204` and `31979574530` replayed the same poisoned 2,364,776-byte intermediary response even after URL cache-busting and a version rotation.

Related incident: #626

## Validation

- [x] JSON syntax validation
- [x] Asset Health self-tests — 13 passed
- [x] distribution-body parity self-test
- [x] static Asset Health — 61 endpoints, 52 media files, 0 failures, 0 warnings
- [x] `git diff --check`
