### PR TITLE
fix: align asset monitor with production cache nonce

### DIFF
--- a/.github/scripts/check_asset_health.py
+++ b/.github/scripts/check_asset_health.py
@@ -362,12 +362,12 @@ def content_type_base(value: str | None) -> str:
 
 
 def cache_bust(url: str) -> str:
-    """Bypass stale intermediary copies of TKB's dynamic first-party routes."""
+    """Use the production-proven audit nonce to bypass cached TKB routes."""
     parsed = urllib.parse.urlparse(url)
     if parsed.hostname != "tkb-gaming.scot":
         return url
     query = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
-    query.append(("asset_health", str(time.time_ns())))
+    query.append(("audit", str(time.time_ns())))
     return urllib.parse.urlunparse(parsed._replace(query=urllib.parse.urlencode(query)))
 
 

--- a/.github/scripts/check_distribution_body_parity.py
+++ b/.github/scripts/check_distribution_body_parity.py
@@ -62,7 +62,7 @@ def cache_bust(url: str) -> str:
     if parsed.hostname not in {"tkb-gaming.scot", "raw.githubusercontent.com"}:
         return url
     query = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
-    query.append(("asset_health", str(time.time_ns())))
+    query.append(("audit", str(time.time_ns())))
     return urllib.parse.urlunparse(parsed._replace(query=urllib.parse.urlencode(query)))
 
 
@@ -244,6 +244,14 @@ class FixtureHandler(BaseHTTPRequestHandler):
 
 
 def self_test() -> int:
+    busted = cache_bust(
+        "https://tkb-gaming.scot/mission-chief-scripts/map-command-toolkit/install/?channel=stable"
+    )
+    busted_query = dict(urllib.parse.parse_qsl(urllib.parse.urlparse(busted).query, keep_blank_values=True))
+    assert busted_query["channel"] == "stable"
+    assert busted_query["audit"].isdigit()
+    assert "asset_health" not in busted_query
+
     base = b"// ==UserScript==\n// @version 1.2.3\n// ==/UserScript==\nconsole.log('same');\n"
     transformed = b"// ==UserScript==\n// @version 1.2.3\n// served-by first-party gateway\n// ==/UserScript==\nconsole.log('same');\n"
     changed = b"// ==UserScript==\n// @version 1.2.3\n// ==/UserScript==\nconsole.log('changed');\n"

--- a/.github/scripts/test_asset_health.py
+++ b/.github/scripts/test_asset_health.py
@@ -141,7 +141,8 @@ def test_first_party_live_requests_are_cache_busted() -> None:
 
     assert parsed.path == "/mission-chief-scripts/map-command-toolkit/install/"
     assert query["channel"] == "stable"
-    assert query["asset_health"].isdigit()
+    assert query["audit"].isdigit()
+    assert "asset_health" not in query
     assert asset_health.cache_bust("https://example.com/script.user.js") == "https://example.com/script.user.js"
 
 


### PR DESCRIPTION
## Summary

- use the production-proven `audit` nonce for first-party TKB cache bypasses
- align executable-body parity requests with the same nonce
- add regression coverage that preserves existing query parameters and rejects the ineffective `asset_health` cache key

## Evidence

After the telemetry-free installer endpoint was deployed successfully, Asset Health run `31981821642` still received the original stale response (`f9097d41…`, 2,364,776 bytes). The post-deployment TKB audit run `31981793131` used the same `MissionChief-Toolkit-Asset-Health/1.0` identity with an `audit` nonce and received exact release bytes.

This isolates the remaining fault to intermediary cache-key handling: `asset_health` is ignored, while `audit` is proven to bypass the stale object.

## Validation

- [x] 13 Asset Health self-tests
- [x] distribution-body parity self-test
- [x] static Asset Health: 61 endpoints, 52 local media files, 0 failures, 0 warnings
- [x] `git diff --check`
- [ ] required pull-request checks
- [ ] post-merge live Asset Health Monitor

Related to #626.