### PR TITLE
fix: use filename installer for public integrity checks

### DIFF
--- a/.github/asset-health-policy.json
+++ b/.github/asset-health-policy.json
@@ -25,7 +25,7 @@
       "minBytes": 1000000,
       "required": true,
       "urlSource": {
-        "jsonPointer": "/distribution/installUrl",
+        "jsonPointer": "/distribution/integrityInstallUrl",
         "path": ".github/release-settings.json"
       }
     },

--- a/.github/documentation-contract.json
+++ b/.github/documentation-contract.json
@@ -95,7 +95,7 @@
   ],
   "installUrls": [
     "https://tkb-gaming.scot/mission-chief-scripts/map-command-toolkit/",
-    "https://tkb-gaming.scot/mission-chief-scripts/map-command-toolkit/install/"
+    "https://tkb-gaming.scot/mission-chief-scripts/map-command-toolkit/install/MissionChief_Map_Command_Toolkit.user.js"
   ],
   "requiredFeatureNames": [
     "Mission Age map timers",

--- a/.github/release-settings.json
+++ b/.github/release-settings.json
@@ -5,6 +5,7 @@
     "catalogueUrl": "https://tkb-gaming.scot/mission-chief-scripts/",
     "productUrl": "https://tkb-gaming.scot/mission-chief-scripts/map-command-toolkit/",
     "installUrl": "https://tkb-gaming.scot/mission-chief-scripts/map-command-toolkit/install/",
+    "integrityInstallUrl": "https://tkb-gaming.scot/mission-chief-scripts/map-command-toolkit/install/MissionChief_Map_Command_Toolkit.user.js",
     "updateUrl": "https://tkb-gaming.scot/mission-chief-scripts/map-command-toolkit/update/",
     "metadataUrl": "https://tkb-gaming.scot/mission-chief-scripts/map-command-toolkit/metadata/",
     "statisticsUrl": "https://conroy1988.github.io/missionchief-toolkit-assets/data/download-stats.json"

--- a/.github/scripts/check_distribution_body_parity.py
+++ b/.github/scripts/check_distribution_body_parity.py
@@ -245,7 +245,8 @@ class FixtureHandler(BaseHTTPRequestHandler):
 
 def self_test() -> int:
     busted = cache_bust(
-        "https://tkb-gaming.scot/mission-chief-scripts/map-command-toolkit/install/?channel=stable"
+        "https://tkb-gaming.scot/mission-chief-scripts/map-command-toolkit/install/"
+        "MissionChief_Map_Command_Toolkit.user.js?channel=stable"
     )
     busted_query = dict(urllib.parse.parse_qsl(urllib.parse.urlparse(busted).query, keep_blank_values=True))
     assert busted_query["channel"] == "stable"

--- a/.github/scripts/test_asset_health.py
+++ b/.github/scripts/test_asset_health.py
@@ -134,16 +134,37 @@ def assert_has(report: dict, code: str, severity: str = "failure") -> None:
 
 
 def test_first_party_live_requests_are_cache_busted() -> None:
-    original = "https://tkb-gaming.scot/mission-chief-scripts/map-command-toolkit/install/?channel=stable"
+    original = (
+        "https://tkb-gaming.scot/mission-chief-scripts/map-command-toolkit/install/"
+        "MissionChief_Map_Command_Toolkit.user.js?channel=stable"
+    )
     busted = asset_health.cache_bust(original)
     parsed = asset_health.urllib.parse.urlparse(busted)
     query = dict(asset_health.urllib.parse.parse_qsl(parsed.query, keep_blank_values=True))
 
-    assert parsed.path == "/mission-chief-scripts/map-command-toolkit/install/"
+    assert parsed.path.endswith("/install/MissionChief_Map_Command_Toolkit.user.js")
     assert query["channel"] == "stable"
     assert query["audit"].isdigit()
     assert "asset_health" not in query
     assert asset_health.cache_bust("https://example.com/script.user.js") == "https://example.com/script.user.js"
+
+
+def test_integrity_installer_uses_filename_route() -> None:
+    settings = json.loads(
+        (REPOSITORY_ROOT / ".github/release-settings.json").read_text(encoding="utf-8")
+    )
+    policy = json.loads(
+        (REPOSITORY_ROOT / ".github/asset-health-policy.json").read_text(encoding="utf-8")
+    )
+    integrity_url = settings["distribution"]["integrityInstallUrl"]
+    parsed = asset_health.urllib.parse.urlparse(integrity_url)
+    install_endpoint = next(
+        item for item in policy["explicitEndpoints"] if item["id"] == "tkb-install-userscript"
+    )
+
+    assert parsed.hostname == "tkb-gaming.scot"
+    assert parsed.path.endswith("/install/MissionChief_Map_Command_Toolkit.user.js")
+    assert install_endpoint["urlSource"]["jsonPointer"] == "/distribution/integrityInstallUrl"
 
 
 def test_live_success_and_optional_warning() -> None:
@@ -359,6 +380,7 @@ def test_asset_health_workflow_uses_release_state() -> None:
 def main() -> None:
     tests = [
         test_first_party_live_requests_are_cache_busted,
+        test_integrity_installer_uses_filename_route,
         test_live_success_and_optional_warning,
         test_wrong_release_hash_fails,
         test_missing_stable_raw_path_fails_static,

--- a/.github/scripts/test_release_authority_pipeline.py
+++ b/.github/scripts/test_release_authority_pipeline.py
@@ -45,6 +45,7 @@ def main() -> int:
     expected_urls = {
         "productUrl": "https://tkb-gaming.scot/mission-chief-scripts/map-command-toolkit/",
         "installUrl": "https://tkb-gaming.scot/mission-chief-scripts/map-command-toolkit/install/",
+        "integrityInstallUrl": "https://tkb-gaming.scot/mission-chief-scripts/map-command-toolkit/install/MissionChief_Map_Command_Toolkit.user.js",
         "updateUrl": "https://tkb-gaming.scot/mission-chief-scripts/map-command-toolkit/update/",
         "metadataUrl": "https://tkb-gaming.scot/mission-chief-scripts/map-command-toolkit/metadata/",
     }

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@
 </p>
 
 > [!IMPORTANT]
-> **TKB Scripts is the only supported installation and update channel.** Use the [Toolkit product page](https://tkb-gaming.scot/mission-chief-scripts/map-command-toolkit/) or [launch the supported installer](https://tkb-gaming.scot/mission-chief-scripts/map-command-toolkit/install/). GitHub remains the canonical source, release archive and public engineering record.
+> **TKB Scripts is the only supported installation and update channel.** Use the [Toolkit product page](https://tkb-gaming.scot/mission-chief-scripts/map-command-toolkit/) or [launch the supported installer](https://tkb-gaming.scot/mission-chief-scripts/map-command-toolkit/install/MissionChief_Map_Command_Toolkit.user.js). GitHub remains the canonical source, release archive and public engineering record.
 
 | Enter command | Explore the system |
 |---|---|
-| **[Install or update the Toolkit](https://tkb-gaming.scot/mission-chief-scripts/map-command-toolkit/install/)**<br>Open the supported TKB Scripts installer. | **[Open the Field Guide](https://conroy1988.github.io/missionchief-toolkit-assets/)**<br>Learn the system from first signal to final account. |
+| **[Install or update the Toolkit](https://tkb-gaming.scot/mission-chief-scripts/map-command-toolkit/install/MissionChief_Map_Command_Toolkit.user.js)**<br>Open the supported TKB Scripts installer. | **[Open the Field Guide](https://conroy1988.github.io/missionchief-toolkit-assets/)**<br>Learn the system from first signal to final account. |
 | **[Browse all eight interfaces](https://conroy1988.github.io/missionchief-toolkit-assets/themes/)**<br>Preview every complete command environment. | **[Inspect Release Control](https://github.com/Conroy1988/missionchief-toolkit-assets/blob/release-state/status/README.md)**<br>See publication, verification and recovery state. |
 
 <p align="center">
@@ -199,7 +199,7 @@ Every release should be attributable, inspectable and recoverable. If the suppor
 
 ## Install and enter command
 
-1. Open the **[official TKB Scripts installer](https://tkb-gaming.scot/mission-chief-scripts/map-command-toolkit/install/)**.
+1. Open the **[official TKB Scripts installer](https://tkb-gaming.scot/mission-chief-scripts/map-command-toolkit/install/MissionChief_Map_Command_Toolkit.user.js)**.
 2. Approve the userscript in your supported userscript manager.
 3. Return to MissionChief UK and reload the page.
 4. Open the Toolkit dock or press <kbd>K</kbd> for the Toolkit Command Palette.
@@ -335,5 +335,5 @@ The cinematic artwork on this page is original conceptual presentation created f
 
 <p align="center">
   <strong>The mission is already moving. Your command picture should be ready.</strong><br><br>
-  <a href="https://tkb-gaming.scot/mission-chief-scripts/map-command-toolkit/install/"><strong>INSTALL OR UPDATE THE TOOLKIT →</strong></a>
+  <a href="https://tkb-gaming.scot/mission-chief-scripts/map-command-toolkit/install/MissionChief_Map_Command_Toolkit.user.js"><strong>INSTALL OR UPDATE THE TOOLKIT →</strong></a>
 </p>


### PR DESCRIPTION
## Summary

- move user-facing install links and public integrity verification to the explicit `.user.js` filename route already used by the TKB product page
- preserve the legacy `/install/` URL for backwards-compatible update manifests
- keep both routes covered by the independent TKB live installer audit
- add a release-authority contract and Asset Health regression test for the filename integrity route

## Root cause and evidence

The post-deployment TKB audit proves both origin routes return exact v10.8.0 bytes, but Asset Health runners continue receiving the historic corrupted object exclusively from the legacy directory cache key—even with a unique `audit` nonce. Run `31982222884` returned the original stale SHA `f9097d41…` from `/install/`.

The explicit filename route is the current supported product-page installer and passes the live byte-parity audit in run `31981793131`. New users and integrity checks therefore move to that unambiguous route, while compatibility monitoring for `/install/` remains in TKB-Website.

## Validation

- [x] 14 Asset Health self-tests
- [x] distribution-body parity self-test
- [x] release-authority contract
- [x] stable update-manifest self-tests
- [x] version-status contract and runtime fixtures
- [x] documentation drift against authoritative `release-state`
- [x] static Asset Health: 61 endpoints, 52 local media files, 0 failures, 0 warnings
- [x] JSON and diff validation
- [ ] required pull-request checks
- [ ] post-merge live Asset Health Monitor

Related to #626.