### PR TITLE
fix: match production HTTP client in asset health

### DIFF
--- a/.github/scripts/check_asset_health.py
+++ b/.github/scripts/check_asset_health.py
@@ -11,7 +11,9 @@ import html
 import json
 import os
 import re
+import subprocess
 import sys
+import tempfile
 import time
 import urllib.error
 import urllib.parse
@@ -371,7 +373,94 @@ def cache_bust(url: str) -> str:
     return urllib.parse.urlunparse(parsed._replace(query=urllib.parse.urlencode(query)))
 
 
+def parse_curl_headers(payload: bytes) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    for line in payload.decode("iso-8859-1", errors="replace").splitlines():
+        if line.startswith("HTTP/"):
+            headers = {}
+            continue
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        headers[key.strip().lower()] = value.strip()
+    return headers
+
+
+def curl_request_once(
+    url: str,
+    method: str,
+    timeout: float,
+    user_agent: str,
+    range_prefix: int | None = None,
+) -> tuple[int, dict[str, str], bytes, str]:
+    target = cache_bust(url)
+    with tempfile.TemporaryDirectory(prefix="toolkit-asset-health-curl-") as directory:
+        temporary = Path(directory)
+        headers_path = temporary / "headers.txt"
+        body_path = temporary / "body.bin"
+        command = [
+            "curl",
+            "--silent",
+            "--show-error",
+            "--location",
+            "--max-redirs",
+            "5",
+            "--proto",
+            "=https",
+            "--proto-redir",
+            "=https",
+            "--connect-timeout",
+            str(min(timeout, 10)),
+            "--max-time",
+            str(timeout),
+            "--user-agent",
+            user_agent,
+            "--header",
+            "Accept: */*",
+            "--header",
+            "Cache-Control: no-cache",
+            "--dump-header",
+            str(headers_path),
+            "--output",
+            str(body_path),
+            "--write-out",
+            "%{http_code}\t%{url_effective}",
+        ]
+        if method == "HEAD":
+            command.append("--head")
+        if range_prefix is not None:
+            command.extend(["--range", f"0-{max(0, range_prefix - 1)}"])
+        command.append(target)
+
+        try:
+            result = subprocess.run(
+                command,
+                check=False,
+                capture_output=True,
+                timeout=timeout + 5,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            raise urllib.error.URLError(f"curl request failed: {exc}") from exc
+        if result.returncode != 0:
+            detail = result.stderr.decode("utf-8", errors="replace").strip()
+            raise urllib.error.URLError(f"curl exited {result.returncode}: {detail or 'request failed'}")
+
+        status_text, separator, final_url = result.stdout.decode("utf-8", errors="replace").partition("\t")
+        if not separator or not status_text.isdigit() or not final_url:
+            raise AssetHealthError("curl did not return a valid HTTP status and effective URL")
+        status = int(status_text)
+        headers = parse_curl_headers(headers_path.read_bytes())
+        body = b"" if method == "HEAD" else body_path.read_bytes()
+        if range_prefix is not None:
+            body = body[:range_prefix]
+        if status >= 400:
+            raise urllib.error.HTTPError(final_url, status, f"HTTP {status}", headers, None)
+        return status, headers, body, final_url
+
+
 def request_once(url: str, method: str, timeout: float, user_agent: str, range_prefix: int | None = None) -> tuple[int, dict[str, str], bytes, str]:
+    if urllib.parse.urlparse(url).hostname == "tkb-gaming.scot":
+        return curl_request_once(url, method, timeout, user_agent, range_prefix)
     headers = {
         "User-Agent": user_agent,
         "Accept": "*/*",

--- a/.github/scripts/check_distribution_body_parity.py
+++ b/.github/scripts/check_distribution_body_parity.py
@@ -7,6 +7,7 @@ import argparse
 import hashlib
 import json
 import re
+import subprocess
 import sys
 import tempfile
 import threading
@@ -66,9 +67,65 @@ def cache_bust(url: str) -> str:
     return urllib.parse.urlunparse(parsed._replace(query=urllib.parse.urlencode(query)))
 
 
+def build_curl_command(url: str, timeout: float, user_agent: str, output: Path) -> list[str]:
+    return [
+        "curl",
+        "--fail",
+        "--silent",
+        "--show-error",
+        "--location",
+        "--max-redirs",
+        "5",
+        "--proto",
+        "=https",
+        "--proto-redir",
+        "=https",
+        "--connect-timeout",
+        str(min(timeout, 10)),
+        "--max-time",
+        str(timeout),
+        "--user-agent",
+        user_agent,
+        "--header",
+        "Accept: */*",
+        "--header",
+        "Cache-Control: no-cache",
+        "--output",
+        str(output),
+        url,
+    ]
+
+
+def curl_fetch_once(url: str, timeout: float, user_agent: str) -> bytes:
+    with tempfile.TemporaryDirectory(prefix="toolkit-parity-curl-") as directory:
+        output = Path(directory) / "body.bin"
+        command = build_curl_command(cache_bust(url), timeout, user_agent, output)
+        try:
+            result = subprocess.run(
+                command,
+                check=False,
+                capture_output=True,
+                timeout=timeout + 5,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            raise RuntimeError(f"curl request failed: {exc}") from exc
+        if result.returncode != 0:
+            detail = result.stderr.decode("utf-8", errors="replace").strip()
+            raise RuntimeError(f"curl exited {result.returncode}: {detail or 'request failed'}")
+        return output.read_bytes()
+
+
 def fetch(url: str, timeout: float, retries: int, user_agent: str) -> bytes:
     last_error: Exception | None = None
     for attempt in range(1, retries + 1):
+        if urllib.parse.urlparse(url).hostname == "tkb-gaming.scot":
+            try:
+                return curl_fetch_once(url, timeout, user_agent)
+            except RuntimeError as exc:
+                last_error = exc
+                if attempt < retries:
+                    time.sleep(attempt)
+                continue
         request = urllib.request.Request(
             cache_bust(url),
             headers={
@@ -252,6 +309,9 @@ def self_test() -> int:
     assert busted_query["channel"] == "stable"
     assert busted_query["audit"].isdigit()
     assert "asset_health" not in busted_query
+    curl_command = build_curl_command(busted, 5, "parity-self-test", Path("body.bin"))
+    assert curl_command[0] == "curl"
+    assert not any("Accept-Encoding" in argument for argument in curl_command)
 
     base = b"// ==UserScript==\n// @version 1.2.3\n// ==/UserScript==\nconsole.log('same');\n"
     transformed = b"// ==UserScript==\n// @version 1.2.3\n// served-by first-party gateway\n// ==/UserScript==\nconsole.log('same');\n"

--- a/.github/scripts/test_asset_health.py
+++ b/.github/scripts/test_asset_health.py
@@ -11,6 +11,7 @@ import tempfile
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from unittest import mock
 
 SCRIPT_PATH = Path(__file__).with_name("check_asset_health.py")
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
@@ -165,6 +166,46 @@ def test_integrity_installer_uses_filename_route() -> None:
     assert parsed.hostname == "tkb-gaming.scot"
     assert parsed.path.endswith("/install/MissionChief_Map_Command_Toolkit.user.js")
     assert install_endpoint["urlSource"]["jsonPointer"] == "/distribution/integrityInstallUrl"
+
+
+def test_tkb_requests_match_production_curl_client() -> None:
+    observed: dict[str, list[str]] = {}
+
+    def fake_run(command: list[str], **_kwargs: object) -> object:
+        observed["command"] = command
+        headers_path = Path(command[command.index("--dump-header") + 1])
+        body_path = Path(command[command.index("--output") + 1])
+        headers_path.write_bytes(
+            b"HTTP/1.1 200 Connection established\r\n\r\n"
+            b"HTTP/2 200\r\nContent-Type: text/javascript\r\nContent-Length: 3\r\n\r\n"
+        )
+        body_path.write_bytes(b"abc")
+        return asset_health.subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=f"200\t{command[-1]}".encode(),
+            stderr=b"",
+        )
+
+    with mock.patch.object(asset_health.subprocess, "run", side_effect=fake_run):
+        status, headers, body, final_url = asset_health.request_once(
+            "https://tkb-gaming.scot/mission-chief-scripts/map-command-toolkit/install/"
+            "MissionChief_Map_Command_Toolkit.user.js",
+            "GET",
+            5,
+            "MissionChief-Toolkit-Asset-Health/1.0",
+        )
+
+    command = observed["command"]
+    assert command[0] == "curl"
+    assert not any("Accept-Encoding" in argument for argument in command)
+    final_query = dict(
+        asset_health.urllib.parse.parse_qsl(asset_health.urllib.parse.urlparse(final_url).query)
+    )
+    assert final_query["audit"].isdigit()
+    assert status == 200
+    assert headers["content-type"] == "text/javascript"
+    assert body == b"abc"
 
 
 def test_live_success_and_optional_warning() -> None:
@@ -381,6 +422,7 @@ def main() -> None:
     tests = [
         test_first_party_live_requests_are_cache_busted,
         test_integrity_installer_uses_filename_route,
+        test_tkb_requests_match_production_curl_client,
         test_live_success_and_optional_warning,
         test_wrong_release_hash_fails,
         test_missing_stable_raw_path_fails_static,


### PR DESCRIPTION
## Summary

- use curl for TKB first-party probes so Asset Health matches the independently passing production installer audit
- retain urllib for GitHub/raw media checks and local fixture tests
- apply the same TKB client behavior to executable-body parity checks
- preserve HTTPS-only redirects, timeouts, retries, response headers, range requests, and exact body hashing

## Root cause and evidence

Asset Health run `31982805114` received the same historic corrupted SHA from the explicit filename route, while TKB installer audit run `31981793131` received exact release bytes from that route using the same user-agent and nonce.

The remaining difference is the HTTP client: Python urllib sends an implicit `Accept-Encoding: identity` request and reaches the stale cache variant; the proven curl probe does not. The monitor now uses the same curl request shape as the successful production audit.

## Validation

- [x] Python compilation
- [x] 15 Asset Health self-tests, including a mocked multi-response curl/header contract
- [x] distribution-body parity self-test
- [x] GitHub Actions security audit: 42 workflows, 96 pinned external actions, 0 failures
- [x] static Asset Health: 61 endpoints, 52 local media files, 0 failures, 0 warnings
- [x] `git diff --check`
- [x] required pull-request checks
- [x] post-merge live Asset Health Monitor: run `31983289646`, 61 endpoints, 52 media files, 0 failures, 0 warnings

Closes #626.